### PR TITLE
Add health check and monitoring endpoints

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/core": "^10.3.0",
         "@nestjs/platform-express": "^10.3.0",
         "@nestjs/swagger": "^11.2.5",
+        "@nestjs/terminus": "^11.0.0",
         "@nestjs/typeorm": "^10.0.0",
         "@sentry/node": "^10.36.0",
         "@sentry/profiling-node": "^10.36.0",
@@ -1981,6 +1982,76 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/@nestjs/terminus": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.0.0.tgz",
+      "integrity": "sha512-c55LOo9YGovmQHtFUMa/vDaxGZ2cglMTZejqgHREaApt/GArTfgYYGwhRXPLq8ZwiQQlLuYB+79e9iA8mlDSLA==",
+      "license": "MIT",
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/microservices": "^10.0.0 || ^11.0.0",
+        "@nestjs/mongoose": "^11.0.0",
+        "@nestjs/sequelize": "^10.0.0 || ^11.0.0",
+        "@nestjs/typeorm": "^10.0.0 || ^11.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x || 0.2.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "10.4.22",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.22.tgz",
@@ -3497,22 +3568,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
@@ -3851,6 +3906,15 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -4376,6 +4440,57 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -4645,6 +4760,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -4696,6 +4820,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
@@ -4711,6 +4842,18 @@
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
         "validator": "^13.15.20"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -6543,6 +6686,22 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -7750,13 +7909,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/jest-runtime/node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8419,9 +8571,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -11109,7 +11261,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -11268,6 +11419,21 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11659,6 +11825,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^10.3.0",
     "@nestjs/platform-express": "^10.3.0",
     "@nestjs/swagger": "^11.2.5",
+    "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^10.0.0",
     "@sentry/node": "^10.36.0",
     "@sentry/profiling-node": "^10.36.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,7 +13,7 @@ import { TradesModule } from './trades/trades.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
 import { configSchema } from './config/schemas/config.schema';
 import configuration from './config/configuration';
-import { HealthController } from './health/health.controller';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -60,15 +60,15 @@ import { HealthController } from './health/health.controller';
         entities: ['dist/**/*.entity{.ts,.js}'],
         migrations: ['dist/migrations/*{.ts,.js}'],
         subscribers: ['dist/subscribers/*{.ts,.js}'],
-        ssl: configService.get<boolean>('database.ssl'),
+        ssl: configService.get<boolean>('database.ssl') ?? false,
       }),
     }),
     // Feature Modules
     BetaModule,
     TradesModule,
     PortfolioModule,
+    HealthModule,
   ],
-  controllers: [HealthController],
   providers: [StellarConfigService],
   exports: [StellarConfigService],
 })

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,16 +1,81 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  HealthCheck,
+  HealthCheckService,
+  HealthCheckResult,
+} from '@nestjs/terminus';
+import {
+  StellarHealthIndicator,
+  SorobanHealthIndicator,
+  DatabaseHealthIndicator,
+  RedisHealthIndicator,
+} from './indicators';
 
-@ApiTags('Health')
 @Controller('health')
 export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private stellarHealth: StellarHealthIndicator,
+    private sorobanHealth: SorobanHealthIndicator,
+    private databaseHealth: DatabaseHealthIndicator,
+    private redisHealth: RedisHealthIndicator,
+  ) { }
+
   @Get()
