### PR TITLE
feat(cache): add reliable cache invalidation for user data updates

### DIFF
--- a/src/cache/cache-invalidation.service.spec.ts
+++ b/src/cache/cache-invalidation.service.spec.ts
@@ -1,0 +1,130 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  CacheInvalidationService,
+  UserCacheKeys,
+} from './cache-invalidation.service';
+import { CacheService, CachePrefix } from './cache.service';
+
+const mockCacheService = {
+  del: jest.fn(),
+};
+
+describe('CacheInvalidationService', () => {
+  let service: CacheInvalidationService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CacheInvalidationService,
+        { provide: CacheService, useValue: mockCacheService },
+      ],
+    }).compile();
+
+    service = module.get<CacheInvalidationService>(CacheInvalidationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('UserCacheKeys', () => {
+    it('profile key includes userId', () => {
+      expect(UserCacheKeys.profile('u1')).toContain('u1');
+    });
+
+    it('preferences key includes userId', () => {
+      expect(UserCacheKeys.preferences('u1')).toContain('u1');
+    });
+
+    it('sessions key includes userId', () => {
+      expect(UserCacheKeys.sessions('u1')).toContain('u1');
+    });
+
+    it('portfolio key uses PORTFOLIO prefix', () => {
+      expect(UserCacheKeys.portfolio('u1')).toContain(CachePrefix.PORTFOLIO);
+    });
+  });
+
+  describe('invalidateUser', () => {
+    it('deletes all four user cache keys', async () => {
+      mockCacheService.del.mockResolvedValue(undefined);
+
+      await service.invalidateUser('user-1');
+
+      expect(mockCacheService.del).toHaveBeenCalledTimes(4);
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.profile('user-1'),
+      );
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.preferences('user-1'),
+      );
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.sessions('user-1'),
+      );
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.portfolio('user-1'),
+      );
+    });
+
+    it('does not throw when cache.del rejects', async () => {
+      mockCacheService.del.mockRejectedValue(new Error('redis down'));
+      await expect(service.invalidateUser('user-1')).rejects.toThrow();
+    });
+  });
+
+  describe('invalidateUserProfile', () => {
+    it('deletes only the profile key', async () => {
+      mockCacheService.del.mockResolvedValue(undefined);
+
+      await service.invalidateUserProfile('user-2');
+
+      expect(mockCacheService.del).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.profile('user-2'),
+      );
+    });
+  });
+
+  describe('invalidateUserPreferences', () => {
+    it('deletes only the preferences key', async () => {
+      mockCacheService.del.mockResolvedValue(undefined);
+
+      await service.invalidateUserPreferences('user-3');
+
+      expect(mockCacheService.del).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.preferences('user-3'),
+      );
+    });
+  });
+
+  describe('invalidateUserSessions', () => {
+    it('deletes only the sessions key', async () => {
+      mockCacheService.del.mockResolvedValue(undefined);
+
+      await service.invalidateUserSessions('user-4');
+
+      expect(mockCacheService.del).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.del).toHaveBeenCalledWith(
+        UserCacheKeys.sessions('user-4'),
+      );
+    });
+  });
+
+  describe('invalidateUsers', () => {
+    it('invalidates all four keys for each user', async () => {
+      mockCacheService.del.mockResolvedValue(undefined);
+
+      await service.invalidateUsers(['u1', 'u2']);
+
+      // 4 keys × 2 users = 8 deletions
+      expect(mockCacheService.del).toHaveBeenCalledTimes(8);
+    });
+
+    it('handles an empty array without error', async () => {
+      await expect(service.invalidateUsers([])).resolves.toBeUndefined();
+      expect(mockCacheService.del).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cache/cache-invalidation.service.ts
+++ b/src/cache/cache-invalidation.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CacheService, CachePrefix } from './cache.service';
+
+/** All user-data cache keys are namespaced under this prefix. */
+const USER_PREFIX = 'stellarswipe:user:';
+
+/** Cache key builders – centralised so invalidation is always consistent. */
+export const UserCacheKeys = {
+  profile: (userId: string) => `${USER_PREFIX}${userId}:profile`,
+  preferences: (userId: string) => `${USER_PREFIX}${userId}:preferences`,
+  sessions: (userId: string) => `${USER_PREFIX}${userId}:sessions`,
+  portfolio: (userId: string) => `${CachePrefix.PORTFOLIO}${userId}`,
+};
+
+@Injectable()
+export class CacheInvalidationService {
+  private readonly logger = new Logger(CacheInvalidationService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  /**
+   * Invalidate all cache entries that belong to a single user.
+   * Call this whenever any user data changes (profile, preferences, sessions).
+   */
+  async invalidateUser(userId: string): Promise<void> {
+    const keys = [
+      UserCacheKeys.profile(userId),
+      UserCacheKeys.preferences(userId),
+      UserCacheKeys.sessions(userId),
+      UserCacheKeys.portfolio(userId),
+    ];
+
+    await Promise.all(keys.map((k) => this.cacheService.del(k)));
+    this.logger.log(`Cache invalidated for user ${userId}`);
+  }
+
+  /** Invalidate only the user's profile cache entry. */
+  async invalidateUserProfile(userId: string): Promise<void> {
+    await this.cacheService.del(UserCacheKeys.profile(userId));
+    this.logger.log(`Profile cache invalidated for user ${userId}`);
+  }
+
+  /** Invalidate only the user's preferences cache entry. */
+  async invalidateUserPreferences(userId: string): Promise<void> {
+    await this.cacheService.del(UserCacheKeys.preferences(userId));
+    this.logger.log(`Preferences cache invalidated for user ${userId}`);
+  }
+
+  /** Invalidate only the user's sessions cache entry. */
+  async invalidateUserSessions(userId: string): Promise<void> {
+    await this.cacheService.del(UserCacheKeys.sessions(userId));
+    this.logger.log(`Sessions cache invalidated for user ${userId}`);
+  }
+
+  /** Invalidate cache for multiple users at once (e.g. bulk admin operations). */
+  async invalidateUsers(userIds: string[]): Promise<void> {
+    await Promise.all(userIds.map((id) => this.invalidateUser(id)));
+  }
+}

--- a/src/cache/cache.module.ts
+++ b/src/cache/cache.module.ts
@@ -9,6 +9,7 @@ import { CacheInvalidatorService } from './invalidation/cache-invalidator.servic
 import { CacheMetricsService } from './monitoring/cache-metrics.service';
 import { CacheController } from './cache.controller';
 import { CacheService } from './cache.service';
+import { CacheInvalidationService } from './cache-invalidation.service';
 
 @Global()
 @Module({
@@ -40,6 +41,7 @@ import { CacheService } from './cache.service';
     PriceCacheStrategy,
     CacheInvalidatorService,
     CacheMetricsService,
+    CacheInvalidationService,
   ],
   controllers: [CacheController],
   exports: [
@@ -49,6 +51,7 @@ import { CacheService } from './cache.service';
     PriceCacheStrategy,
     CacheInvalidatorService,
     CacheMetricsService,
+    CacheInvalidationService,
   ],
 })
 export class CacheModule { }


### PR DESCRIPTION
- Add CacheInvalidationService in src/cache/cache-invalidation.service.ts with invalidateUser(), invalidateUserProfile(), invalidateUserPreferences(), invalidateUserSessions(), and invalidateUsers() methods
- Export UserCacheKeys helpers so key construction is centralised and consistent across the codebase (profile, preferences, sessions, portfolio)
- Register and export CacheInvalidationService in CacheModule so it can be injected by any module that modifies user data
- Add 12 regression tests covering all public methods and edge cases (bulk invalidation, empty array, key-prefix correctness)

Why: Closes the backend gap identified in issue #397 – user data changes (profile updates, preference changes, session mutations) had no dedicated invalidation path, risking stale cache entries being served after writes.

Assumptions: CacheService.del() is the correct primitive for single-key invalidation; pattern-based bulk eviction is deferred to the existing CacheInvalidatorService which owns that concern.