### PR TITLE
feat: notification preferences management system

### DIFF
--- a/src/notifications/dto/update-preferences.dto.ts
+++ b/src/notifications/dto/update-preferences.dto.ts
@@ -1,0 +1,34 @@
+import { IsBoolean, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ChannelPreferenceDto {
+  @IsOptional()
+  @IsBoolean()
+  email?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  push?: boolean;
+}
+
+export class UpdatePreferencesDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelPreferenceDto)
+  tradeUpdates?: ChannelPreferenceDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelPreferenceDto)
+  signalPerformance?: ChannelPreferenceDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelPreferenceDto)
+  systemAlerts?: ChannelPreferenceDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelPreferenceDto)
+  marketing?: ChannelPreferenceDto;
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationPreference } from './preferences/entities/notification-preference.entity';
+import { PreferencesService } from './preferences/preferences.service';
+import { PreferencesController } from './preferences/preferences.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([NotificationPreference])],
+  controllers: [PreferencesController],
+  providers: [PreferencesService],
+  exports: [PreferencesService], // export so other modules can call isEnabled() before sending
+})
+export class NotificationsModule {}

--- a/src/notifications/preferences/entities/notification-preference.entity.ts
+++ b/src/notifications/preferences/entities/notification-preference.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('user_notification_preferences')
+export class NotificationPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true })
+  @Column({ name: 'user_id' })
+  userId: string;
+
+  // Trade updates
+  @Column({ name: 'trade_updates_email', default: true })
+  tradeUpdatesEmail: boolean;
+
+  @Column({ name: 'trade_updates_push', default: true })
+  tradeUpdatesPush: boolean;
+
+  // Signal performance
+  @Column({ name: 'signal_performance_email', default: true })
+  signalPerformanceEmail: boolean;
+
+  @Column({ name: 'signal_performance_push', default: true })
+  signalPerformancePush: boolean;
+
+  // System alerts
+  @Column({ name: 'system_alerts_email', default: true })
+  systemAlertsEmail: boolean;
+
+  @Column({ name: 'system_alerts_push', default: true })
+  systemAlertsPush: boolean;
+
+  // Marketing
+  @Column({ name: 'marketing_email', default: false })
+  marketingEmail: boolean;
+
+  @Column({ name: 'marketing_push', default: false })
+  marketingPush: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/notifications/preferences/preferences.controller.ts
+++ b/src/notifications/preferences/preferences.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  Query,
+} from '@nestjs/common';
+import {
+  PreferencesService,
+  PreferencesResponse,
+  NotificationType,
+  NotificationChannel,
+} from './preferences.service';
+import { UpdatePreferencesDto } from '../dto/update-preferences.dto';
+
+// Replace with your actual auth guard and user decorator
+// import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+// import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+
+@Controller('notifications/preferences')
+export class PreferencesController {
+  constructor(private readonly preferencesService: PreferencesService) {}
+
+  // GET /notifications/preferences
+  // In production: use @UseGuards(JwtAuthGuard) and extract userId from @CurrentUser()
+  // The userId param here is a stand-in until auth decorators are confirmed
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getPreferences(
+    @Query('userId') userId: string,
+  ): Promise<PreferencesResponse> {
+    return this.preferencesService.getPreferences(userId);
+  }
+
+  // PUT /notifications/preferences
+  @Put()
+  @HttpCode(HttpStatus.OK)
+  async updatePreferences(
+    @Query('userId') userId: string,
+    @Body() dto: UpdatePreferencesDto,
+  ): Promise<PreferencesResponse> {
+    return this.preferencesService.updatePreferences(userId, dto);
+  }
+
+  // GET /notifications/preferences/unsubscribe
+  // Used by email unsubscribe links:
+  // e.g. /notifications/preferences/unsubscribe?userId=X&type=marketing&channel=email
+  @Get('unsubscribe')
+  @HttpCode(HttpStatus.OK)
+  async unsubscribe(
+    @Query('userId') userId: string,
+    @Query('type') type: NotificationType,
+    @Query('channel') channel: NotificationChannel,
+  ): Promise<{ message: string }> {
+    await this.preferencesService.unsubscribe(userId, type, channel);
+    return {
+      message: `Successfully unsubscribed from ${type} ${channel} notifications.`,
+    };
+  }
+}

