### PR TITLE
feat(database): improve migration rollback safety and detect irrevers…

### DIFF
--- a/src/database/migrations/README.md
+++ b/src/database/migrations/README.md
@@ -17,4 +17,113 @@ npm run typeorm migration:revert
 
 ## Migration Files
 
-- `1737561600000-CreateUserTables.ts` - Initial user schema with users, user_preferences, and sessions tables
+- `1737561600000-CreateUserTables.ts` – Initial user schema with users, user_preferences, and sessions tables
+
+## Migration Rollback Safety (`migration-utils.ts`)
+
+`migration-utils.ts` provides helpers that improve rollback safety and surface
+irreversible changes **before** they are applied to the database.
+
+### `detectIrreversibleChanges(sql)`
+
+Analyses a SQL string (or array of strings) for operations that cannot be
+safely rolled back. Returns an `IrreversibilityReport` with all findings
+sorted by severity (`CRITICAL → HIGH → WARNING`).
+
+```ts
+import { detectIrreversibleChanges } from './migration-utils';
+
+const report = detectIrreversibleChanges('DROP TABLE legacy_tokens');
+if (report.hasIrreversibleChanges) {
+  console.warn(report.changes); // [{ rule: 'DROP_TABLE', severity: 'CRITICAL', … }]
+}
+```
+
+**Detected patterns**
+
+| Rule               | Severity | Description                                              |
+|--------------------|----------|----------------------------------------------------------|
+| `DROP_TABLE`       | CRITICAL | Permanently removes table and data                       |
+| `DROP_COLUMN`      | CRITICAL | Permanently removes column and stored values             |
+| `DROP_DATABASE`    | CRITICAL | Destroys the entire database                             |
+| `DROP_SCHEMA`      | CRITICAL | Removes schema and all contained objects                 |
+| `TRUNCATE`         | CRITICAL | Removes all rows without row-level logging               |
+| `DROP_TYPE`        | HIGH     | Removes a custom type; dependent columns must be migrated|
+| `DROP_CONSTRAINT`  | HIGH     | Existing data may violate constraint on re-add           |
+| `ALTER_COLUMN_TYPE`| HIGH     | Narrowing a type may cause data loss                     |
+| `DELETE_DATA`      | HIGH     | Permanently removes rows                                 |
+| `DROP_INDEX`       | WARNING  | Performance impact if `down()` does not recreate it      |
+| `SET_NOT_NULL`     | WARNING  | Fails if existing rows contain NULL                      |
+| `UPDATE_DATA`      | WARNING  | Original values lost unless `down()` reverses the change |
+
+---
+
+### `withRollbackSafety(queryRunner, sql, body, options?)`
+
+Wraps a migration `up()` body with:
+
+1. Pre-flight irreversibility analysis (logs findings).
+2. Optional blocking on `CRITICAL` or `HIGH` findings.
+3. Savepoint-based partial-failure recovery.
+
+```ts
+import { withRollbackSafety } from './migration-utils';
+
+public async up(queryRunner: QueryRunner): Promise<void> {
+  await withRollbackSafety(
+    queryRunner,
+    'DROP TABLE legacy_tokens',
+    async () => {
+      await queryRunner.query('DROP TABLE legacy_tokens');
+    },
+    { blockOnCritical: true }, // throws MigrationRollbackError if CRITICAL found
+  );
+}
+```
+
+**Options**
+
+| Option           | Type      | Default | Description                                      |
+|------------------|-----------|---------|--------------------------------------------------|
+| `blockOnCritical`| `boolean` | `false` | Throw before executing if CRITICAL changes found |
+| `blockOnHigh`    | `boolean` | `false` | Throw before executing if HIGH changes found     |
+| `logger`         | `Console` | `console`| Custom logger for findings                      |
+
+---
+
+### Data-level backup helpers
+
+Use these when a migration modifies or removes data and you need a safety net
+that can be used in `down()`.
+
+```ts
+import { createSafeBackup, restoreFromBackup, dropBackupTable } from './migration-utils';
+
+// In up():
+const backupTable = await createSafeBackup(queryRunner, 'users');
+// … destructive operation …
+
+// In down():
+await restoreFromBackup(queryRunner, 'users', backupTable);
+// Once confirmed stable:
+await dropBackupTable(queryRunner, backupTable);
+```
+
+---
+
+### Existence guards
+
+Use these in `down()` to prevent errors on double-rollback.
+
+```ts
+import { tableExists, columnExists } from './migration-utils';
+
+public async down(queryRunner: QueryRunner): Promise<void> {
+  if (await tableExists(queryRunner, 'legacy_tokens')) {
+    await queryRunner.dropTable('legacy_tokens');
+  }
+  if (await columnExists(queryRunner, 'users', 'referred_by')) {
+    await queryRunner.dropColumn('users', 'referred_by');
+  }
+}
+```

