### PR TITLE
Secure backend health and metrics endpoints behind authentication (#379)

### DIFF
--- a/src/common/guards/health-metrics-auth.guard.ts
+++ b/src/common/guards/health-metrics-auth.guard.ts
@@ -1,0 +1,58 @@
+/**
+ * Guard used for backend health and metrics endpoints.
+ * Only authenticated internal or authorized clients may access these routes.
+ * Supports JWT bearer auth and admin-style API keys.
+ */
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ApiKeyAuthGuard } from '../../api-keys/guards/api-key-auth.guard';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+
+@Injectable()
+export class HealthMetricsAuthGuard implements CanActivate {
+  constructor(
+    private readonly jwtAuthGuard: JwtAuthGuard,
+    private readonly apiKeyAuthGuard: ApiKeyAuthGuard,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    let jwtError: unknown;
+
+    try {
+      if (await this.jwtAuthGuard.canActivate(context)) {
+        return true;
+      }
+    } catch (error) {
+      jwtError = error;
+    }
+
+    try {
+      if (await this.apiKeyAuthGuard.canActivate(context)) {
+        return true;
+      }
+    } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+      if (jwtError instanceof ForbiddenException) {
+        throw jwtError;
+      }
+      throw error;
+    }
+
+    if (jwtError) {
+      if (jwtError instanceof Error) {
+        throw jwtError;
+      }
+    }
+
+    throw new UnauthorizedException(
+      'Authentication is required for health and metrics endpoints',
+    );
+  }
+}

--- a/src/health/health-summary.service.ts
+++ b/src/health/health-summary.service.ts
@@ -31,6 +31,10 @@ export interface HealthStatus {
   lastChecked: string;
 }
 
