### PR TITLE
Feat/api versioning and deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,3 +348,6 @@ kill -9 <PID>
 ## License
 
 MIT
+
+
+# I just want to be sure this goes to github

--- a/README.md
+++ b/README.md
@@ -349,5 +349,3 @@ kill -9 <PID>
 
 MIT
 
-
-# I just want to be sure this goes to github

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,51 +1,93 @@
 # API Versioning Guide
 
 ## Overview
-StellarSwipe API supports multiple versions to ensure backward compatibility during updates.
+
+StellarSwipe API uses **URI-based versioning** as the primary strategy, with optional header-based fallback. NestJS `VersioningType.URI` is enabled globally in `main.ts`.
 
 ## Version Detection
 
-### URL-based (Recommended)
+### URI-based (Recommended)
 ```
 GET /api/v1/signals
 GET /api/v2/signals
 ```
 
-### Header-based
+### Header-based (fallback)
 ```
 GET /api/signals
-Headers: { "api-version": "2" }
+api-version: 2
 ```
+
+When both are present, the URI version takes precedence.
 
 ## Current Versions
 
-### v1 (Deprecated)
-- **Status**: Deprecated
-- **Sunset Date**: 2025-12-31
-- **Features**: Original API implementation
+| Version | Status     | Sunset Date | Notes                        |
+|---------|------------|-------------|------------------------------|
+| v1      | Deprecated | 2025-12-31  | Migrate to v2                |
+| v2      | Supported  | —           | Current stable version       |
 
-### v2 (Current)
-- **Status**: Active
-- **Features**: Enhanced response formats, improved error handling
+## Deprecation Notices
 
-## Deprecation Warnings
+### Version-level (automatic)
 
-Deprecated versions return these headers:
+`VersionResolverMiddleware` runs on every request. When a deprecated version is detected it automatically injects:
+
 ```
 Deprecation: true
 Sunset: 2025-12-31
 Link: </api/v2>; rel="successor-version"
 ```
 
+### Endpoint-level (opt-in)
+
+Use the `@Deprecated()` decorator on any controller or handler. The global `DeprecationInterceptor` reads this metadata and sets the same headers plus a human-readable notice:
+
+```typescript
+import { Deprecated } from '../versioning/decorators/deprecated.decorator';
+
+@Get('old-endpoint')
+@Deprecated({ sunsetDate: '2025-12-31', successorVersion: '2', reason: 'Use /new-endpoint instead.' })
+async oldEndpoint() { ... }
+```
+
+Response headers emitted:
+```
+Deprecation: true
+Sunset: 2025-12-31
+Link: </api/v2>; rel="successor-version"
+X-Deprecation-Notice: This endpoint is deprecated. Use /new-endpoint instead. Sunset date: 2025-12-31. Please migrate to v2.
+```
+
+## Architecture
+
+| Component                        | Location                                              | Role                                                    |
+|----------------------------------|-------------------------------------------------------|---------------------------------------------------------|
+| `VersioningType.URI`             | `src/main.ts`                                         | Enables NestJS URI versioning globally                  |
+| `VersionResolverMiddleware`      | `src/versioning/middleware/`                          | Resolves version, rejects unsupported, sets headers     |
+| `DeprecationInterceptor`         | `src/versioning/interceptors/`                        | Reads `@Deprecated()` metadata, sets response headers   |
+| `VersionManagerService`          | `src/versioning/version-manager.service.ts`           | Version registry and status queries                     |
+| `@Deprecated()` decorator        | `src/versioning/decorators/deprecated.decorator.ts`   | Marks individual endpoints as deprecated                |
+| `@ApiVersion()` decorator        | `src/versioning/decorators/api-version.decorator.ts`  | Tags controllers/handlers with a version string         |
+
+## Adding a New Version
+
+1. Add the version entry to `VersionManagerService.config.versions`:
+   ```typescript
+   '3': { status: VersionStatus.SUPPORTED, description: 'Next generation API.' }
+   ```
+2. Update the predecessor entry with `successorVersion: '3'`.
+3. Update this document.
+
 ## Migration Guide
 
-### v1 to v2
-- Update base URL from `/api/v1` to `/api/v2`
-- Review response schema changes in affected endpoints
-- Test thoroughly before sunset date
+### v1 → v2
+- Replace `/api/v1/` with `/api/v2/` in all request URLs.
+- Review response schema changes for affected endpoints.
+- Complete migration before **2025-12-31** (v1 sunset date).
 
 ## Best Practices
-- Always specify version explicitly
-- Monitor deprecation headers
-- Plan migrations before sunset dates
-- Use latest stable version for new integrations
+- Always specify the version explicitly in the URL.
+- Monitor `Deprecation` and `Sunset` response headers in your client.
+- Plan migrations well before sunset dates.
+- Use the latest stable version for all new integrations.

--- a/src/database/optimization/index-manager.service.ts
+++ b/src/database/optimization/index-manager.service.ts
@@ -85,6 +85,23 @@ export class IndexManagerService implements OnModuleInit {
       tableName: 'trades',
       columns: [{ name: 'user_id' }, { name: 'created_at', order: 'DESC' }],
     },
