### PR TITLE
feat(database): add backend schema versioning for persisted data models (#405)

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -7,11 +7,13 @@ import { MaterializedViewService } from './optimization/materialized-view.servic
 import { SignalPerformance } from '../signals/entities/signal-performance.entity';
 import { ConnectionPoolMetricsService } from './connection-pool.metrics.service';
 import { MonitoringModule } from '../monitoring/monitoring.module';
+import { SchemaVersioningService } from './schema-versioning.service';
+import { SchemaVersion } from './schema-version.entity';
 
 @Global()
 @Module({
   imports: [
-    TypeOrmModule.forFeature([SignalPerformance]),
+    TypeOrmModule.forFeature([SignalPerformance, SchemaVersion]),
     EventEmitterModule.forRoot(),
     MonitoringModule,
   ],
@@ -20,12 +22,14 @@ import { MonitoringModule } from '../monitoring/monitoring.module';
     IndexManagerService,
     MaterializedViewService,
     ConnectionPoolMetricsService,
+    SchemaVersioningService,
   ],
   exports: [
     QueryAnalyzerService,
     IndexManagerService,
     MaterializedViewService,
     ConnectionPoolMetricsService,
+    SchemaVersioningService,
   ],
 })
 export class DatabaseOptimizationModule {}

--- a/src/database/migrations/1705000000280-CreateSchemaVersionsTable.ts
+++ b/src/database/migrations/1705000000280-CreateSchemaVersionsTable.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateSchemaVersionsTable1705000000280
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'schema_versions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'entity_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'version',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'is_compatible',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'migration_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'applied_at',
+            type: 'timestamp with time zone',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+        uniques: [
+          {
+            name: 'UQ_schema_versions_entity_version',
+            columnNames: ['entity_name', 'version'],
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'schema_versions',
+      new TableIndex({
+        name: 'IDX_schema_versions_entity_name',
+        columnNames: ['entity_name'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'schema_versions',
+      new TableIndex({
+        name: 'IDX_schema_versions_entity_version',
+        columnNames: ['entity_name', 'version'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('schema_versions', true);
+  }
+}

--- a/src/database/schema-version.entity.ts
+++ b/src/database/schema-version.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('schema_versions')
+@Index(['entityName', 'version'], { unique: true })
+export class SchemaVersion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'entity_name', length: 255 })
+  entityName: string;
+
+  @Column({ type: 'int' })
+  version: number;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ name: 'is_compatible', type: 'boolean', default: true })
+  isCompatible: boolean;
+
+  @Column({ name: 'migration_name', length: 255, nullable: true })
+  migrationName: string | null;
+
+  @CreateDateColumn({ name: 'applied_at', type: 'timestamp with time zone' })
+  appliedAt: Date;
+}

--- a/src/database/schema-versioning.service.spec.ts
+++ b/src/database/schema-versioning.service.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SchemaVersioningService } from './schema-versioning.service';
+import { SchemaVersion } from './schema-version.entity';
+
+const mockRepo = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+});
+
+describe('SchemaVersioningService', () => {
+  let service: SchemaVersioningService;
+  let repo: jest.Mocked<Repository<SchemaVersion>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchemaVersioningService,
+        { provide: getRepositoryToken(SchemaVersion), useFactory: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(SchemaVersioningService);
+    repo = module.get(getRepositoryToken(SchemaVersion));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('register', () => {
+    it('should create and save a new schema version entry', async () => {
+      const entry = {
+        id: 'uuid-1',
+        entityName: 'User',
+        version: 1,
+        description: 'initial',
+        isCompatible: true,
+        migrationName: null,
+        appliedAt: new Date(),
+      } as SchemaVersion;
+
+      repo.findOne.mockResolvedValue(null);
+      repo.create.mockReturnValue(entry);
+      repo.save.mockResolvedValue(entry);
+
+      const result = await service.register('User', 1, {
+        description: 'initial',
+      });
+
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { entityName: 'User', version: 1 },
+      });
+      expect(repo.create).toHaveBeenCalled();
+      expect(repo.save).toHaveBeenCalledWith(entry);
+      expect(result).toEqual(entry);
+    });
+
+    it('should return existing entry without saving if already registered', async () => {
+      const existing = {
+        id: 'uuid-1',
+        entityName: 'User',
+        version: 1,
+      } as SchemaVersion;
+
+      repo.findOne.mockResolvedValue(existing);
+
+      const result = await service.register('User', 1);
+
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
+      expect(result).toEqual(existing);
+    });
+  });
+
+  describe('getCurrentVersion', () => {
+    it('should return the highest version number for an entity', async () => {
+      repo.findOne.mockResolvedValue({ version: 3 } as SchemaVersion);
+      const version = await service.getCurrentVersion('Trade');
+      expect(version).toBe(3);
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { entityName: 'Trade' },
+        order: { version: 'DESC' },
+      });
+    });
+
+    it('should return null when no versions exist', async () => {
+      repo.findOne.mockResolvedValue(null);
+      const version = await service.getCurrentVersion('Unknown');
+      expect(version).toBeNull();
+    });
+  });
+
+  describe('getHistory', () => {
+    it('should return all versions for an entity in ascending order', async () => {
+      const versions = [
+        { version: 1 },
+        { version: 2 },
+        { version: 3 },
+      ] as SchemaVersion[];
+
+      repo.find.mockResolvedValue(versions);
+
+      const result = await service.getHistory('Signal');
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { entityName: 'Signal' },
+        order: { version: 'ASC' },
+      });
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('isCompatible', () => {
+    it('should return true when version is marked compatible', async () => {
+      repo.findOne.mockResolvedValue({
+        isCompatible: true,
+      } as SchemaVersion);
+      expect(await service.isCompatible('User', 2)).toBe(true);
+    });
+
+    it('should return false when version is marked incompatible', async () => {
+      repo.findOne.mockResolvedValue({
+        isCompatible: false,
+      } as SchemaVersion);
+      expect(await service.isCompatible('User', 2)).toBe(false);
+    });
+
+    it('should return false when version does not exist', async () => {
+      repo.findOne.mockResolvedValue(null);
+      expect(await service.isCompatible('User', 99)).toBe(false);
+    });
+  });
+
+  describe('checkCompatibility', () => {
+    it('should return compatible true when current version meets requirement', async () => {
+      repo.findOne
+        .mockResolvedValueOnce({ version: 3 } as SchemaVersion) // getCurrentVersion
+        .mockResolvedValueOnce({ isCompatible: true } as SchemaVersion); // isCompatible
+
+      const result = await service.checkCompatibility('Trade', 2);
+
+      expect(result).toEqual({ compatible: true, currentVersion: 3 });
+    });
+
+    it('should return compatible false when current version is below required', async () => {
+      repo.findOne
+        .mockResolvedValueOnce({ version: 1 } as SchemaVersion)
+        .mockResolvedValueOnce({ isCompatible: true } as SchemaVersion);
+
+      const result = await service.checkCompatibility('Trade', 3);
+
+      expect(result).toEqual({ compatible: false, currentVersion: 1 });
+    });
+
+    it('should return compatible false when no version is registered', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.checkCompatibility('Trade', 1);
+
+      expect(result).toEqual({ compatible: false, currentVersion: null });
+    });
+  });
+});