-  @ApiOperation({ summary: 'Check API health status' })
-  @ApiResponse({ status: 200, description: 'API is healthy', schema: { example: { status: 'ok', timestamp: '2026-01-21T18:13:52Z' } } })
-  checkHealth() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-    };
+  @HealthCheck()
+  async check(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.databaseHealth.isHealthy('database'),
+      () => this.redisHealth.isHealthy('cache'),
+      () => this.stellarHealth.isHealthy('stellar'),
+      () => this.sorobanHealth.isHealthy('soroban'),
+    ]);
+  }
+
+  @Get('stellar')
+  @HealthCheck()
+  async checkStellar(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.stellarHealth.isHealthy('stellar'),
+    ]);
+  }
+
+  @Get('soroban')
+  @HealthCheck()
+  async checkSoroban(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.sorobanHealth.isHealthy('soroban'),
+    ]);
+  }
+
+  @Get('db')
+  @HealthCheck()
+  async checkDatabase(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.databaseHealth.isHealthy('database'),
+    ]);
+  }
+
+  @Get('cache')
+  @HealthCheck()
+  async checkCache(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.redisHealth.isHealthy('cache'),
+    ]);
+  }
+
+  @Get('liveness')
+  @HealthCheck()
+  async liveness(): Promise<HealthCheckResult> {
+    return this.health.check([]);
+  }
+
+  @Get('readiness')
+  @HealthCheck()
+  async readiness(): Promise<HealthCheckResult> {
+    return this.health.check([
+      () => this.databaseHealth.isHealthy('database'),
+      () => this.redisHealth.isHealthy('cache'),
+    ]);
   }
 }

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { HealthController } from './health.controller';
+import {
+  StellarHealthIndicator,
+  SorobanHealthIndicator,
+  DatabaseHealthIndicator,
+  RedisHealthIndicator,
+} from './indicators';
+import { StellarConfigService } from '../config/stellar.service';
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+  providers: [
+    StellarConfigService,
+    StellarHealthIndicator,
+    SorobanHealthIndicator,
+    DatabaseHealthIndicator,
+    RedisHealthIndicator,
+  ],
+  exports: [
+    StellarHealthIndicator,
+    SorobanHealthIndicator,
+    DatabaseHealthIndicator,
+    RedisHealthIndicator,
+  ],
+})
+export class HealthModule {}

--- a/src/health/indicators/database.health.ts
+++ b/src/health/indicators/database.health.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class DatabaseHealthIndicator extends HealthIndicator {
+  constructor(
+    @InjectDataSource()
+    private dataSource: DataSource,
+  ) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const startTime = Date.now();
+
+    try {
+      const isConnected = this.dataSource.isInitialized;
+
+      if (!isConnected) {
+        throw new Error('Database connection not initialized');
+      }
+
+      await this.dataSource.query('SELECT 1 as health_check');
+      const latency = Date.now() - startTime;
+
+      return this.getStatus(key, true, {
+        type: 'postgres',
+        connected: true,
+        latency: `${latency}ms`,
+      });
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      throw new HealthCheckError(
+        'Database check failed',
+        this.getStatus(key, false, {
+          type: 'postgres',
+          connected: false,
+          error: errorMessage,
+          latency: `${latency}ms`,
+        }),
+      );
+    }
+  }
+}

--- a/src/health/indicators/index.ts
+++ b/src/health/indicators/index.ts
@@ -1,0 +1,4 @@
+export * from './stellar.health';
+export * from './soroban.health';
+export * from './database.health';
+export * from './redis.health';

--- a/src/health/indicators/redis.health.ts
+++ b/src/health/indicators/redis.health.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+@Injectable()
+export class RedisHealthIndicator extends HealthIndicator {
+  private redis: Redis;
+
+  constructor(private configService: ConfigService) {
+    super();
+    this.redis = new Redis({
+      host: this.configService.get<string>('redis.host') ?? 'localhost',
+      port: this.configService.get<number>('redis.port') ?? 6379,
+      password: this.configService.get<string>('redis.password'),
+      db: this.configService.get<number>('redis.db') ?? 0,
+      lazyConnect: true,
+    });
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const startTime = Date.now();
+
+    try {
+      await this.redis.connect();
+      const pong = await this.redis.ping();
+      const latency = Date.now() - startTime;
+
+      const info = await this.redis.info('server');
+      const versionMatch = info.match(/redis_version:(\S+)/);
+      const version = versionMatch ? versionMatch[1] : 'unknown';
+
+      await this.redis.disconnect();
+
+      return this.getStatus(key, true, {
+        status: pong === 'PONG' ? 'connected' : 'degraded',
+        version,
+        latency: `${latency}ms`,
+      });
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      try {
+        await this.redis.disconnect();
+      } catch {
+        // Ignore disconnect errors
+      }
+
+      throw new HealthCheckError(
+        'Redis check failed',
+        this.getStatus(key, false, {
+          status: 'disconnected',
+          error: errorMessage,
+          latency: `${latency}ms`,
+        }),
+      );
+    }
+  }
+}