+    // Partial index for open-positions queries – only indexes rows where
+    // closed_at IS NULL, keeping the index small and highly selective.
+    {
+      name: 'idx_trades_open_positions',
+      tableName: 'trades',
+      columns: [{ name: 'user_id' }, { name: 'status' }],
+      isPartial: true,
+      partialCondition: 'closed_at IS NULL',
+      isConcurrently: true,
+    },
+    // Index for signal-based trade lookups
+    {
+      name: 'idx_trades_signal_id',
+      tableName: 'trades',
+      columns: [{ name: 'signal_id' }],
+      isConcurrently: true,
+    },
   ];
 
   constructor(private readonly dataSource: DataSource) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
-import { NestFactory } from "@nestjs/core";
+import { NestFactory, Reflector } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
+import { VersioningType } from '@nestjs/common';
 import { I18nValidationExceptionFilter, I18nValidationPipe } from 'nestjs-i18n';
 import * as compression from 'compression';
 import { AppModule } from "./app.module";
@@ -20,6 +21,7 @@ import { DeadlockRetryInterceptor } from './database/deadlock-retry.interceptor'
 import { initTracing } from './monitoring/tracing/jaeger.config';
 import { DocGeneratorService } from './documentation/doc-generator.service';
 import { generateOpenApiDocument } from './documentation/generators/openapi-generator';
+import { DeprecationInterceptor } from './versioning/interceptors/deprecation.interceptor';
 
 initTracing();
 