+type HealthIndicatorResultWithResponseTime = Record<string, any> & {
+  responseTime?: number;
+};
+
 /**
  * #388 — Health summary service for backend services and dependencies.
  *
@@ -79,7 +83,7 @@ export class HealthSummaryService {
     };
   }
 
-  private async checkDatabase(): Promise<HealthIndicatorResult> {
+  private async checkDatabase(): Promise<HealthIndicatorResultWithResponseTime> {
     const start = Date.now();
     try {
       const result = await this.databaseHealth.isHealthy('database');
@@ -98,7 +102,7 @@ export class HealthSummaryService {
     }
   }
 
-  private async checkCache(): Promise<HealthIndicatorResult> {
+  private async checkCache(): Promise<HealthIndicatorResultWithResponseTime> {
     const start = Date.now();
     try {
       const result = await this.redisHealth.isHealthy('cache');
@@ -117,7 +121,7 @@ export class HealthSummaryService {
     }
   }
 
-  private async checkStellar(): Promise<HealthIndicatorResult> {
+  private async checkStellar(): Promise<HealthIndicatorResultWithResponseTime> {
     const start = Date.now();
     try {
       const result = await this.stellarHealth.isHealthy('stellar');
@@ -136,7 +140,7 @@ export class HealthSummaryService {
     }
   }
 
-  private async checkSoroban(): Promise<HealthIndicatorResult> {
+  private async checkSoroban(): Promise<HealthIndicatorResultWithResponseTime> {
     const start = Date.now();
     try {
       const result = await this.sorobanHealth.isHealthy('soroban');

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, OnApplicationBootstrap, Logger } from '@nestjs/common';
+import { Controller, Get, OnApplicationBootstrap, Logger, UseGuards } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
@@ -11,8 +11,10 @@ import {
   RedisHealthIndicator,
 } from './indicators';
 import { HealthSummaryService, ServiceHealthSummary } from './health-summary.service';
+import { HealthMetricsAuthGuard } from '../common/guards/health-metrics-auth.guard';
 
 @Controller('health')
+@UseGuards(HealthMetricsAuthGuard)
 export class HealthController implements OnApplicationBootstrap {
   private readonly logger = new Logger(HealthController.name);
 

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -9,6 +9,8 @@ import {
 } from './indicators';
 import { StellarConfigService } from '../config/stellar.service';
 import { HealthSummaryService } from './health-summary.service';
+import { AuthModule } from '../auth/auth.module';
+import { ApiKeysModule } from '../api-keys/api-keys.module';
 
 @Module({
   imports: [TerminusModule],

--- a/src/monitoring/monitoring.controller.ts
+++ b/src/monitoring/monitoring.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Header } from '@nestjs/common';
+import { Controller, Get, Header, UseGuards } from '@nestjs/common';
 import { PrometheusService } from './metrics/prometheus.service';
+import { HealthMetricsAuthGuard } from '../common/guards/health-metrics-auth.guard';
 
 @Controller('metrics')
+@UseGuards(HealthMetricsAuthGuard)
 export class MonitoringController {
   constructor(private readonly prometheus: PrometheusService) {}
 

--- a/src/monitoring/monitoring.module.ts
+++ b/src/monitoring/monitoring.module.ts
@@ -2,9 +2,12 @@ import { Module, Global } from '@nestjs/common';
 import { PrometheusService } from './metrics/prometheus.service';
 import { MetricsInterceptor } from './metrics/metrics.interceptor';
 import { MonitoringController } from './monitoring.controller';
+import { AuthModule } from '../auth/auth.module';
+import { ApiKeysModule } from '../api-keys/api-keys.module';
 
 @Global()
 @Module({
+  imports: [AuthModule, ApiKeysModule],
   providers: [PrometheusService, MetricsInterceptor],
   controllers: [MonitoringController],
   exports: [PrometheusService, MetricsInterceptor],

--- a/test/health-metrics-auth.guard.spec.ts
+++ b/test/health-metrics-auth.guard.spec.ts
@@ -1,0 +1,60 @@
+import { ForbiddenException, UnauthorizedException, ExecutionContext } from '@nestjs/common';
+import { HealthMetricsAuthGuard } from '../src/common/guards/health-metrics-auth.guard';
+import { ApiKeyAuthGuard } from '../src/api-keys/guards/api-key-auth.guard';
+import { JwtAuthGuard } from '../src/auth/guards/jwt-auth.guard';
+
+describe('HealthMetricsAuthGuard', () => {
+  let guard: HealthMetricsAuthGuard;
+  let jwtGuard: Partial<JwtAuthGuard>;
+  let apiKeyGuard: Partial<ApiKeyAuthGuard>;
+  const context = {
+    switchToHttp: jest.fn().mockReturnValue({ getRequest: jest.fn(), getResponse: jest.fn() }),
+    getClass: jest.fn(),
+    getHandler: jest.fn(),
+  } as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jwtGuard = { canActivate: jest.fn() };
+    apiKeyGuard = { canActivate: jest.fn() };
+    guard = new HealthMetricsAuthGuard(
+      jwtGuard as JwtAuthGuard,
+      apiKeyGuard as ApiKeyAuthGuard,
+    );
+  });
+
+  it('permits access when JwtAuthGuard succeeds', async () => {
+    (jwtGuard.canActivate as jest.Mock).mockResolvedValue(true);
+    (apiKeyGuard.canActivate as jest.Mock).mockResolvedValue(false);
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(jwtGuard.canActivate).toHaveBeenCalledTimes(1);
+    expect(apiKeyGuard.canActivate).not.toHaveBeenCalled();
+  });
+
+  it('permits access when ApiKeyAuthGuard succeeds after JwtAuthGuard fails', async () => {
+    (jwtGuard.canActivate as jest.Mock).mockRejectedValue(new UnauthorizedException());
+    (apiKeyGuard.canActivate as jest.Mock).mockResolvedValue(true);
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(jwtGuard.canActivate).toHaveBeenCalledTimes(1);
+    expect(apiKeyGuard.canActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with UnauthorizedException when both guards fail with unauthorized', async () => {
+    (jwtGuard.canActivate as jest.Mock).mockRejectedValue(new UnauthorizedException());
+    (apiKeyGuard.canActivate as jest.Mock).mockRejectedValue(new UnauthorizedException());
+
+    await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+    expect(jwtGuard.canActivate).toHaveBeenCalledTimes(1);
+    expect(apiKeyGuard.canActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates ForbiddenException from ApiKeyAuthGuard when JWT fails', async () => {
+    (jwtGuard.canActivate as jest.Mock).mockRejectedValue(new UnauthorizedException());
+    (apiKeyGuard.canActivate as jest.Mock).mockRejectedValue(new ForbiddenException());
+
+    await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+    expect(jwtGuard.canActivate).toHaveBeenCalledTimes(1);
+    expect(apiKeyGuard.canActivate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/health.controller.spec.ts
+++ b/test/health.controller.spec.ts
@@ -7,6 +7,10 @@ import {
   StellarHealthIndicator,
   SorobanHealthIndicator,
 } from '../src/health/indicators';
+import { HealthSummaryService } from '../src/health/health-summary.service';
+import { HealthMetricsAuthGuard } from '../src/common/guards/health-metrics-auth.guard';
+import { JwtAuthGuard } from '../src/auth/guards/jwt-auth.guard';
+import { ApiKeyAuthGuard } from '../src/api-keys/guards/api-key-auth.guard';
 
 const mockHealthCheck = jest.fn();
 const mockDbHealth = { isHealthy: jest.fn() };
@@ -27,6 +31,10 @@ describe('HealthController (#370)', () => {
         { provide: RedisHealthIndicator, useValue: mockRedisHealth },
         { provide: StellarHealthIndicator, useValue: mockStellarHealth },
         { provide: SorobanHealthIndicator, useValue: mockSorobanHealth },
+        HealthMetricsAuthGuard,
+        { provide: JwtAuthGuard, useValue: { canActivate: jest.fn().mockResolvedValue(true) } },
+        { provide: ApiKeyAuthGuard, useValue: { canActivate: jest.fn().mockResolvedValue(false) } },
+        { provide: HealthSummaryService, useValue: { getHealthSummary: jest.fn() } },
       ],
     }).compile();
 
@@ -43,20 +51,13 @@ describe('HealthController (#370)', () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {}) as any);
     mockHealthCheck.mockRejectedValue(new Error('DB unavailable'));
 
-    // Speed up retries
-    jest.useFakeTimers();
-    const bootstrapPromise = controller.onApplicationBootstrap();
-    // Advance through all retry delays (5 retries × 3000ms)
-    for (let i = 0; i < 5; i++) {
-      await Promise.resolve();
-      jest.advanceTimersByTime(3000);
-    }
-    await bootstrapPromise.catch(() => {});
     jest.useRealTimers();
+    const bootstrapPromise = controller.onApplicationBootstrap();
+    await bootstrapPromise.catch(() => {});
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
-  });
+  }, 30000);
 
   it('GET /health should check all indicators', async () => {
     mockHealthCheck.mockResolvedValue({ status: 'ok', info: {}, error: {}, details: {} });


### PR DESCRIPTION
Closes #379

---

This PR secures the backend health and metrics endpoints by protecting them with a combined authentication guard that accepts either a valid JWT bearer token or an authorized API key. It also updates the health module and monitoring module to import the required auth providers, adds regression tests for the new guard, and preserves existing health controller behavior.

Tested:
- npm test -- --runInBand test/health-metrics-auth.guard.spec.ts test/health.controller.spec.ts