--- a/src/database/schema-versioning.service.ts
+++ b/src/database/schema-versioning.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SchemaVersion } from './schema-version.entity';
+
+@Injectable()
+export class SchemaVersioningService {
+  private readonly logger = new Logger(SchemaVersioningService.name);
+
+  constructor(
+    @InjectRepository(SchemaVersion)
+    private readonly schemaVersionRepo: Repository<SchemaVersion>,
+  ) {}
+
+  async register(
+    entityName: string,
+    version: number,
+    options: {
+      description?: string;
+      isCompatible?: boolean;
+      migrationName?: string;
+    } = {},
+  ): Promise<SchemaVersion> {
+    const existing = await this.schemaVersionRepo.findOne({
+      where: { entityName, version },
+    });
+
+    if (existing) {
+      this.logger.debug(
+        `Schema version ${version} for ${entityName} already registered`,
+      );
+      return existing;
+    }
+
+    const entry = this.schemaVersionRepo.create({
+      entityName,
+      version,
+      description: options.description ?? null,
+      isCompatible: options.isCompatible ?? true,
+      migrationName: options.migrationName ?? null,
+    });
+
+    const saved = await this.schemaVersionRepo.save(entry);
+    this.logger.log(
+      `Registered schema version ${version} for entity "${entityName}"`,
+    );
+    return saved;
+  }
+
+  async getCurrentVersion(entityName: string): Promise<number | null> {
+    const row = await this.schemaVersionRepo.findOne({
+      where: { entityName },
+      order: { version: 'DESC' },
+    });
+    return row?.version ?? null;
+  }
+
+  async getHistory(entityName: string): Promise<SchemaVersion[]> {
+    return this.schemaVersionRepo.find({
+      where: { entityName },
+      order: { version: 'ASC' },
+    });
+  }
+
+  async isCompatible(entityName: string, version: number): Promise<boolean> {
+    const row = await this.schemaVersionRepo.findOne({
+      where: { entityName, version },
+    });
+    return row?.isCompatible ?? false;
+  }
+
+  async checkCompatibility(
+    entityName: string,
+    requiredVersion: number,
+  ): Promise<{ compatible: boolean; currentVersion: number | null }> {
+    const currentVersion = await this.getCurrentVersion(entityName);
+
+    if (currentVersion === null) {
+      return { compatible: false, currentVersion: null };
+    }
+
+    const compatible =
+      currentVersion >= requiredVersion &&
+      (await this.isCompatible(entityName, currentVersion));
+
+    return { compatible, currentVersion };
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #405

Introduces schema versioning and compatibility checks for persisted data models in the `src/database/` module.

## Changes

### New Files
- `src/database/schema-version.entity.ts` — TypeORM entity tracking schema versions per entity name
- `src/database/schema-versioning.service.ts` — Service with `register`, `getCurrentVersion`, `getHistory`, `isCompatible`, and `checkCompatibility` methods
- `src/database/migrations/1705000000280-CreateSchemaVersionsTable.ts` — Migration creating the `schema_versions` table with unique constraint on `(entity_name, version)`
- `src/database/schema-versioning.service.spec.ts` — Regression tests covering all service methods

### Modified Files
- `src/database/database.module.ts` — Registers `SchemaVersion` entity and exports `SchemaVersioningService` from the global `DatabaseOptimizationModule`

## Done Criteria
- [x] Rollout/version controls implemented via `SchemaVersioningService`
- [x] Migration documented and reversible (`up`/`down`)
- [x] Regression tests added for all service methods
- [x] Security properties preserved — no changes to auth/authorization semantics
- [x] `SchemaVersioningService` exported globally for use across modules