@@ -51,6 +53,13 @@ async function bootstrap() {
 
   // Set global prefix
   app.setGlobalPrefix(globalPrefix);
+
+  // Enable URI-based API versioning (e.g. /api/v1/..., /api/v2/...)
+  app.enableVersioning({ type: VersioningType.URI });
+
+  // Register deprecation interceptor globally so @Deprecated() headers are
+  // emitted on any handler decorated with it, without touching auth logic.
+  app.useGlobalInterceptors(new DeprecationInterceptor(app.get(Reflector)));
 
   // Enable CORS
   app.enableCors({

--- a/src/trades/entities/trade.entity.ts
+++ b/src/trades/entities/trade.entity.ts
@@ -25,6 +25,12 @@ export enum TradeSide {
   SELL = 'sell',
 }
 
+// Composite index for paginated trade history queries (most common access pattern)
+@Index('idx_trades_user_created_at', ['userId', 'createdAt'])
+// Composite index for open-positions queries (user_id + status + closed_at IS NULL)
+@Index('idx_trades_user_status_closed', ['userId', 'status', 'closedAt'])
+// Index for signal-based lookups
+@Index('idx_trades_signal_id', ['signalId'])
 @Entity('trades')
 export class Trade {
   @PrimaryGeneratedColumn('uuid')

--- a/src/trades/trade-history.service.spec.ts
+++ b/src/trades/trade-history.service.spec.ts
@@ -1,0 +1,310 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TradeHistoryService } from './trade-history.service';
+import { Trade, TradeStatus, TradeSide } from './entities/trade.entity';
+import { tradeFactory } from '../../test/utils/mock-factories';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Builds a minimal mock QueryBuilder that chains fluently and resolves data */
+function buildMockQb(resolveWith: Trade | Trade[] | [Trade[], number] | any) {
+  const qb: any = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(Array.isArray(resolveWith) && !Array.isArray(resolveWith[0]) ? resolveWith : (resolveWith as [Trade[], number])[0] ?? resolveWith),
+    getManyAndCount: jest.fn().mockResolvedValue(resolveWith),
+    getRawOne: jest.fn().mockResolvedValue(resolveWith),
+  };
+  return qb;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TradeHistoryService', () => {
+  let service: TradeHistoryService;
+  let mockRepository: any;
+
+  beforeEach(async () => {
+    mockRepository = {
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeHistoryService,
+        { provide: getRepositoryToken(Trade), useValue: mockRepository },
+      ],
+    }).compile();
+
+    service = module.get<TradeHistoryService>(TradeHistoryService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // getUserTradeHistory
+  // -------------------------------------------------------------------------
+
+  describe('getUserTradeHistory', () => {
+    it('returns paginated results with total count', async () => {
+      const trade = tradeFactory({ id: 'trade-1' });
+      const qb = buildMockQb([[trade], 1]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getUserTradeHistory({ userId: 'user-123' });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(qb.getManyAndCount).toHaveBeenCalled();
+    });
+
+    it('applies status filter when provided', async () => {
+      const qb = buildMockQb([[], 0]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradeHistory({ userId: 'user-123', status: 'completed' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'trade.status = :status',
+        { status: 'completed' },
+      );
+    });
+
+    it('does NOT apply status filter when status is "all"', async () => {
+      const qb = buildMockQb([[], 0]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradeHistory({ userId: 'user-123', status: 'all' });
+
+      const statusCalls = (qb.andWhere as jest.Mock).mock.calls.filter(
+        (c: any[]) => c[0].includes('status'),
+      );
+      expect(statusCalls).toHaveLength(0);
+    });
+
+    it('applies startDate filter when provided', async () => {
+      const qb = buildMockQb([[], 0]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradeHistory({
+        userId: 'user-123',
+        startDate: '2024-01-01',
+      });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'trade.created_at >= :startDate',
+        expect.objectContaining({ startDate: expect.any(Date) }),
+      );
+    });
+
+    it('applies endDate filter when provided', async () => {
+      const qb = buildMockQb([[], 0]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradeHistory({
+        userId: 'user-123',
+        endDate: '2024-12-31',
+      });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'trade.created_at <= :endDate',
+        expect.objectContaining({ endDate: expect.any(Date) }),
+      );
+    });
+
+    it('caps limit at 100', async () => {
+      const qb = buildMockQb([[], 0]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradeHistory({ userId: 'user-123', limit: 500 });
+
+      expect(qb.take).toHaveBeenCalledWith(100);
+    });
+
+    it('uses provided offset', async () => {
+      const qb = buildMockQb([[], 0]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradeHistory({ userId: 'user-123', offset: 40 });
+
+      expect(qb.skip).toHaveBeenCalledWith(40);
+    });
+
+    it('maps trade entity fields to TradeDetailsDto correctly', async () => {
+      const trade = tradeFactory({
+        id: 'trade-abc',
+        userId: 'user-123',
+        status: TradeStatus.COMPLETED,
+        side: TradeSide.BUY,
+        profitLoss: '15.00000000',
+      });
+      const qb = buildMockQb([[trade], 1]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getUserTradeHistory({ userId: 'user-123' });
+
+      expect(result.data[0].id).toBe('trade-abc');
+      expect(result.data[0].profitLoss).toBe('15.00000000');
+      expect(result.data[0].status).toBe(TradeStatus.COMPLETED);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getUserTradesSummary
+  // -------------------------------------------------------------------------
+
+  describe('getUserTradesSummary', () => {
+    it('returns correct summary from DB aggregates', async () => {
+      const rawRow = {
+        totalTrades: '10',
+        openTrades: '2',
+        completedTrades: '6',
+        failedTrades: '2',
+        totalProfitLoss: '50.5',
+        winningTrades: '4',
+        closedWithPnl: '6',
+        averageProfitLoss: '8.416666',
+      };
+      const qb = buildMockQb(rawRow);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getUserTradesSummary('user-123');
+
+      expect(result.totalTrades).toBe(10);
+      expect(result.openTrades).toBe(2);
+      expect(result.completedTrades).toBe(6);
+      expect(result.failedTrades).toBe(2);
+      expect(parseFloat(result.totalProfitLoss)).toBeCloseTo(50.5);
+      // winRate = 4/6 * 100 ≈ 66.67
+      expect(parseFloat(result.winRate)).toBeCloseTo(66.67, 1);
+      expect(result.averageProfitLoss).toBeDefined();
+    });
+
+    it('returns zero winRate when no closed trades with P&L', async () => {
+      const rawRow = {
+        totalTrades: '3',
+        openTrades: '3',
+        completedTrades: '0',
+        failedTrades: '0',
+        totalProfitLoss: '0',
+        winningTrades: '0',
+        closedWithPnl: '0',
+        averageProfitLoss: '0',
+      };
+      const qb = buildMockQb(rawRow);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getUserTradesSummary('user-123');
+
+      expect(parseFloat(result.winRate)).toBe(0);
+      expect(parseFloat(result.totalProfitLoss)).toBe(0);
+    });
+
+    it('issues a single DB query (no in-memory aggregation)', async () => {
+      const qb = buildMockQb({
+        totalTrades: '0', openTrades: '0', completedTrades: '0',
+        failedTrades: '0', totalProfitLoss: '0', winningTrades: '0',
+        closedWithPnl: '0', averageProfitLoss: '0',
+      });
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getUserTradesSummary('user-123');
+
+      // getRawOne = single aggregate query; getMany/find should NOT be called
+      expect(qb.getRawOne).toHaveBeenCalledTimes(1);
+      expect(qb.getMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getOpenPositions
+  // -------------------------------------------------------------------------
+
+  describe('getOpenPositions', () => {
+    it('returns open positions for a user', async () => {
+      const openTrade = tradeFactory({
+        status: TradeStatus.COMPLETED,
+        closedAt: undefined,
+      });
+      const qb = buildMockQb([openTrade]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getOpenPositions('user-123');
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('filters closed_at IS NULL at the DB level', async () => {
+      const qb = buildMockQb([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getOpenPositions('user-123');
+
+      expect(qb.andWhere).toHaveBeenCalledWith('trade.closed_at IS NULL');
+    });
+
+    it('filters by COMPLETED status at the DB level', async () => {
+      const qb = buildMockQb([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getOpenPositions('user-123');
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'trade.status = :status',
+        { status: TradeStatus.COMPLETED },
+      );
+    });
+
+    it('returns empty array when no open positions exist', async () => {
+      const qb = buildMockQb([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getOpenPositions('user-123');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getTradesBySignal
+  // -------------------------------------------------------------------------
+
+  describe('getTradesBySignal', () => {
+    it('returns trades for a given signal ordered by created_at DESC', async () => {
+      const t1 = tradeFactory({ id: 'trade-1', signalId: 'sig-1' });
+      const t2 = tradeFactory({ id: 'trade-2', signalId: 'sig-1' });
+      const qb = buildMockQb([t1, t2]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTradesBySignal('sig-1');
+
+      expect(result).toHaveLength(2);
+      expect(qb.where).toHaveBeenCalledWith(
+        'trade.signal_id = :signalId',
+        { signalId: 'sig-1' },
+      );
+      expect(qb.orderBy).toHaveBeenCalledWith('trade.created_at', 'DESC');
+    });
+
+    it('returns empty array when signal has no trades', async () => {
+      const qb = buildMockQb([]);
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTradesBySignal('sig-unknown');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/trades/trade-history.service.ts
+++ b/src/trades/trade-history.service.ts
@@ -1,0 +1,280 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Trade, TradeStatus } from './entities/trade.entity';
+import { TradeDetailsDto, UserTradesSummaryDto } from './dto/trade-result.dto';
+import { GetUserTradesDto } from './dto/execute-trade.dto';
+
+/**
+ * Extended DTO for trade history queries with date-range filtering.
+ * Extends the base GetUserTradesDto to add startDate / endDate support.
+ */
+export interface TradeHistoryQueryDto extends GetUserTradesDto {
+  /** ISO-8601 date string – only return trades created on or after this date */
+  startDate?: string;
+  /** ISO-8601 date string – only return trades created on or before this date */
+  endDate?: string;
+}
+
+/**
+ * Paginated response wrapper for trade history.
+ */
+export interface PaginatedTradeHistoryDto {
+  data: TradeDetailsDto[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * TradeHistoryService
+ *
+ * Provides optimised database queries for trade history endpoints.
+ * All aggregations are pushed to the database layer to avoid loading
+ * large result sets into application memory.
+ *
+ * Performance characteristics:
+ *  - getUserTradeHistory  → uses idx_trades_user_created_at, single query + COUNT
+ *  - getUserTradesSummary → single SQL aggregate query (no in-memory reduce)
+ *  - getOpenPositions     → uses idx_trades_user_status_closed, DB-side NULL filter
+ *  - getTradesBySignal    → uses idx_trades_signal_id
+ */
+@Injectable()
+export class TradeHistoryService {
+  private readonly logger = new Logger(TradeHistoryService.name);
+
+  constructor(
+    @InjectRepository(Trade)
+    private readonly tradeRepository: Repository<Trade>,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns a paginated, filtered list of trades for a user.
+   *
+   * Optimisations vs the original TradesService.getUserTrades():
+   *  - Explicit SELECT projection avoids fetching the heavy `metadata` JSONB column.
+   *  - Date-range predicates are pushed to the DB so the index on
+   *    (user_id, created_at) can be used for range scans.
+   *  - Total count is fetched in the same query via getManyAndCount() to avoid
+   *    a second round-trip.
+   */
+  async getUserTradeHistory(
+    dto: TradeHistoryQueryDto,
+  ): Promise<PaginatedTradeHistoryDto> {
+    const limit = Math.min(dto.limit ?? 20, 100);
+    const offset = dto.offset ?? 0;
+
+    const qb = this.buildHistoryQuery(dto);
+    qb.take(limit).skip(offset);
+
+    const [trades, total] = await qb.getManyAndCount();
+
+    return {
+      data: trades.map((t) => this.mapToTradeDetails(t)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  /**
+   * Returns aggregate statistics for a user's trade history.
+   *
+   * Optimisation: replaces the original implementation that loaded ALL trades
+   * into memory and computed aggregates in JavaScript. This version issues a
+   * single SQL query with SUM / COUNT / FILTER expressions.
+   */
+  async getUserTradesSummary(userId: string): Promise<UserTradesSummaryDto> {
+    const raw = await this.tradeRepository
+      .createQueryBuilder('trade')
+      .select('COUNT(*)', 'totalTrades')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE trade.status = :completedStatus AND trade.closed_at IS NULL)`,
+        'openTrades',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE trade.closed_at IS NOT NULL)`,
+        'completedTrades',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE trade.status = :failedStatus)`,
+        'failedTrades',
+      )
+      .addSelect(
+        `COALESCE(SUM(CAST(trade.profit_loss AS DECIMAL)) FILTER (WHERE trade.closed_at IS NOT NULL), 0)`,
+        'totalProfitLoss',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE trade.closed_at IS NOT NULL AND CAST(trade.profit_loss AS DECIMAL) > 0)`,
+        'winningTrades',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE trade.closed_at IS NOT NULL AND trade.profit_loss IS NOT NULL)`,
+        'closedWithPnl',
+      )
+      .addSelect(
+        `COALESCE(AVG(CAST(trade.profit_loss AS DECIMAL)) FILTER (WHERE trade.closed_at IS NOT NULL AND trade.profit_loss IS NOT NULL), 0)`,
+        'averageProfitLoss',
+      )
+      .where('trade.user_id = :userId', { userId })
+      .setParameter('completedStatus', TradeStatus.COMPLETED)
+      .setParameter('failedStatus', TradeStatus.FAILED)
+      .getRawOne();
+
+    const totalTrades = parseInt(raw.totalTrades, 10);
+    const openTrades = parseInt(raw.openTrades, 10);
+    const completedTrades = parseInt(raw.completedTrades, 10);
+    const failedTrades = parseInt(raw.failedTrades, 10);
+    const totalProfitLoss = parseFloat(raw.totalProfitLoss);
+    const winningTrades = parseInt(raw.winningTrades, 10);
+    const closedWithPnl = parseInt(raw.closedWithPnl, 10);
+    const averageProfitLoss = parseFloat(raw.averageProfitLoss);
+    const winRate = closedWithPnl > 0 ? (winningTrades / closedWithPnl) * 100 : 0;
+
+    return {
+      totalTrades,
+      openTrades,
+      completedTrades,
+      failedTrades,
+      totalProfitLoss: totalProfitLoss.toFixed(8),
+      winRate: winRate.toFixed(2),
+      averageProfitLoss: averageProfitLoss.toFixed(8),
+    };
+  }
+
+  /**
+   * Returns all open positions for a user.
+   *
+   * Optimisation: the original implementation fetched all COMPLETED trades and
+   * filtered `!closedAt` in JavaScript. This version pushes the IS NULL
+   * predicate to the DB, allowing the composite index
+   * idx_trades_user_status_closed to be used.
+   */
+  async getOpenPositions(userId: string): Promise<TradeDetailsDto[]> {
+    const trades = await this.tradeRepository
+      .createQueryBuilder('trade')
+      .select(this.historyColumns('trade'))
+      .where('trade.user_id = :userId', { userId })
+      .andWhere('trade.status = :status', { status: TradeStatus.COMPLETED })
+      .andWhere('trade.closed_at IS NULL')
+      .orderBy('trade.created_at', 'DESC')
+      .getMany();
+
+    return trades.map((t) => this.mapToTradeDetails(t));
+  }
+
+  /**
+   * Returns all trades for a given signal, ordered newest-first.
+   * Uses idx_trades_signal_id for efficient lookup.
+   */
+  async getTradesBySignal(signalId: string): Promise<TradeDetailsDto[]> {
+    const trades = await this.tradeRepository
+      .createQueryBuilder('trade')
+      .select(this.historyColumns('trade'))
+      .where('trade.signal_id = :signalId', { signalId })
+      .orderBy('trade.created_at', 'DESC')
+      .getMany();
+
+    return trades.map((t) => this.mapToTradeDetails(t));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds the base QueryBuilder for history list queries.
+   * Applies user, status, and date-range filters.
+   */
+  private buildHistoryQuery(
+    dto: TradeHistoryQueryDto,
+  ): SelectQueryBuilder<Trade> {
+    const qb = this.tradeRepository
+      .createQueryBuilder('trade')
+      .select(this.historyColumns('trade'))
+      .where('trade.user_id = :userId', { userId: dto.userId })
+      .orderBy('trade.created_at', 'DESC');
+
+    if (dto.status && dto.status !== 'all') {
+      qb.andWhere('trade.status = :status', { status: dto.status });
+    }
+
+    if (dto.startDate) {
+      qb.andWhere('trade.created_at >= :startDate', {
+        startDate: new Date(dto.startDate),
+      });
+    }
+
+    if (dto.endDate) {
+      qb.andWhere('trade.created_at <= :endDate', {
+        endDate: new Date(dto.endDate),
+      });
+    }
+
+    return qb;
+  }
+
+  /**
+   * Returns the explicit column list used in SELECT projections.
+   * Excludes the `metadata` JSONB column to reduce data transfer for list queries.
+   */
+  private historyColumns(alias: string): string[] {
+    return [
+      `${alias}.id`,
+      `${alias}.userId`,
+      `${alias}.signalId`,
+      `${alias}.status`,
+      `${alias}.side`,
+      `${alias}.baseAsset`,
+      `${alias}.counterAsset`,
+      `${alias}.entryPrice`,
+      `${alias}.exitPrice`,
+      `${alias}.amount`,
+      `${alias}.totalValue`,
+      `${alias}.feeAmount`,
+      `${alias}.profitLoss`,
+      `${alias}.profitLossPercentage`,
+      `${alias}.stopLossPrice`,
+      `${alias}.takeProfitPrice`,
+      `${alias}.transactionHash`,
+      `${alias}.sorobanContractId`,
+      `${alias}.errorMessage`,
+      `${alias}.executedAt`,
+      `${alias}.closedAt`,
+      `${alias}.createdAt`,
+      `${alias}.updatedAt`,
+    ];
+  }
+
+  private mapToTradeDetails(trade: Trade): TradeDetailsDto {
+    return {
+      id: trade.id,
+      userId: trade.userId,
+      signalId: trade.signalId,
+      status: trade.status,
+      side: trade.side,
+      baseAsset: trade.baseAsset,
+      counterAsset: trade.counterAsset,
+      entryPrice: trade.entryPrice,
+      exitPrice: trade.exitPrice,
+      amount: trade.amount,
+      totalValue: trade.totalValue,
+      feeAmount: trade.feeAmount,
+      profitLoss: trade.profitLoss,
+      profitLossPercentage: trade.profitLossPercentage,
+      stopLossPrice: trade.stopLossPrice,
+      takeProfitPrice: trade.takeProfitPrice,
+      transactionHash: trade.transactionHash,
+      sorobanContractId: trade.sorobanContractId,
+      errorMessage: trade.errorMessage,
+      executedAt: trade.executedAt,
+      closedAt: trade.closedAt,
+      createdAt: trade.createdAt,
+      updatedAt: trade.updatedAt,
+    };
+  }
+}

--- a/src/trades/trades.controller.ts
+++ b/src/trades/trades.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseUUIDPipe,
 } from '@nestjs/common';
 import { TradesService } from './trades.service';
+import { TradeHistoryService } from './trade-history.service';
 import { RiskManagerService } from './services/risk-manager.service';
 import { ExecuteTradeDto, CloseTradeDto } from './dto/execute-trade.dto';
 import { PartialCloseDto } from './partial-close/dto/partial-close.dto';
@@ -21,11 +22,13 @@ import {
   UserTradesSummaryDto,
   CloseTradeResultDto,
 } from './dto/trade-result.dto';
+import { PaginatedTradeHistoryDto } from './trade-history.service';
 
 @Controller('trades')
 export class TradesController {
   constructor(
     private readonly tradesService: TradesService,
+    private readonly tradeHistoryService: TradeHistoryService,
     private readonly riskManager: RiskManagerService,
     private readonly partialCloseService: PartialCloseService,
   ) { }
@@ -83,7 +86,31 @@ export class TradesController {
   }
 
   /**
-   * Get user's trades with filtering
+   * Get user's trade history with optional filtering and pagination.
+   * Supports status, date-range (startDate/endDate), limit, and offset.
+   * GET /trades/user/:userId/history
+   */
+  @Get('user/:userId/history')
+  async getUserTradeHistory(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('status') status?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('limit') limit?: number,
+    @Query('offset') offset?: number,
+  ): Promise<PaginatedTradeHistoryDto> {
+    return this.tradeHistoryService.getUserTradeHistory({
+      userId,
+      status,
+      startDate,
+      endDate,
+      limit,
+      offset,
+    });
+  }
+
+  /**
+   * Get user's trades with filtering (legacy – prefer /history for new clients)
    * GET /trades/user/:userId
    */
   @Get('user/:userId')
@@ -102,25 +129,25 @@ export class TradesController {
   }
 
   /**
-   * Get user's trading summary/statistics
+   * Get user's trading summary/statistics (DB-aggregated)
    * GET /trades/user/:userId/summary
    */
   @Get('user/:userId/summary')
   async getUserTradesSummary(
     @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<UserTradesSummaryDto> {
-    return this.tradesService.getUserTradesSummary(userId);
+    return this.tradeHistoryService.getUserTradesSummary(userId);
   }
 
   /**
-   * Get user's open positions
+   * Get user's open positions (DB-filtered)
    * GET /trades/user/:userId/positions
    */
   @Get('user/:userId/positions')
   async getOpenPositions(
     @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<TradeDetailsDto[]> {
-    return this.tradesService.getOpenPositions(userId);
+    return this.tradeHistoryService.getOpenPositions(userId);
   }
 
   /**
@@ -131,7 +158,7 @@ export class TradesController {
   async getTradesBySignal(
     @Param('signalId', ParseUUIDPipe) signalId: string,
   ): Promise<TradeDetailsDto[]> {
-    return this.tradesService.getTradesBySignal(signalId);
+    return this.tradeHistoryService.getTradesBySignal(signalId);
   }
 
   /**

--- a/src/trades/trades.module.ts
+++ b/src/trades/trades.module.ts
@@ -16,6 +16,7 @@ import { WebsocketModule } from '../websocket/websocket.module';
 import { TxMonitorService } from './services/tx-monitor.service';
 import { MonitorTransactionsJob } from './jobs/monitor-transactions.job';
 import { PartialCloseService } from './partial-close/partial-close.service';
+import { TradeHistoryService } from './trade-history.service';
 
 @Module({
   imports: [
@@ -37,8 +38,9 @@ import { PartialCloseService } from './partial-close/partial-close.service';
     OcoOrderService,
     IcebergOrderService,
     PartialCloseService,
+    TradeHistoryService,
   ],
-  exports: [TradesService, RiskManagerService, OcoOrderService, IcebergOrderService, PartialCloseService],
+  exports: [TradesService, RiskManagerService, OcoOrderService, IcebergOrderService, PartialCloseService, TradeHistoryService],
 })
 export class TradesModule { }
 

--- a/src/versioning/interceptors/deprecation.interceptor.spec.ts
+++ b/src/versioning/interceptors/deprecation.interceptor.spec.ts
@@ -1,0 +1,143 @@
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of } from 'rxjs';
+import { DeprecationInterceptor } from './deprecation.interceptor';
+import { DEPRECATED_KEY, DEPRECATION_METADATA_KEY } from '../decorators/deprecated.decorator';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildContext(isDeprecated: boolean, options?: any): ExecutionContext {
+  const headers: Record<string, string> = {};
+  const res = {
+    setHeader: jest.fn((k: string, v: string) => { headers[k] = v; }),
+    _headers: headers,
+  };
+
+  const reflector = new Reflector();
+  jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key: any) => {
+    if (key === DEPRECATED_KEY) return isDeprecated;
+    if (key === DEPRECATION_METADATA_KEY) return options;
+    return undefined;
+  });
+
+  const ctx = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: jest.fn().mockReturnValue({
+      getResponse: jest.fn().mockReturnValue(res),
+    }),
+  } as unknown as ExecutionContext;
+
+  return ctx;
+}
+
+function buildHandler(): CallHandler {
+  return { handle: jest.fn().mockReturnValue(of({})) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DeprecationInterceptor', () => {
+  let reflector: Reflector;
+  let interceptor: DeprecationInterceptor;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    interceptor = new DeprecationInterceptor(reflector);
+  });
+
+  it('sets Deprecation header when endpoint is deprecated', (done) => {
+    const ctx = buildContext(true, { sunsetDate: '2025-12-31', successorVersion: '2' });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      const res = ctx.switchToHttp().getResponse() as any;
+      expect(res.setHeader).toHaveBeenCalledWith('Deprecation', 'true');
+      done();
+    });
+  });
+
+  it('sets Sunset header when sunsetDate is provided', (done) => {
+    const ctx = buildContext(true, { sunsetDate: '2025-12-31' });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      const res = ctx.switchToHttp().getResponse() as any;
+      expect(res.setHeader).toHaveBeenCalledWith('Sunset', '2025-12-31');
+      done();
+    });
+  });
+
+  it('sets Link header when successorVersion is provided', (done) => {
+    const ctx = buildContext(true, { successorVersion: '2' });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      const res = ctx.switchToHttp().getResponse() as any;
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Link',
+        '</api/v2>; rel="successor-version"',
+      );
+      done();
+    });
+  });
+
+  it('sets X-Deprecation-Notice header with reason when provided', (done) => {
+    const ctx = buildContext(true, {
+      sunsetDate: '2025-12-31',
+      successorVersion: '2',
+      reason: 'Use the new endpoint.',
+    });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      const res = ctx.switchToHttp().getResponse() as any;
+      const noticeCalls = (res.setHeader as jest.Mock).mock.calls.find(
+        (c: any[]) => c[0] === 'X-Deprecation-Notice',
+      );
+      expect(noticeCalls).toBeDefined();
+      expect(noticeCalls[1]).toContain('Use the new endpoint.');
+      done();
+    });
+  });
+
+  it('does NOT set any deprecation headers when endpoint is not deprecated', (done) => {
+    const ctx = buildContext(false);
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      const res = ctx.switchToHttp().getResponse() as any;
+      expect(res.setHeader).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('still calls next.handle() and passes through the response', (done) => {
+    const ctx = buildContext(true, { sunsetDate: '2025-12-31' });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe((value) => {
+      expect(value).toEqual({});
+      expect(handler.handle).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('does not set Sunset header when sunsetDate is absent', (done) => {
+    const ctx = buildContext(true, { successorVersion: '2' });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      const res = ctx.switchToHttp().getResponse() as any;
+      const sunsetCall = (res.setHeader as jest.Mock).mock.calls.find(
+        (c: any[]) => c[0] === 'Sunset',
+      );
+      expect(sunsetCall).toBeUndefined();
+      done();
+    });
+  });
+});

--- a/src/versioning/interceptors/deprecation.interceptor.ts
+++ b/src/versioning/interceptors/deprecation.interceptor.ts
@@ -1,0 +1,72 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { Response } from 'express';
+import {
+  DEPRECATED_KEY,
+  DEPRECATION_METADATA_KEY,
+  DeprecationOptions,
+} from '../decorators/deprecated.decorator';
+
+/**
+ * DeprecationInterceptor
+ *
+ * Reads the @Deprecated() decorator metadata from the route handler or
+ * controller class and injects the standard deprecation response headers:
+ *
+ *   Deprecation: true
+ *   Sunset: <date>          (when sunsetDate is provided)
+ *   Link: </api/v2>; rel="successor-version"  (when successorVersion is provided)
+ *   X-Deprecation-Notice: <human-readable message>
+ *
+ * This works in tandem with VersionResolverMiddleware which handles
+ * version-level deprecation. This interceptor handles endpoint-level
+ * deprecation via the @Deprecated() decorator.
+ */
+@Injectable()
+export class DeprecationInterceptor implements NestInterceptor {
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const isDeprecated = this.reflector.getAllAndOverride<boolean>(
+      DEPRECATED_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (isDeprecated) {
+      const options = this.reflector.getAllAndOverride<DeprecationOptions>(
+        DEPRECATION_METADATA_KEY,
+        [context.getHandler(), context.getClass()],
+      );
+
+      const res: Response = context.switchToHttp().getResponse();
+      res.setHeader('Deprecation', 'true');
+
+      if (options?.sunsetDate) {
+        res.setHeader('Sunset', options.sunsetDate);
+      }
+
+      if (options?.successorVersion) {
+        res.setHeader(
+          'Link',
+          `</api/v${options.successorVersion}>; rel="successor-version"`,
+        );
+      }
+
+      const parts: string[] = ['This endpoint is deprecated.'];
+      if (options?.reason) parts.push(options.reason);
+      if (options?.sunsetDate) parts.push(`Sunset date: ${options.sunsetDate}.`);
+      if (options?.successorVersion)
+        parts.push(`Please migrate to v${options.successorVersion}.`);
+
+      res.setHeader('X-Deprecation-Notice', parts.join(' '));
+    }
+
+    return next.handle();
+  }
+}

--- a/src/versioning/middleware/version-resolver.middleware.spec.ts
+++ b/src/versioning/middleware/version-resolver.middleware.spec.ts
@@ -1,0 +1,126 @@
+import { NotFoundException } from '@nestjs/common';
+import { VersionResolverMiddleware } from './version-resolver.middleware';
+import { VersionManagerService } from '../version-manager.service';
+import { VersionStatus } from '../interfaces/version-config.interface';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildMockRes() {
+  const headers: Record<string, string> = {};
+  return {
+    setHeader: jest.fn((k: string, v: string) => { headers[k] = v; }),
+    _headers: headers,
+  };
+}
+
+function buildMockReq(path: string, headerVersion?: string) {
+  return {
+    path,
+    headers: headerVersion ? { 'api-version': headerVersion } : {},
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('VersionResolverMiddleware', () => {
+  let middleware: VersionResolverMiddleware;
+  let versionManager: VersionManagerService;
+
+  beforeEach(async () => {
+    versionManager = new VersionManagerService();
+    middleware = new VersionResolverMiddleware(versionManager);
+  });
+
+  it('resolves version from URL path', () => {
+    const req = buildMockReq('/api/v2/signals');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    middleware.use(req, res as any, next);
+
+    expect(req['apiVersion']).toBe('2');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('resolves version from api-version header when no URL version', () => {
+    const req = buildMockReq('/api/signals', '2');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    middleware.use(req, res as any, next);
+
+    expect(req['apiVersion']).toBe('2');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('falls back to default version when no version info present', () => {
+    const req = buildMockReq('/health');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    middleware.use(req, res as any, next);
+
+    expect(req['apiVersion']).toBe(versionManager.getDefaultVersion());
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException for unsupported version', () => {
+    const req = buildMockReq('/api/v99/signals');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    expect(() => middleware.use(req, res as any, next)).toThrow(NotFoundException);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('sets Deprecation headers for deprecated version (v1)', () => {
+    const req = buildMockReq('/api/v1/signals');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    middleware.use(req, res as any, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Deprecation', 'true');
+    expect(res.setHeader).toHaveBeenCalledWith('Sunset', '2025-12-31');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Link',
+      '</api/v2>; rel="successor-version"',
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does NOT set Deprecation headers for current version (v2)', () => {
+    const req = buildMockReq('/api/v2/signals');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    middleware.use(req, res as any, next);
+
+    expect(res.setHeader).not.toHaveBeenCalledWith('Deprecation', 'true');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('URL version takes precedence over header version', () => {
+    const req = buildMockReq('/api/v2/signals', '1');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    middleware.use(req, res as any, next);
+
+    expect(req['apiVersion']).toBe('2');
+  });
+
+  it('throws NotFoundException for sunset version', () => {
+    // Temporarily override isSupported to simulate a sunset version
+    jest.spyOn(versionManager, 'isSupported').mockReturnValue(false);
+    const req = buildMockReq('/api/v1/signals');
+    const res = buildMockRes();
+    const next = jest.fn();
+
+    expect(() => middleware.use(req, res as any, next)).toThrow(NotFoundException);
+  });
+});

--- a/src/versioning/versioning.module.ts
+++ b/src/versioning/versioning.module.ts
@@ -1,10 +1,12 @@
 import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { VersionManagerService } from './version-manager.service';
 import { VersionResolverMiddleware } from './middleware/version-resolver.middleware';
+import { DeprecationInterceptor } from './interceptors/deprecation.interceptor';
 
 @Module({
-  providers: [VersionManagerService],
-  exports: [VersionManagerService],
+  providers: [VersionManagerService, DeprecationInterceptor, Reflector],
+  exports: [VersionManagerService, DeprecationInterceptor],
 })
 export class VersioningModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {


### PR DESCRIPTION

This PR closes the backend gap around API versioning and deprecation notices. The versioning infrastructure (VersionManagerService, VersionResolverMiddleware, decorators, interfaces) already existed but was not fully wired — NestJS URI versioning was not enabled, and there was no mechanism to emit deprecation headers at the endpoint level.closes #376 