### PR TITLE
feat(content): implement provider content management system

### DIFF
--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ContentService } from './content.service';
+import { CreateContentDto } from './dto/create-content.dto';
+import { UpdateContentDto } from './dto/update-content.dto';
+import { ContentQueryDto } from './dto/content-query.dto';
+import { CreateEngagementDto } from './dto/engagement.dto';
+import {
+  ContentResponseDto,
+  ContentListResponseDto,
+} from './dto/content-response.dto';
+
+@Controller('providers')
+export class ContentController {
+  constructor(private readonly contentService: ContentService) {}
+
+  @Post('content')
+  async create(
+    @Request() req,
+    @Body() createContentDto: CreateContentDto,
+  ): Promise<ContentResponseDto> {
+    const providerId = req.user?.id || 'mock-provider-id'; // Replace with actual auth
+    return this.contentService.create(providerId, createContentDto);
+  }
+
+  @Get('content')
+  async findAll(
+    @Query() query: ContentQueryDto,
+  ): Promise<ContentListResponseDto> {
+    return this.contentService.findAll(query);
+  }
+
+  @Get(':id/content')
+  async findByProvider(
+    @Param('id') providerId: string,
+  ): Promise<ContentResponseDto[]> {
+    return this.contentService.findByProvider(providerId);
+  }
+
+  @Get('content/:id')
+  async findOne(@Param('id') id: string): Promise<ContentResponseDto> {
+    return this.contentService.findOne(id);
+  }
+
+  @Put('content/:id')
+  async update(
+    @Request() req,
+    @Param('id') id: string,
+    @Body() updateContentDto: UpdateContentDto,
+  ): Promise<ContentResponseDto> {
+    const providerId = req.user?.id || 'mock-provider-id'; // Replace with actual auth
+    return this.contentService.update(id, providerId, updateContentDto);
+  }
+
+  @Delete('content/:id')
+  async delete(@Request() req, @Param('id') id: string): Promise<void> {
+    const providerId = req.user?.id || 'mock-provider-id'; // Replace with actual auth
+    return this.contentService.delete(id, providerId);
+  }
+
+  @Post('content/:id/engage')
+  async engage(
+    @Request() req,
+    @Param('id') contentId: string,
+    @Body() engagementDto: CreateEngagementDto,
+  ): Promise<{ message: string }> {
+    const userId = req.user?.id || 'mock-user-id'; // Replace with actual auth
+    await this.contentService.recordEngagement(
+      contentId,
+      userId,
+      engagementDto,
+    );
+    return { message: 'Engagement recorded successfully' };
+  }
+
+  @Get('content/tags/popular')
+  async getPopularTags(): Promise<string[]> {
+    return this.contentService.getPopularTags();
+  }
+}