--- a/src/health/indicators/soroban.health.ts
+++ b/src/health/indicators/soroban.health.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { StellarConfigService } from '../../config/stellar.service';
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+@Injectable()
+export class SorobanHealthIndicator extends HealthIndicator {
+  constructor(private stellarConfig: StellarConfigService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const startTime = Date.now();
+
+    try {
+      const server = new StellarSdk.SorobanRpc.Server(
+        this.stellarConfig.sorobanRpcUrl,
+      );
+
+      const health = await server.getHealth();
+
+      const latency = Date.now() - startTime;
+
+      const result = this.getStatus(key, true, {
+        network: this.stellarConfig.network,
+        sorobanRpcUrl: this.stellarConfig.sorobanRpcUrl,
+        status: health.status,
+        latency: `${latency}ms`,
+      });
+
+      return result;
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      throw new HealthCheckError(
+        'Soroban RPC check failed',
+        this.getStatus(key, false, {
+          network: this.stellarConfig.network,
+          sorobanRpcUrl: this.stellarConfig.sorobanRpcUrl,
+          error: errorMessage,
+          latency: `${latency}ms`,
+        }),
+      );
+    }
+  }
+}

--- a/src/health/indicators/stellar.health.ts
+++ b/src/health/indicators/stellar.health.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { StellarConfigService } from '../../config/stellar.service';
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+@Injectable()
+export class StellarHealthIndicator extends HealthIndicator {
+  private server: StellarSdk.Horizon.Server;
+
+  constructor(private stellarConfig: StellarConfigService) {
+    super();
+    this.server = new StellarSdk.Horizon.Server(this.stellarConfig.horizonUrl);
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const startTime = Date.now();
+
+    try {
+      const ledger = await this.server.ledgers().order('desc').limit(1).call();
+
+      const latency = Date.now() - startTime;
+      const latestLedger = ledger.records[0];
+
+      const result = this.getStatus(key, true, {
+        network: this.stellarConfig.network,
+        horizonUrl: this.stellarConfig.horizonUrl,
+        latestLedger: latestLedger?.sequence,
+        latency: `${latency}ms`,
+      });
+
+      return result;
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      throw new HealthCheckError(
+        'Stellar Horizon check failed',
+        this.getStatus(key, false, {
+          network: this.stellarConfig.network,
+          horizonUrl: this.stellarConfig.horizonUrl,
+          error: errorMessage,
+          latency: `${latency}ms`,
+        }),
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive health check endpoints using @nestjs/terminus
- Implement custom health indicators for Stellar Horizon, Soroban RPC, PostgreSQL, and Redis
- Include Kubernetes-ready liveness and readiness probes with latency measurements

## Endpoints
| Endpoint | Description |
|----------|-------------|
| `GET /health` | Overall system health status |
| `GET /health/stellar` | Stellar Horizon connectivity |
| `GET /health/soroban` | Soroban RPC connectivity |
| `GET /health/db` | PostgreSQL database health |
| `GET /health/cache` | Redis cache health |
| `GET /health/liveness` | Kubernetes liveness probe |
| `GET /health/readiness` | Kubernetes readiness probe |

## Test plan
- [ ] Verify `GET /health` returns overall system status
- [ ] Verify `GET /health/stellar` checks Stellar Horizon connectivity
- [ ] Verify `GET /health/soroban` checks Soroban RPC connectivity
- [ ] Verify `GET /health/db` checks PostgreSQL connection
- [ ] Verify `GET /health/cache` checks Redis connection
- [ ] Verify `GET /health/liveness` returns HTTP 200
- [ ] Verify `GET /health/readiness` checks DB and Redis
- [ ] Confirm HTTP 503 is returned when services are unhealthy

Closes #5