--- a/src/notifications/preferences/preferences.service.ts
+++ b/src/notifications/preferences/preferences.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationPreference } from './entities/notification-preference.entity';
+import { UpdatePreferencesDto } from '../dto/update-preferences.dto';
+
+export interface PreferenceChannel {
+  email: boolean;
+  push: boolean;
+}
+
+export interface PreferencesResponse {
+  userId: string;
+  tradeUpdates: PreferenceChannel;
+  signalPerformance: PreferenceChannel;
+  systemAlerts: PreferenceChannel;
+  marketing: PreferenceChannel;
+  updatedAt: Date;
+}
+
+export type NotificationType =
+  | 'tradeUpdates'
+  | 'signalPerformance'
+  | 'systemAlerts'
+  | 'marketing';
+
+export type NotificationChannel = 'email' | 'push';
+
+@Injectable()
+export class PreferencesService {
+  constructor(
+    @InjectRepository(NotificationPreference)
+    private readonly preferenceRepository: Repository<NotificationPreference>,
+  ) {}
+
+  async getPreferences(userId: string): Promise<PreferencesResponse> {
+    const preference = await this.findOrCreate(userId);
+    return this.toResponse(preference);
+  }
+
+  async updatePreferences(
+    userId: string,
+    dto: UpdatePreferencesDto,
+  ): Promise<PreferencesResponse> {
+    const preference = await this.findOrCreate(userId);
+
+    if (dto.tradeUpdates !== undefined) {
+      if (dto.tradeUpdates.email !== undefined) {
+        preference.tradeUpdatesEmail = dto.tradeUpdates.email;
+      }
+      if (dto.tradeUpdates.push !== undefined) {
+        preference.tradeUpdatesPush = dto.tradeUpdates.push;
+      }
+    }
+
+    if (dto.signalPerformance !== undefined) {
+      if (dto.signalPerformance.email !== undefined) {
+        preference.signalPerformanceEmail = dto.signalPerformance.email;
+      }
+      if (dto.signalPerformance.push !== undefined) {
+        preference.signalPerformancePush = dto.signalPerformance.push;
+      }
+    }
+
+    if (dto.systemAlerts !== undefined) {
+      if (dto.systemAlerts.email !== undefined) {
+        preference.systemAlertsEmail = dto.systemAlerts.email;
+      }
+      if (dto.systemAlerts.push !== undefined) {
+        preference.systemAlertsPush = dto.systemAlerts.push;
+      }
+    }
+
+    if (dto.marketing !== undefined) {
+      if (dto.marketing.email !== undefined) {
+        preference.marketingEmail = dto.marketing.email;
+      }
+      if (dto.marketing.push !== undefined) {
+        preference.marketingPush = dto.marketing.push;
+      }
+    }
+
+    const saved = await this.preferenceRepository.save(preference);
+    return this.toResponse(saved);
+  }
+
+  /**
+   * Check if a user has a specific notification type/channel enabled.
+   * Call this before sending any notification.
+   */
+  async isEnabled(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannel,
+  ): Promise<boolean> {
+    const preference = await this.findOrCreate(userId);
+
+    const map: Record<
+      NotificationType,
+      Record<NotificationChannel, boolean>
+    > = {
+      tradeUpdates: {
+        email: preference.tradeUpdatesEmail,
+        push: preference.tradeUpdatesPush,
+      },
+      signalPerformance: {
+        email: preference.signalPerformanceEmail,
+        push: preference.signalPerformancePush,
+      },
+      systemAlerts: {
+        email: preference.systemAlertsEmail,
+        push: preference.systemAlertsPush,
+      },
+      marketing: {
+        email: preference.marketingEmail,
+        push: preference.marketingPush,
+      },
+    };
+
+    return map[type][channel];
+  }
+
+  /**
+   * Unsubscribe a user from a specific type and channel.
+   * Used by unsubscribe links in emails.
+   */
+  async unsubscribe(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannel,
+  ): Promise<PreferencesResponse> {
+    const dto: UpdatePreferencesDto = {
+      [type]: { [channel]: false },
+    };
+    return this.updatePreferences(userId, dto);
+  }
+
+  private async findOrCreate(userId: string): Promise<NotificationPreference> {
+    const existing = await this.preferenceRepository.findOne({
+      where: { userId },
+    });
+
+    if (existing) return existing;
+
+    // Create with defaults defined on the entity columns
+    const preference = this.preferenceRepository.create({ userId });
+    return this.preferenceRepository.save(preference);
+  }
+
+  private toResponse(preference: NotificationPreference): PreferencesResponse {
+    return {
+      userId: preference.userId,
+      tradeUpdates: {
+        email: preference.tradeUpdatesEmail,
+        push: preference.tradeUpdatesPush,
+      },
+      signalPerformance: {
+        email: preference.signalPerformanceEmail,
+        push: preference.signalPerformancePush,
+      },
+      systemAlerts: {
+        email: preference.systemAlertsEmail,
+        push: preference.systemAlertsPush,
+      },
+      marketing: {
+        email: preference.marketingEmail,
+        push: preference.marketingPush,
+      },
+      updatedAt: preference.updatedAt,
+    };
+  }
+}


### PR DESCRIPTION
## Description
Implements a notification preferences management system allowing users to control which notification types they receive and via which channels (email and push). Preferences are stored per user in the database with sensible defaults. A reusable `isEnabled()` method allows other services to check preferences before dispatching any notification. An unsubscribe endpoint supports one-click unsubscribe links in emails.

## Related Issue
- Closes #84

## Changes Made

- `src/notifications/preferences/entities/notification-preference.entity.ts`: TypeORM entity mapping to `user_notification_preferences` table. Stores boolean flags for each notification type and channel combination. Defaults: trade updates, signal performance, and system alerts are enabled on both channels; marketing is disabled on both.

- `src/notifications/dto/update-preferences.dto.ts`: Partial update DTO using nested `ChannelPreferenceDto` per notification type. All fields are optional so users can update a single channel without resending the full object.

- `src/notifications/preferences/preferences.service.ts`: Core service with `getPreferences()`, `updatePreferences()`, `isEnabled()`, and `unsubscribe()`. Uses a `findOrCreate` pattern to transparently provision default preferences for new users on first access.

- `src/notifications/preferences/preferences.controller.ts`: Exposes `GET /notifications/preferences`, `PUT /notifications/preferences`, and `GET /notifications/preferences/unsubscribe`. Auth guard integration is marked with comments pending confirmation of the project's auth decorator pattern.

- `src/notifications/notifications.module.ts`: Registers the entity, service, and controller. Exports `PreferencesService` so other modules (e.g. a mailer or push service) can call `isEnabled()` before sending.

## Acceptance Criteria

- `GET /notifications/preferences` returns current settings for a user, creating defaults on first call
- `PUT /notifications/preferences` updates only the fields provided, leaving others unchanged
- Defaults are trade updates email/push true, signal performance email/push true, system alerts email/push true, marketing email/push false
- `isEnabled(userId, type, channel)` available for other services to gate notification sending
- Unsubscribe endpoint at `GET /notifications/preferences/unsubscribe` disables a specific type/channel