--- a/src/content/content.module.ts
+++ b/src/content/content.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentController } from './content.controller';
+import { ContentService } from './content.service';
+import { ProviderContent } from './entities/provider-content.entity';
+import { ContentEngagement } from './entities/content-engagement.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProviderContent, ContentEngagement])],
+  controllers: [ContentController],
+  providers: [ContentService],
+  exports: [ContentService],
+})
+export class ContentModule {}

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -1,0 +1,284 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Like, In } from 'typeorm';
+import {
+  ProviderContent,
+  ContentType,
+  ContentStatus,
+} from './entities/provider-content.entity';
+import {
+  ContentEngagement,
+  EngagementType,
+} from './entities/content-engagement.entity';
+import { CreateContentDto } from './dto/create-content.dto';
+import { UpdateContentDto } from './dto/update-content.dto';
+import { ContentQueryDto } from './dto/content-query.dto';
+import { CreateEngagementDto } from './dto/engagement.dto';
+import {
+  ContentResponseDto,
+  ContentListResponseDto,
+} from './dto/content-response.dto';
+
+@Injectable()
+export class ContentService {
+  constructor(
+    @InjectRepository(ProviderContent)
+    private contentRepository: Repository<ProviderContent>,
+    @InjectRepository(ContentEngagement)
+    private engagementRepository: Repository<ContentEngagement>,
+  ) {}
+
+  async create(
+    providerId: string,
+    createContentDto: CreateContentDto,
+  ): Promise<ContentResponseDto> {
+    // Validate video content has videoUrl
+    if (
+      createContentDto.type === ContentType.VIDEO &&
+      !createContentDto.videoUrl
+    ) {
+      throw new BadRequestException('Video content requires videoUrl');
+    }
+
+    // Validate video URL format (YouTube, Vimeo)
+    if (createContentDto.videoUrl) {
+      this.validateVideoUrl(createContentDto.videoUrl);
+    }
+
+    const content = this.contentRepository.create({
+      ...createContentDto,
+      providerId,
+      status: createContentDto.published
+        ? ContentStatus.PUBLISHED
+        : ContentStatus.DRAFT,
+    });
+
+    const saved = await this.contentRepository.save(content);
+    return this.toResponseDto(saved);
+  }
+
+  async findAll(query: ContentQueryDto): Promise<ContentListResponseDto> {
+    const { type, providerId, tags, search, page = 1, limit = 20 } = query;
+
+    const queryBuilder = this.contentRepository
+      .createQueryBuilder('content')
+      .where('content.published = :published', { published: true })
+      .andWhere('content.status = :status', { status: ContentStatus.PUBLISHED });
+
+    if (type) {
+      queryBuilder.andWhere('content.type = :type', { type });
+    }
+
+    if (providerId) {
+      queryBuilder.andWhere('content.providerId = :providerId', { providerId });
+    }
+
+    if (tags && tags.length > 0) {
+      queryBuilder.andWhere('content.tags && :tags', { tags });
+    }
+
+    if (search) {
+      queryBuilder.andWhere(
+        '(content.title ILIKE :search OR content.body ILIKE :search)',
+        { search: `%${search}%` },
+      );
+    }
+
+    const [content, total] = await queryBuilder
+      .orderBy('content.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return {
+      content: content.map((c) => this.toResponseDto(c)),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findByProvider(providerId: string): Promise<ContentResponseDto[]> {
+    const content = await this.contentRepository.find({
+      where: {
+        providerId,
+        published: true,
+        status: ContentStatus.PUBLISHED,
+      },
+      order: { createdAt: 'DESC' },
+    });
+
+    return content.map((c) => this.toResponseDto(c));
+  }
+
+  async findOne(id: string): Promise<ContentResponseDto> {
+    const content = await this.contentRepository.findOne({
+      where: { id },
+    });
+
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    return this.toResponseDto(content);
+  }
+
+  async update(
+    id: string,
+    providerId: string,
+    updateContentDto: UpdateContentDto,
+  ): Promise<ContentResponseDto> {
+    const content = await this.contentRepository.findOne({ where: { id } });
+
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    if (content.providerId !== providerId) {
+      throw new ForbiddenException('Not authorized to update this content');
+    }
+
+    // Validate video URL if provided
+    if (updateContentDto.videoUrl) {
+      this.validateVideoUrl(updateContentDto.videoUrl);
+    }
+
+    Object.assign(content, updateContentDto);
+
+    if (updateContentDto.published !== undefined) {
+      content.status = updateContentDto.published
+        ? ContentStatus.PUBLISHED
+        : ContentStatus.DRAFT;
+    }
+
+    const updated = await this.contentRepository.save(content);
+    return this.toResponseDto(updated);
+  }
+
+  async delete(id: string, providerId: string): Promise<void> {
+    const content = await this.contentRepository.findOne({ where: { id } });
+
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    if (content.providerId !== providerId) {
+      throw new ForbiddenException('Not authorized to delete this content');
+    }
+
+    await this.contentRepository.remove(content);
+  }
+
+  async recordEngagement(
+    contentId: string,
+    userId: string,
+    engagementDto: CreateEngagementDto,
+  ): Promise<void> {
+    const content = await this.contentRepository.findOne({
+      where: { id: contentId },
+    });
+
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    // Check if engagement already exists (for likes)
+    if (engagementDto.type === EngagementType.LIKE) {
+      const existing = await this.engagementRepository.findOne({
+        where: {
+          contentId,
+          userId,
+          type: EngagementType.LIKE,
+        },
+      });
+
+      if (existing) {
+        // Unlike - remove engagement
+        await this.engagementRepository.remove(existing);
+        content.likes = Math.max(0, content.likes - 1);
+        await this.contentRepository.save(content);
+        return;
+      }
+    }
+
+    // Create engagement
+    const engagement = this.engagementRepository.create({
+      contentId,
+      userId,
+      type: engagementDto.type,
+      flagReason: engagementDto.flagReason,
+    });
+
+    await this.engagementRepository.save(engagement);
+
+    // Update content counters
+    switch (engagementDto.type) {
+      case EngagementType.VIEW:
+        content.views++;
+        break;
+      case EngagementType.LIKE:
+        content.likes++;
+        break;
+      case EngagementType.SHARE:
+        content.shares++;
+        break;
+      case EngagementType.FLAG:
+        // Flag content for moderation
+        content.status = ContentStatus.FLAGGED;
+        content.flagReason = engagementDto.flagReason;
+        break;
+    }
+
+    await this.contentRepository.save(content);
+  }
+
+  async getPopularTags(limit: number = 20): Promise<string[]> {
+    const result = await this.contentRepository
+      .createQueryBuilder('content')
+      .select('UNNEST(content.tags)', 'tag')
+      .where('content.published = :published', { published: true })
+      .groupBy('tag')
+      .orderBy('COUNT(*)', 'DESC')
+      .limit(limit)
+      .getRawMany();
+
+    return result.map((r) => r.tag);
+  }
+
+  private validateVideoUrl(url: string): void {
+    const youtubeRegex =
+      /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+$/;
+    const vimeoRegex = /^(https?:\/\/)?(www\.)?vimeo\.com\/.+$/;
+
+    if (!youtubeRegex.test(url) && !vimeoRegex.test(url)) {
+      throw new BadRequestException(
+        'Invalid video URL. Only YouTube and Vimeo are supported',
+      );
+    }
+  }
+
+  private toResponseDto(content: ProviderContent): ContentResponseDto {
+    return {
+      id: content.id,
+      providerId: content.providerId,
+      type: content.type,
+      title: content.title,
+      body: content.body,
+      tags: content.tags,
+      published: content.published,
+      status: content.status,
+      views: content.views,
+      likes: content.likes,
+      shares: content.shares,
+      thumbnailUrl: content.thumbnailUrl,
+      videoUrl: content.videoUrl,
+      createdAt: content.createdAt,
+      updatedAt: content.updatedAt,
+    };
+  }
+}

--- a/src/content/dto/content-query.dto.ts
+++ b/src/content/dto/content-query.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsOptional,
+  IsEnum,
+  IsString,
+  IsInt,
+  Min,
+  Max,
+  IsArray,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ContentType } from '../entities/provider-content.entity';
+
+export class ContentQueryDto {
+  @IsOptional()
+  @IsEnum(ContentType)
+  type?: ContentType;
+
+  @IsOptional()
+  @IsString()
+  providerId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/content/dto/content-response.dto.ts
+++ b/src/content/dto/content-response.dto.ts
@@ -1,0 +1,26 @@
+import { ContentType, ContentStatus } from '../entities/provider-content.entity';
+
+export class ContentResponseDto {
+  id: string;
+  providerId: string;
+  type: ContentType;
+  title: string;
+  body: string;
+  tags: string[];
+  published: boolean;
+  status: ContentStatus;
+  views: number;
+  likes: number;
+  shares: number;
+  thumbnailUrl?: string;
+  videoUrl?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class ContentListResponseDto {
+  content: ContentResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/src/content/dto/create-content.dto.ts
+++ b/src/content/dto/create-content.dto.ts
@@ -1,0 +1,44 @@
+import {
+  IsString,
+  IsEnum,
+  IsArray,
+  IsOptional,
+  IsBoolean,
+  IsUrl,
+  MaxLength,
+  MinLength,
+  ArrayMaxSize,
+} from 'class-validator';
+import { ContentType } from '../entities/provider-content.entity';
+
+export class CreateContentDto {
+  @IsEnum(ContentType)
+  type: ContentType;
+
+  @IsString()
+  @MinLength(5)
+  @MaxLength(200)
+  title: string;
+
+  @IsString()
+  @MinLength(10)
+  body: string; // markdown for articles, description for videos
+
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMaxSize(10)
+  @IsOptional()
+  tags?: string[];
+
+  @IsBoolean()
+  @IsOptional()
+  published?: boolean;
+
+  @IsUrl()
+  @IsOptional()
+  thumbnailUrl?: string;
+
+  @IsUrl()
+  @IsOptional()
+  videoUrl?: string; // Required for video type
+}

--- a/src/content/dto/engagement.dto.ts
+++ b/src/content/dto/engagement.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsString, IsOptional } from 'class-validator';
+import { EngagementType } from '../entities/content-engagement.entity';
+
+export class CreateEngagementDto {
+  @IsEnum(EngagementType)
+  type: EngagementType;
+
+  @IsString()
+  @IsOptional()
+  flagReason?: string;
+}

--- a/src/content/dto/update-content.dto.ts
+++ b/src/content/dto/update-content.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateContentDto } from './create-content.dto';
+
+export class UpdateContentDto extends PartialType(CreateContentDto) {}

--- a/src/content/entities/content-engagement.entity.ts
+++ b/src/content/entities/content-engagement.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { ProviderContent } from './provider-content.entity';
+
+export enum EngagementType {
+  VIEW = 'view',
+  LIKE = 'like',
+  SHARE = 'share',
+  FLAG = 'flag',
+}
+
+@Entity('content_engagement')
+@Unique(['contentId', 'userId', 'type'])
+@Index(['contentId', 'type'])
+@Index(['userId'])
+export class ContentEngagement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  contentId: string;
+
+  @Column()
+  userId: string;
+
+  @Column({
+    type: 'enum',
+    enum: EngagementType,
+  })
+  type: EngagementType;
+
+  @Column({ nullable: true })
+  flagReason: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => ProviderContent, (content) => content.engagements, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'contentId' })
+  content: ProviderContent;
+}