--- a/src/database/migrations/migration-utils.spec.ts
+++ b/src/database/migrations/migration-utils.spec.ts
@@ -1,0 +1,343 @@
+import {
+  detectIrreversibleChanges,
+  withRollbackSafety,
+  createSafeBackup,
+  restoreFromBackup,
+  dropBackupTable,
+  tableExists,
+  columnExists,
+  IrreversibleSeverity,
+  MigrationRollbackError,
+} from './migration-utils';
+
+// ---------------------------------------------------------------------------
+// Shared mock QueryRunner
+// ---------------------------------------------------------------------------
+
+function buildQueryRunner(queryResults: Record<string, unknown> = {}) {
+  return {
+    query: jest.fn().mockImplementation((sql: string, _params?: unknown[]) => {
+      // Return a custom result if registered, otherwise resolve to []
+      for (const [key, value] of Object.entries(queryResults)) {
+        if (sql.includes(key)) return Promise.resolve(value);
+      }
+      return Promise.resolve([]);
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// detectIrreversibleChanges
+// ---------------------------------------------------------------------------
+
+describe('detectIrreversibleChanges', () => {
+  it('returns a clean report for safe SQL', () => {
+    const report = detectIrreversibleChanges('CREATE TABLE foo (id uuid PRIMARY KEY)');
+    expect(report.hasIrreversibleChanges).toBe(false);
+    expect(report.changes).toHaveLength(0);
+    expect(report.maxSeverity).toBeNull();
+  });
+
+  it('detects DROP TABLE as CRITICAL', () => {
+    const report = detectIrreversibleChanges('DROP TABLE users');
+    expect(report.hasIrreversibleChanges).toBe(true);
+    const finding = report.changes.find((c) => c.rule === 'DROP_TABLE');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.CRITICAL);
+  });
+
+  it('detects DROP COLUMN as CRITICAL', () => {
+    const report = detectIrreversibleChanges(
+      'ALTER TABLE users DROP COLUMN email',
+    );
+    const finding = report.changes.find((c) => c.rule === 'DROP_COLUMN');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.CRITICAL);
+  });
+
+  it('detects TRUNCATE as CRITICAL', () => {
+    const report = detectIrreversibleChanges('TRUNCATE TABLE sessions');
+    const finding = report.changes.find((c) => c.rule === 'TRUNCATE');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.CRITICAL);
+  });
+
+  it('detects DROP TYPE as HIGH', () => {
+    const report = detectIrreversibleChanges('DROP TYPE risk_level_enum');
+    const finding = report.changes.find((c) => c.rule === 'DROP_TYPE');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.HIGH);
+  });
+
+  it('detects DROP CONSTRAINT as HIGH', () => {
+    const report = detectIrreversibleChanges(
+      'ALTER TABLE users DROP CONSTRAINT uq_users_email',
+    );
+    const finding = report.changes.find((c) => c.rule === 'DROP_CONSTRAINT');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.HIGH);
+  });
+
+  it('detects ALTER COLUMN TYPE as HIGH', () => {
+    const report = detectIrreversibleChanges(
+      'ALTER TABLE users ALTER COLUMN score TYPE bigint',
+    );
+    const finding = report.changes.find((c) => c.rule === 'ALTER_COLUMN_TYPE');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.HIGH);
+  });
+
+  it('detects DROP INDEX as WARNING', () => {
+    const report = detectIrreversibleChanges('DROP INDEX idx_users_email');
+    const finding = report.changes.find((c) => c.rule === 'DROP_INDEX');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.WARNING);
+  });
+
+  it('detects SET NOT NULL as WARNING', () => {
+    const report = detectIrreversibleChanges(
+      'ALTER TABLE users ALTER COLUMN email SET NOT NULL',
+    );
+    const finding = report.changes.find((c) => c.rule === 'SET_NOT_NULL');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.WARNING);
+  });
+
+  it('detects DELETE FROM as HIGH', () => {
+    const report = detectIrreversibleChanges('DELETE FROM sessions WHERE expired = true');
+    const finding = report.changes.find((c) => c.rule === 'DELETE_DATA');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.HIGH);
+  });
+
+  it('detects UPDATE … SET as WARNING', () => {
+    const report = detectIrreversibleChanges("UPDATE users SET status = 'active'");
+    const finding = report.changes.find((c) => c.rule === 'UPDATE_DATA');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe(IrreversibleSeverity.WARNING);
+  });
+
+  it('accepts an array of SQL statements', () => {
+    const report = detectIrreversibleChanges([
+      'CREATE TABLE foo (id uuid PRIMARY KEY)',
+      'DROP TABLE bar',
+    ]);
+    expect(report.hasIrreversibleChanges).toBe(true);
+    expect(report.changes.find((c) => c.rule === 'DROP_TABLE')).toBeDefined();
+  });
+
+  it('sorts findings CRITICAL → HIGH → WARNING', () => {
+    const report = detectIrreversibleChanges(
+      "DROP INDEX idx_foo; DROP TABLE bar; UPDATE baz SET x = 1",
+    );
+    const severities = report.changes.map((c) => c.severity);
+    const critIdx = severities.indexOf(IrreversibleSeverity.CRITICAL);
+    const warnIdx = severities.indexOf(IrreversibleSeverity.WARNING);
+    expect(critIdx).toBeLessThan(warnIdx);
+  });
+
+  it('sets maxSeverity to the highest finding', () => {
+    const report = detectIrreversibleChanges('DROP INDEX idx_foo; DROP TABLE bar');
+    expect(report.maxSeverity).toBe(IrreversibleSeverity.CRITICAL);
+  });
+
+  it('includes the matched SQL fragment in the finding', () => {
+    const report = detectIrreversibleChanges('DROP TABLE users');
+    expect(report.changes[0].fragment).toBeTruthy();
+  });
+
+  it('is case-insensitive', () => {
+    const report = detectIrreversibleChanges('drop table users');
+    expect(report.changes.find((c) => c.rule === 'DROP_TABLE')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withRollbackSafety
+// ---------------------------------------------------------------------------
+
+describe('withRollbackSafety', () => {
+  it('executes the body and releases the savepoint on success', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockResolvedValue(undefined);
+
+    await withRollbackSafety(qr as any, 'CREATE TABLE foo (id uuid)', body);
+
+    expect(body).toHaveBeenCalledTimes(1);
+    const calls: string[] = qr.query.mock.calls.map((c: string[]) => c[0]);
+    expect(calls.some((s) => s.startsWith('SAVEPOINT'))).toBe(true);
+    expect(calls.some((s) => s.startsWith('RELEASE SAVEPOINT'))).toBe(true);
+  });
+
+  it('rolls back to savepoint and re-throws when body throws', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockRejectedValue(new Error('query failed'));
+
+    await expect(
+      withRollbackSafety(qr as any, 'CREATE TABLE foo (id uuid)', body),
+    ).rejects.toThrow('query failed');
+
+    const calls: string[] = qr.query.mock.calls.map((c: string[]) => c[0]);
+    expect(calls.some((s) => s.startsWith('ROLLBACK TO SAVEPOINT'))).toBe(true);
+  });
+
+  it('logs CRITICAL findings but does not block by default', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockResolvedValue(undefined);
+    const logger = { warn: jest.fn(), error: jest.fn(), log: jest.fn() };
+
+    await withRollbackSafety(qr as any, 'DROP TABLE users', body, { logger });
+
+    expect(logger.error).toHaveBeenCalled();
+    expect(body).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws MigrationRollbackError when blockOnCritical is true and CRITICAL found', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withRollbackSafety(qr as any, 'DROP TABLE users', body, {
+        blockOnCritical: true,
+      }),
+    ).rejects.toThrow(MigrationRollbackError);
+
+    expect(body).not.toHaveBeenCalled();
+  });
+
+  it('does NOT throw when blockOnCritical is true but SQL is safe', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withRollbackSafety(
+        qr as any,
+        'CREATE TABLE foo (id uuid PRIMARY KEY)',
+        body,
+        { blockOnCritical: true },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(body).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws MigrationRollbackError when blockOnHigh is true and HIGH found', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withRollbackSafety(qr as any, 'DROP TYPE my_enum', body, {
+        blockOnHigh: true,
+      }),
+    ).rejects.toThrow(MigrationRollbackError);
+
+    expect(body).not.toHaveBeenCalled();
+  });
+
+  it('does NOT throw when blockOnHigh is true but only WARNING found', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn().mockResolvedValue(undefined);
+
+    await withRollbackSafety(qr as any, 'DROP INDEX idx_foo', body, {
+      blockOnHigh: true,
+    });
+
+    expect(body).toHaveBeenCalledTimes(1);
+  });
+
+  it('MigrationRollbackError carries the full report', async () => {
+    const qr = buildQueryRunner();
+    const body = jest.fn();
+
+    let caught: MigrationRollbackError | undefined;
+    try {
+      await withRollbackSafety(qr as any, 'DROP TABLE users', body, {
+        blockOnCritical: true,
+      });
+    } catch (e) {
+      caught = e as MigrationRollbackError;
+    }
+
+    expect(caught).toBeInstanceOf(MigrationRollbackError);
+    expect(caught!.report.hasIrreversibleChanges).toBe(true);
+    expect(caught!.report.maxSeverity).toBe(IrreversibleSeverity.CRITICAL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSafeBackup / restoreFromBackup / dropBackupTable
+// ---------------------------------------------------------------------------
+
+describe('createSafeBackup', () => {
+  it('creates a backup table with the correct naming pattern', async () => {
+    const qr = buildQueryRunner();
+    const backupName = await createSafeBackup(qr as any, 'users');
+
+    expect(backupName).toMatch(/^users_backup_\d+$/);
+    expect(qr.query).toHaveBeenCalledWith(
+      expect.stringContaining('CREATE TABLE'),
+    );
+  });
+});
+
+describe('restoreFromBackup', () => {
+  it('truncates the target table and inserts from backup', async () => {
+    const qr = buildQueryRunner();
+    await restoreFromBackup(qr as any, 'users', 'users_backup_123');
+
+    const calls: string[] = qr.query.mock.calls.map((c: string[]) => c[0]);
+    expect(calls.some((s) => s.includes('TRUNCATE'))).toBe(true);
+    expect(calls.some((s) => s.includes('INSERT INTO'))).toBe(true);
+  });
+});
+
+describe('dropBackupTable', () => {
+  it('issues DROP TABLE IF EXISTS for the backup table', async () => {
+    const qr = buildQueryRunner();
+    await dropBackupTable(qr as any, 'users_backup_123');
+
+    expect(qr.query).toHaveBeenCalledWith(
+      expect.stringContaining('DROP TABLE IF EXISTS'),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tableExists / columnExists
+// ---------------------------------------------------------------------------
+
+describe('tableExists', () => {
+  it('returns true when the table exists', async () => {
+    const qr = buildQueryRunner({
+      information_schema: [{ exists: true }],
+    });
+    const result = await tableExists(qr as any, 'users');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the table does not exist', async () => {
+    const qr = buildQueryRunner({
+      information_schema: [{ exists: false }],
+    });
+    const result = await tableExists(qr as any, 'nonexistent');
+    expect(result).toBe(false);
+  });
+});
+
+describe('columnExists', () => {
+  it('returns true when the column exists', async () => {
+    const qr = buildQueryRunner({
+      information_schema: [{ exists: true }],
+    });
+    const result = await columnExists(qr as any, 'users', 'email');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the column does not exist', async () => {
+    const qr = buildQueryRunner({
+      information_schema: [{ exists: false }],
+    });
+    const result = await columnExists(qr as any, 'users', 'nonexistent_col');
+    expect(result).toBe(false);
+  });
+});

--- a/src/database/migrations/migration-utils.ts
+++ b/src/database/migrations/migration-utils.ts
@@ -1,0 +1,445 @@
+/**
+ * migration-utils.ts
+ *
+ * Utilities for improving database migration rollback safety and detecting
+ * irreversible migration changes before they are applied.
+ *
+ * Usage:
+ *   - Wrap destructive `up()` bodies with `withRollbackSafety()` to get
+ *     automatic pre-flight checks and structured error reporting.
+ *   - Call `detectIrreversibleChanges()` on a SQL string to surface
+ *     operations that cannot be safely rolled back.
+ *   - Use `createSafeBackup()` / `restoreFromBackup()` helpers inside
+ *     `up()` / `down()` when you need a data-level safety net.
+ */
+
+import { QueryRunner } from 'typeorm';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Severity level of a detected irreversible change. */
+export enum IrreversibleSeverity {
+  /** Informational – rollback is possible but may lose data. */
+  WARNING = 'WARNING',
+  /** Rollback is technically possible but extremely risky. */
+  HIGH = 'HIGH',
+  /** Rollback is impossible without a prior backup. */
+  CRITICAL = 'CRITICAL',
+}
+
+/** A single detected irreversible change within a SQL statement. */
+export interface IrreversibleChange {
+  /** Short identifier for the rule that triggered this finding. */
+  rule: string;
+  /** Human-readable description of the risk. */
+  description: string;
+  /** Severity of the finding. */
+  severity: IrreversibleSeverity;
+  /** The SQL fragment that triggered the rule (if extractable). */
+  fragment?: string;
+}
+
+/** Result returned by `detectIrreversibleChanges()`. */
+export interface IrreversibilityReport {
+  /** Whether any irreversible changes were detected. */
+  hasIrreversibleChanges: boolean;
+  /** All findings, ordered by severity (CRITICAL first). */
+  changes: IrreversibleChange[];
+  /** Highest severity found, or null when the report is clean. */
+  maxSeverity: IrreversibleSeverity | null;
+}
+
+/** Options for `withRollbackSafety()`. */
+export interface RollbackSafetyOptions {
+  /**
+   * When true, throw a `MigrationRollbackError` if CRITICAL irreversible
+   * changes are detected before running `up()`.
+   * @default false
+   */
+  blockOnCritical?: boolean;
+  /**
+   * When true, throw on HIGH-severity findings as well.
+   * @default false
+   */
+  blockOnHigh?: boolean;
+  /**
+   * Custom logger. Defaults to `console`.
+   */
+  logger?: Pick<Console, 'warn' | 'error' | 'log'>;
+}
+
+/** Thrown when `withRollbackSafety()` blocks execution due to critical risks. */
+export class MigrationRollbackError extends Error {
+  constructor(
+    public readonly report: IrreversibilityReport,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `Migration blocked: ${report.changes.length} irreversible change(s) detected ` +
+          `(max severity: ${report.maxSeverity})`,
+    );
+    this.name = 'MigrationRollbackError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Irreversible-change detection rules
+// ---------------------------------------------------------------------------
+
+interface DetectionRule {
+  rule: string;
+  pattern: RegExp;
+  description: string;
+  severity: IrreversibleSeverity;
+}
+
+const DETECTION_RULES: DetectionRule[] = [
+  {
+    rule: 'DROP_TABLE',
+    pattern: /\bDROP\s+TABLE\b/i,
+    description:
+      'DROP TABLE permanently removes the table and all its data. ' +
+      'Ensure a backup exists before applying.',
+    severity: IrreversibleSeverity.CRITICAL,
+  },
+  {
+    rule: 'DROP_COLUMN',
+    pattern: /\bDROP\s+COLUMN\b/i,
+    description:
+      'DROP COLUMN removes the column and all stored values. ' +
+      'Data cannot be recovered without a prior backup.',
+    severity: IrreversibleSeverity.CRITICAL,
+  },
+  {
+    rule: 'DROP_DATABASE',
+    pattern: /\bDROP\s+DATABASE\b/i,
+    description:
+      'DROP DATABASE destroys the entire database. This is irreversible.',
+    severity: IrreversibleSeverity.CRITICAL,
+  },
+  {
+    rule: 'DROP_SCHEMA',
+    pattern: /\bDROP\s+SCHEMA\b/i,
+    description:
+      'DROP SCHEMA removes the schema and all contained objects. ' +
+      'Ensure a full backup exists.',
+    severity: IrreversibleSeverity.CRITICAL,
+  },
+  {
+    rule: 'TRUNCATE',
+    pattern: /\bTRUNCATE\b/i,
+    description:
+      'TRUNCATE removes all rows from a table without logging individual row deletions. ' +
+      'Data cannot be recovered without a prior backup.',
+    severity: IrreversibleSeverity.CRITICAL,
+  },
+  {
+    rule: 'DROP_TYPE',
+    pattern: /\bDROP\s+TYPE\b/i,
+    description:
+      'DROP TYPE removes a custom type. Columns using this type must be migrated first.',
+    severity: IrreversibleSeverity.HIGH,
+  },
+  {
+    rule: 'DROP_INDEX',
+    pattern: /\bDROP\s+INDEX\b/i,
+    description:
+      'DROP INDEX removes an index. While re-creatable, it may cause performance degradation ' +
+      'if the down() migration is not implemented.',
+    severity: IrreversibleSeverity.WARNING,
+  },
+  {
+    rule: 'DROP_CONSTRAINT',
+    pattern: /\bDROP\s+CONSTRAINT\b/i,
+    description:
+      'DROP CONSTRAINT removes a constraint. Existing data may violate the constraint ' +
+      'when it is re-added during rollback.',
+    severity: IrreversibleSeverity.HIGH,
+  },
+  {
+    rule: 'ALTER_COLUMN_TYPE',
+    pattern: /\bALTER\s+COLUMN\b.*\bTYPE\b/i,
+    description:
+      'Changing a column type may cause data loss if the new type is narrower than the old one.',
+    severity: IrreversibleSeverity.HIGH,
+  },
+  {
+    rule: 'SET_NOT_NULL',
+    pattern: /\bSET\s+NOT\s+NULL\b/i,
+    description:
+      'Adding NOT NULL to an existing column will fail if any rows contain NULL values. ' +
+      'Rollback restores the constraint but existing NULLs may have been coerced.',
+    severity: IrreversibleSeverity.WARNING,
+  },
+  {
+    rule: 'DELETE_DATA',
+    pattern: /\bDELETE\s+FROM\b/i,
+    description:
+      'DELETE FROM inside a migration permanently removes rows. ' +
+      'Ensure the down() migration can restore them or that a backup exists.',
+    severity: IrreversibleSeverity.HIGH,
+  },
+  {
+    rule: 'UPDATE_DATA',
+    pattern: /\bUPDATE\b.*\bSET\b/i,
+    description:
+      'UPDATE inside a migration modifies existing data. ' +
+      'The original values are lost unless the down() migration reverses the change.',
+    severity: IrreversibleSeverity.WARNING,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Core utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyse a SQL string (or array of SQL strings) for irreversible operations.
+ *
+ * @param sql - A single SQL statement or an array of statements.
+ * @returns An `IrreversibilityReport` describing all findings.
+ *
+ * @example
+ * const report = detectIrreversibleChanges('DROP TABLE users');
+ * if (report.hasIrreversibleChanges) {
+ *   console.warn(report.changes);
+ * }
+ */
+export function detectIrreversibleChanges(
+  sql: string | string[],
+): IrreversibilityReport {
+  const statements = Array.isArray(sql) ? sql : [sql];
+  const combined = statements.join('\n');
+
+  const changes: IrreversibleChange[] = [];
+
+  for (const rule of DETECTION_RULES) {
+    const match = rule.pattern.exec(combined);
+    if (match) {
+      changes.push({
+        rule: rule.rule,
+        description: rule.description,
+        severity: rule.severity,
+        fragment: match[0],
+      });
+    }
+  }
+
+  // Sort: CRITICAL → HIGH → WARNING
+  const severityOrder: Record<IrreversibleSeverity, number> = {
+    [IrreversibleSeverity.CRITICAL]: 0,
+    [IrreversibleSeverity.HIGH]: 1,
+    [IrreversibleSeverity.WARNING]: 2,
+  };
+  changes.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+  const maxSeverity =
+    changes.length > 0 ? (changes[0].severity as IrreversibleSeverity) : null;
+
+  return {
+    hasIrreversibleChanges: changes.length > 0,
+    changes,
+    maxSeverity,
+  };
+}
+
+/**
+ * Wrap a migration `up()` body with rollback-safety pre-flight checks.
+ *
+ * The wrapper:
+ *  1. Analyses the provided SQL for irreversible changes.
+ *  2. Logs findings at the appropriate level.
+ *  3. Optionally blocks execution when CRITICAL (or HIGH) changes are found.
+ *  4. Executes the migration body inside a savepoint so partial failures
+ *     can be rolled back without affecting the outer transaction.
+ *
+ * @param queryRunner - The TypeORM QueryRunner for the current migration.
+ * @param sql         - The SQL statement(s) that will be executed.
+ * @param body        - Async function containing the actual migration logic.
+ * @param options     - Behaviour overrides.
+ *
+ * @example
+ * public async up(queryRunner: QueryRunner): Promise<void> {
+ *   await withRollbackSafety(
+ *     queryRunner,
+ *     'DROP TABLE legacy_tokens',
+ *     async () => {
+ *       await queryRunner.query('DROP TABLE legacy_tokens');
+ *     },
+ *     { blockOnCritical: true },
+ *   );
+ * }
+ */
+export async function withRollbackSafety(
+  queryRunner: QueryRunner,
+  sql: string | string[],
+  body: () => Promise<void>,
+  options: RollbackSafetyOptions = {},
+): Promise<void> {
+  const {
+    blockOnCritical = false,
+    blockOnHigh = false,
+    logger = console,
+  } = options;
+
+  const report = detectIrreversibleChanges(sql);
+
+  if (report.hasIrreversibleChanges) {
+    for (const change of report.changes) {
+      const msg =
+        `[MigrationUtils] ${change.severity} – ${change.rule}: ${change.description}` +
+        (change.fragment ? ` (fragment: "${change.fragment}")` : '');
+
+      if (change.severity === IrreversibleSeverity.CRITICAL) {
+        logger.error(msg);
+      } else if (change.severity === IrreversibleSeverity.HIGH) {
+        logger.warn(msg);
+      } else {
+        logger.log(msg);
+      }
+    }
+
+    const shouldBlock =
+      (blockOnCritical &&
+        report.maxSeverity === IrreversibleSeverity.CRITICAL) ||
+      (blockOnHigh &&
+        (report.maxSeverity === IrreversibleSeverity.CRITICAL ||
+          report.maxSeverity === IrreversibleSeverity.HIGH));
+
+    if (shouldBlock) {
+      throw new MigrationRollbackError(report);
+    }
+  }
+
+  // Execute inside a savepoint so a partial failure can be rolled back
+  // without aborting the outer transaction managed by TypeORM.
+  const savepointName = `sp_migration_${Date.now()}`;
+  await queryRunner.query(`SAVEPOINT ${savepointName}`);
+
+  try {
+    await body();
+  } catch (err) {
+    await queryRunner.query(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+    throw err;
+  }
+
+  await queryRunner.query(`RELEASE SAVEPOINT ${savepointName}`);
+}
+
+/**
+ * Create a backup of a table's data into a temporary shadow table.
+ *
+ * The shadow table is named `<tableName>_backup_<timestamp>` and is
+ * created in the same schema. Call `restoreFromBackup()` in `down()` to
+ * restore the data.
+ *
+ * @param queryRunner - The TypeORM QueryRunner.
+ * @param tableName   - Name of the table to back up.
+ * @returns The name of the created backup table.
+ *
+ * @example
+ * const backupTable = await createSafeBackup(queryRunner, 'users');
+ * // … destructive operation …
+ * // In down():
+ * await restoreFromBackup(queryRunner, 'users', backupTable);
+ */
+export async function createSafeBackup(
+  queryRunner: QueryRunner,
+  tableName: string,
+): Promise<string> {
+  const backupTable = `${tableName}_backup_${Date.now()}`;
+  await queryRunner.query(
+    `CREATE TABLE "${backupTable}" AS SELECT * FROM "${tableName}"`,
+  );
+  return backupTable;
+}
+
+/**
+ * Restore a table's data from a backup created by `createSafeBackup()`.
+ *
+ * This truncates the target table and re-inserts all rows from the backup.
+ * The backup table is **not** dropped automatically so it can serve as an
+ * audit trail; drop it manually once the migration is confirmed stable.
+ *
+ * @param queryRunner   - The TypeORM QueryRunner.
+ * @param tableName     - Name of the table to restore into.
+ * @param backupTable   - Name of the backup table (returned by `createSafeBackup()`).
+ */
+export async function restoreFromBackup(
+  queryRunner: QueryRunner,
+  tableName: string,
+  backupTable: string,
+): Promise<void> {
+  await queryRunner.query(`TRUNCATE TABLE "${tableName}"`);
+  await queryRunner.query(
+    `INSERT INTO "${tableName}" SELECT * FROM "${backupTable}"`,
+  );
+}
+
+/**
+ * Drop a backup table created by `createSafeBackup()` once it is no
+ * longer needed.
+ *
+ * @param queryRunner - The TypeORM QueryRunner.
+ * @param backupTable - Name of the backup table to drop.
+ */
+export async function dropBackupTable(
+  queryRunner: QueryRunner,
+  backupTable: string,
+): Promise<void> {
+  await queryRunner.query(`DROP TABLE IF EXISTS "${backupTable}"`);
+}
+
+/**
+ * Verify that a table exists in the database.
+ *
+ * Useful in `down()` migrations to guard against double-rollback scenarios.
+ *
+ * @param queryRunner - The TypeORM QueryRunner.
+ * @param tableName   - Table name to check.
+ * @returns `true` if the table exists, `false` otherwise.
+ */
+export async function tableExists(
+  queryRunner: QueryRunner,
+  tableName: string,
+): Promise<boolean> {
+  const result: Array<{ exists: boolean }> = await queryRunner.query(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public'
+         AND table_name = $1
+     ) AS "exists"`,
+    [tableName],
+  );
+  return result[0]?.exists === true;
+}
+
+/**
+ * Verify that a column exists on a table.
+ *
+ * Useful in `down()` migrations to guard against double-rollback scenarios.
+ *
+ * @param queryRunner - The TypeORM QueryRunner.
+ * @param tableName   - Table name.
+ * @param columnName  - Column name to check.
+ * @returns `true` if the column exists, `false` otherwise.
+ */
+export async function columnExists(
+  queryRunner: QueryRunner,
+  tableName: string,
+  columnName: string,
+): Promise<boolean> {
+  const result: Array<{ exists: boolean }> = await queryRunner.query(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name   = $1
+         AND column_name  = $2
+     ) AS "exists"`,
+    [tableName, columnName],
+  );
+  return result[0]?.exists === true;
+}


### PR DESCRIPTION
…ible changes

Add src/database/migrations/migration-utils.ts with:

- detectIrreversibleChanges(sql) – analyses SQL for operations that cannot be safely rolled back (DROP TABLE/COLUMN/DATABASE/SCHEMA, TRUNCATE, DROP TYPE/CONSTRAINT/INDEX, ALTER COLUMN TYPE, SET NOT NULL, DELETE FROM, UPDATE … SET). Returns a structured IrreversibilityReport with findings sorted CRITICAL → HIGH → WARNING.

- withRollbackSafety(queryRunner, sql, body, options) – wraps a migration up() body with pre-flight irreversibility analysis, optional blocking on CRITICAL/HIGH findings (throws MigrationRollbackError), and savepoint-based partial-failure recovery so a failed migration does not leave the outer transaction in an aborted state.

- createSafeBackup / restoreFromBackup / dropBackupTable – data-level backup helpers for migrations that modify or remove rows, enabling down() to restore the original data.

- tableExists / columnExists – existence guards for use in down() migrations to prevent errors on double-rollback.

Add src/database/migrations/migration-utils.spec.ts with 31 regression tests covering all public functions and edge cases.

Update src/database/migrations/README.md with full usage documentation, a severity table, and code examples for every helper.

Why: Closes the backend gap identified in issue #391 – migrations that perform destructive operations (DROP TABLE, TRUNCATE, etc.) had no mechanism to warn operators, block unsafe runs, or recover from partial failures, increasing maintenance risk and runtime instability.

Assumptions: PostgreSQL is the target database; savepoint syntax and information_schema queries are PostgreSQL-compatible. The backup helpers create tables in the default (public) schema.