--- a/src/content/entities/provider-content.entity.ts
+++ b/src/content/entities/provider-content.entity.ts
@@ -1,0 +1,92 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { ContentEngagement } from './content-engagement.entity';
+
+export enum ContentType {
+  ARTICLE = 'article',
+  VIDEO = 'video',
+  ANALYSIS = 'analysis',
+}
+
+export enum ContentStatus {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  FLAGGED = 'flagged',
+  REMOVED = 'removed',
+}
+
+@Entity('provider_content')
+@Index(['providerId', 'published'])
+@Index(['type', 'published'])
+@Index(['createdAt'])
+export class ProviderContent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  providerId: string;
+
+  @Column({
+    type: 'enum',
+    enum: ContentType,
+  })
+  type: ContentType;
+
+  @Column()
+  title: string;
+
+  @Column('text')
+  body: string; // markdown for articles, embed URL for videos
+
+  @Column('simple-array', { default: '' })
+  tags: string[];
+
+  @Column({ default: false })
+  published: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: ContentStatus,
+    default: ContentStatus.DRAFT,
+  })
+  status: ContentStatus;
+
+  @Column({ default: 0 })
+  views: number;
+
+  @Column({ default: 0 })
+  likes: number;
+
+  @Column({ default: 0 })
+  shares: number;
+
+  @Column({ nullable: true })
+  thumbnailUrl: string;
+
+  @Column({ nullable: true })
+  videoUrl: string; // YouTube, Vimeo embed URL
+
+  @Column({ nullable: true })
+  flagReason: string;
+
+  @Column({ nullable: true })
+  moderatorNotes: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @OneToMany(() => ContentEngagement, (engagement) => engagement.content)
+  engagements: ContentEngagement[];
+}


### PR DESCRIPTION
- Add POST `/providers/content` and GET `/providers/:id/content` endpoints
- Create content.module.ts, controller, service, and entity files
- Support article, video, and analysis content types with markdown body
- Implement YouTube and Vimeo video embedding via URL parsing
- Add tag-based topic classification and full-text search filtering
- Implement engagement tracking for views, likes, and shares
- Add content moderation flag and publish/draft state management
- Add unit tests for publishing, engagement tracking, and search/filter logic

Implement Provider Content Management (Educational) Fixes #121