### PR TITLE
feat: bulk validaton

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -61,6 +61,8 @@ import { TelegramBotModule } from './integrations/telegram/telegram-bot.module';
 import { MobileModule } from './mobile/mobile.module';
 
 import { AutomationModule } from './integrations/automation-platforms/automation.module';
+import { CurrencyModule } from './currency/currency.module';
+import { ImportModule } from './import/import.module';
  main
  main
  main
@@ -173,6 +175,8 @@ import { AutomationModule } from './integrations/automation-platforms/automation
     MobileModule,
 
     AutomationModule,
+    CurrencyModule,
+    ImportModule,
  main
  main
  main

--- a/src/auth/auth-audit.service.spec.ts
+++ b/src/auth/auth-audit.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthAuditService } from './auth-audit.service';
+import { AuditService } from '../audit-log/audit.service';
+import { AuditAction, AuditStatus } from '../audit-log/entities/audit-log.entity';
+import { Request } from 'express';
+
+const mockAuditService = {
+  log: jest.fn().mockResolvedValue({}),
+};
+
+const mockRequest = (overrides: Partial<Request> = {}): Request =>
+  ({
+    path: '/api/v1/auth/verify',
+    method: 'POST',
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'jest-test' },
+    socket: { remoteAddress: '127.0.0.1' },
+    ...overrides,
+  } as unknown as Request);
+
+describe('AuthAuditService', () => {
+  let service: AuthAuditService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthAuditService,
+        { provide: AuditService, useValue: mockAuditService },
+      ],
+    }).compile();
+
+    service = module.get(AuthAuditService);
+  });
+
+  it('logLogin writes a LOGIN SUCCESS audit entry', async () => {
+    await service.logLogin('user-123', mockRequest());
+    expect(mockAuditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AuditAction.LOGIN,
+        userId: 'user-123',
+        status: AuditStatus.SUCCESS,
+        resource: 'auth',
+      }),
+    );
+  });
+
+  it('logLoginFailed writes a LOGIN_FAILED FAILURE audit entry', async () => {
+    await service.logLoginFailed(mockRequest(), 'Invalid signature');
+    expect(mockAuditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AuditAction.LOGIN_FAILED,
+        status: AuditStatus.FAILURE,
+        errorMessage: 'Invalid signature',
+      }),
+    );
+  });
+
+  it('logLogout writes a LOGOUT SUCCESS audit entry', async () => {
+    await service.logLogout('user-456', mockRequest());
+    expect(mockAuditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AuditAction.LOGOUT,
+        userId: 'user-456',
+        status: AuditStatus.SUCCESS,
+      }),
+    );
+  });
+
+  it('does not throw when AuditService.log rejects', async () => {
+    mockAuditService.log.mockRejectedValueOnce(new Error('DB down'));
+    await expect(service.logLogin('user-789', mockRequest())).resolves.not.toThrow();
+  });
+
+  it('extracts IP from x-forwarded-for header', async () => {
+    const req = mockRequest({ headers: { 'x-forwarded-for': '10.0.0.1, 192.168.1.1' } } as any);
+    await service.logLogin('user-123', req);
+    expect(mockAuditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ ipAddress: '10.0.0.1' }),
+    );
+  });
+});

--- a/src/auth/auth-audit.service.ts
+++ b/src/auth/auth-audit.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable, tap, catchError, throwError } from 'rxjs';
+import { Request } from 'express';
+import { AuditService } from '../audit-log/audit.service';
+import { AuditAction, AuditStatus } from '../audit-log/entities/audit-log.entity';
+
+export interface AuthAuditEvent {
+  action: AuditAction;
+  userId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  endpoint: string;
+  method: string;
+  status: AuditStatus;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Logs authentication events at the endpoint level for security audits.
+ * Captures login, logout, failed attempts, and 2FA events with full
+ * request context (IP, user-agent, endpoint, outcome).
+ */
+@Injectable()
+export class AuthAuditService {
+  private readonly logger = new Logger(AuthAuditService.name);
+
+  constructor(private readonly auditService: AuditService) {}
+
+  async logAuthEvent(event: AuthAuditEvent): Promise<void> {
+    try {
+      await this.auditService.log({
+        userId: event.userId,
+        action: event.action,
+        resource: 'auth',
+        resourceId: event.endpoint,
+        ipAddress: event.ipAddress,
+        userAgent: event.userAgent,
+        status: event.status,
+        errorMessage: event.errorMessage,
+        metadata: {
+          endpoint: event.endpoint,
+          method: event.method,
+          ...event.metadata,
+        },
+      });
+    } catch (err) {
+      // Auth audit must never break the auth flow
+      this.logger.error('Failed to write auth audit event', (err as Error).message);
+    }
+  }
+
+  async logLogin(userId: string, req: Request): Promise<void> {
+    await this.logAuthEvent({
+      action: AuditAction.LOGIN,
+      userId,
+      ipAddress: this.extractIp(req),
+      userAgent: req.headers['user-agent'],
+      endpoint: req.path,
+      method: req.method,
+      status: AuditStatus.SUCCESS,
+    });
+  }
+
+  async logLoginFailed(req: Request, reason: string): Promise<void> {
+    await this.logAuthEvent({
+      action: AuditAction.LOGIN_FAILED,
+      ipAddress: this.extractIp(req),
+      userAgent: req.headers['user-agent'],
+      endpoint: req.path,
+      method: req.method,
+      status: AuditStatus.FAILURE,
+      errorMessage: reason,
+    });
+  }
+
+  async logLogout(userId: string, req: Request): Promise<void> {
+    await this.logAuthEvent({
+      action: AuditAction.LOGOUT,
+      userId,
+      ipAddress: this.extractIp(req),
+      userAgent: req.headers['user-agent'],
+      endpoint: req.path,
+      method: req.method,
+      status: AuditStatus.SUCCESS,
+    });
+  }
+
+  private extractIp(req: Request): string {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+      return (Array.isArray(forwarded) ? forwarded[0] : forwarded).split(',')[0].trim();
+    }
+    return req.socket?.remoteAddress ?? req.ip ?? 'unknown';
+  }
+}
+
+/**
+ * Interceptor that automatically emits auth audit events for any
+ * controller handler decorated with @AuthAudit().
+ */
+export const AUTH_AUDIT_KEY = 'authAuditAction';
+
+export function AuthAudit(action: AuditAction): MethodDecorator {
+  return (_target, _key, descriptor: PropertyDescriptor) => {
+    Reflect.defineMetadata(AUTH_AUDIT_KEY, action, descriptor.value);
+    return descriptor;
+  };
+}
+
+@Injectable()
+export class AuthAuditInterceptor implements NestInterceptor {
+  constructor(
+    private readonly authAuditService: AuthAuditService,
+    private readonly reflector: any,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const action: AuditAction | undefined = this.reflector.get(
+      AUTH_AUDIT_KEY,
+      context.getHandler(),
+    );
+    if (!action) return next.handle();
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const user = (req as any).user;
+
+    return next.handle().pipe(
+      tap(() => {
+        this.authAuditService.logAuthEvent({
+          action,
+          userId: user?.id ?? user?.sub,
+          ipAddress: (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.ip,
+          userAgent: req.headers['user-agent'],
+          endpoint: req.path,
+          method: req.method,
+          status: AuditStatus.SUCCESS,
+        });
+      }),
+      catchError((err) => {
+        this.authAuditService.logAuthEvent({
+          action,
+          userId: user?.id ?? user?.sub,
+          ipAddress: (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.ip,
+          userAgent: req.headers['user-agent'],
+          endpoint: req.path,
+          method: req.method,
+          status: AuditStatus.FAILURE,
+          errorMessage: err?.message,
+        });
+        return throwError(() => err);
+      }),
+    );
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -16,6 +16,8 @@ import { UsersModule } from '../users/users.module';
 import { TwoFactor } from './two-factor/entities/two-factor.entity';
 import { TwoFactorService } from './two-factor/two-factor.service';
 import { TwoFactorController } from './two-factor/two-factor.controller';
+import { AuthAuditService } from './auth-audit.service';
+import { AuditModule } from '../audit-log/audit.module';
 
 @Module({
   imports: [
@@ -31,6 +33,7 @@ import { TwoFactorController } from './two-factor/two-factor.controller';
       }),
     }),
     CacheModule,
+    AuditModule,
     TypeOrmModule.forFeature([User, SocialConnection, TwoFactor]),
     UsersModule,
   ],
@@ -41,7 +44,8 @@ import { TwoFactorController } from './two-factor/two-factor.controller';
     JwtAuthGuard,
     TwitterOauthService,
     TwoFactorService,
+    AuthAuditService,
   ],
-  exports: [AuthService, JwtAuthGuard, TwitterOauthService, TwoFactorService],
+  exports: [AuthService, JwtAuthGuard, TwitterOauthService, TwoFactorService, AuthAuditService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,12 +8,15 @@ import * as crypto from 'crypto';
 import { VerifySignatureDto } from './dto/verify-signature.dto';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
 import { UsersService } from '../users/users.service';
+import { AuthAuditService } from './auth-audit.service';
+import { Request } from 'express';
 
 @Injectable()
 export class AuthService {
     constructor(
         private jwtService: JwtService,
         private usersService: UsersService,
+        private authAuditService: AuthAuditService,
         @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) { }
 
@@ -27,17 +30,19 @@ export class AuthService {
         return { message };
     }
 
-    async verifySignature(dto: VerifySignatureDto): Promise<{ accessToken: string }> {
+    async verifySignature(dto: VerifySignatureDto, req?: Request): Promise<{ accessToken: string }> {
         const { publicKey, signature, message } = dto;
 
         // 1. Retrieve challenge from Redis
         const storedMessage = await this.cacheManager.get<string>(`auth_challenge:${publicKey}`);
 
         if (!storedMessage) {
+            if (req) await this.authAuditService.logLoginFailed(req, 'Challenge expired or not found');
             throw new UnauthorizedException('Challenge expired or not found. Please request a new challenge.');
         }
 
         if (storedMessage !== message) {
+            if (req) await this.authAuditService.logLoginFailed(req, 'Message mismatch');
             throw new UnauthorizedException('Message mismatch. Please sign the correct challenge.');
         }
 
@@ -47,9 +52,11 @@ export class AuthService {
             const isValid = keypair.verify(Buffer.from(message), Buffer.from(signature, 'base64'));
 
             if (!isValid) {
+                if (req) await this.authAuditService.logLoginFailed(req, 'Invalid signature');
                 throw new UnauthorizedException('Invalid signature');
             }
         } catch (error) {
+            if (req) await this.authAuditService.logLoginFailed(req, 'Signature verification failed');
             throw new UnauthorizedException('Signature verification failed');
         }
 
@@ -62,6 +69,8 @@ export class AuthService {
         // 5. Generate JWT using Internal User ID
         const payload: JwtPayload = { sub: user.id };
         const accessToken = this.jwtService.sign(payload);
+
+        if (req) await this.authAuditService.logLogin(user.id, req);
 
         return { accessToken };
     }

--- a/src/cache/cache.module.ts
+++ b/src/cache/cache.module.ts
@@ -10,6 +10,7 @@ import { CacheMetricsService } from './monitoring/cache-metrics.service';
 import { CacheController } from './cache.controller';
 import { CacheService } from './cache.service';
 import { CacheInvalidationService } from './cache-invalidation.service';
+import { ResponseCacheService, ResponseCacheInterceptor } from './response-cache.service';
 
 @Global()
 @Module({
@@ -42,6 +43,8 @@ import { CacheInvalidationService } from './cache-invalidation.service';
     CacheInvalidatorService,
     CacheMetricsService,
     CacheInvalidationService,
+    ResponseCacheService,
+    ResponseCacheInterceptor,
   ],
   controllers: [CacheController],
   exports: [
@@ -52,6 +55,8 @@ import { CacheInvalidationService } from './cache-invalidation.service';
     CacheInvalidatorService,
     CacheMetricsService,
     CacheInvalidationService,
+    ResponseCacheService,
+    ResponseCacheInterceptor,
   ],
 })
 export class CacheModule { }

--- a/src/cache/response-cache.service.spec.ts
+++ b/src/cache/response-cache.service.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResponseCacheService, ResponseCacheOptions } from './response-cache.service';
+import { CacheService } from './cache.service';
+import { Request } from 'express';
+
+const mockCacheService = {
+  get: jest.fn(),
+  setWithTTL: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockReq = (path: string, query: Record<string, string> = {}): Request =>
+  ({ path, query, method: 'GET' } as unknown as Request);
+
+describe('ResponseCacheService', () => {
+  let service: ResponseCacheService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResponseCacheService,
+        { provide: CacheService, useValue: mockCacheService },
+      ],
+    }).compile();
+
+    service = module.get(ResponseCacheService);
+  });
+
+  describe('buildKey', () => {
+    it('builds key from path', () => {
+      const key = service.buildKey(mockReq('/currencies'), {});
+      expect(key).toBe('stellarswipe:response:/currencies');
+    });
+
+    it('includes query params in key', () => {
+      const key = service.buildKey(mockReq('/currencies', { base: 'USD' }), {});
+      expect(key).toContain('USD');
+    });
+
+    it('includes userId when perUser=true', () => {
+      const key = service.buildKey(mockReq('/portfolio'), { perUser: true }, 'user-1');
+      expect(key).toContain('u:user-1');
+    });
+
+    it('omits userId when perUser=false', () => {
+      const key = service.buildKey(mockReq('/rates'), { perUser: false }, 'user-1');
+      expect(key).not.toContain('user-1');
+    });
+
+    it('uses keyPrefix when provided', () => {
+      const key = service.buildKey(mockReq('/ignored'), { keyPrefix: 'custom-prefix' });
+      expect(key).toContain('custom-prefix');
+    });
+  });
+
+  describe('get', () => {
+    it('returns cached value', async () => {
+      mockCacheService.get.mockResolvedValueOnce({ data: 'cached' });
+      const result = await service.get('some-key');
+      expect(result).toEqual({ data: 'cached' });
+    });
+
+    it('returns undefined on cache miss', async () => {
+      mockCacheService.get.mockResolvedValueOnce(undefined);
+      const result = await service.get('missing-key');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('set', () => {
+    it('calls setWithTTL with correct args', async () => {
+      await service.set('my-key', { foo: 'bar' }, 120);
+      expect(mockCacheService.setWithTTL).toHaveBeenCalledWith('my-key', { foo: 'bar' }, 120);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('deletes the namespaced key', async () => {
+      await service.invalidate('currencies');
+      expect(mockCacheService.del).toHaveBeenCalledWith('stellarswipe:response:currencies');
+    });
+  });
+});

--- a/src/cache/response-cache.service.ts
+++ b/src/cache/response-cache.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, Logger, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable, of, tap } from 'rxjs';
+import { Request, Response } from 'express';
+import { CacheService } from './cache.service';
+
+export interface ResponseCacheOptions {
+  /** Cache key prefix. Defaults to the request path. */
+  keyPrefix?: string;
+  /** TTL in seconds. Defaults to 300 (5 min). */
+  ttlSeconds?: number;
+  /** When true, the cache key includes the authenticated user's ID. */
+  perUser?: boolean;
+}
+
+const DEFAULT_TTL = 300;
+const CACHE_NS = 'stellarswipe:response:';
+
+/**
+ * Decorator to mark a controller handler for response-level caching.
+ *
+ * @example
+ * @CacheResponse({ ttlSeconds: 600 })
+ * @Get('supported-currencies')
+ * getSupportedCurrencies() { ... }
+ */
+export const RESPONSE_CACHE_KEY = 'responseCacheOptions';
+
+export function CacheResponse(options: ResponseCacheOptions = {}): MethodDecorator {
+  return (_target, _key, descriptor: PropertyDescriptor) => {
+    Reflect.defineMetadata(RESPONSE_CACHE_KEY, options, descriptor.value);
+    return descriptor;
+  };
+}
+
+@Injectable()
+export class ResponseCacheService {
+  private readonly logger = new Logger(ResponseCacheService.name);
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  buildKey(req: Request, options: ResponseCacheOptions, userId?: string): string {
+    const base = options.keyPrefix ?? req.path;
+    const query = Object.keys(req.query).length
+      ? `:${JSON.stringify(req.query)}`
+      : '';
+    const userSegment = options.perUser && userId ? `:u:${userId}` : '';
+    return `${CACHE_NS}${base}${query}${userSegment}`;
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.cacheService.get<T>(key);
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    await this.cacheService.setWithTTL(key, value, ttlSeconds);
+    this.logger.debug(`Response cached: ${key} (TTL ${ttlSeconds}s)`);
+  }
+
+  async invalidate(keyPrefix: string): Promise<void> {
+    await this.cacheService.del(`${CACHE_NS}${keyPrefix}`);
+    this.logger.log(`Response cache invalidated: ${keyPrefix}`);
+  }
+}
+
+/**
+ * Interceptor that caches HTTP responses for handlers decorated with @CacheResponse().
+ * Authenticated endpoints are supported via perUser option — the user ID is included
+ * in the cache key so users never see each other's data.
+ */
+@Injectable()
+export class ResponseCacheInterceptor implements NestInterceptor {
+  constructor(
+    private readonly responseCacheService: ResponseCacheService,
+    private readonly reflector: any,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const options: ResponseCacheOptions | undefined = this.reflector.get(
+      RESPONSE_CACHE_KEY,
+      context.getHandler(),
+    );
+
+    if (!options) return next.handle();
+
+    const req = context.switchToHttp().getRequest<Request>();
+    // Only cache GET requests
+    if (req.method !== 'GET') return next.handle();
+
+    const user = (req as any).user;
+    const userId = user?.id ?? user?.sub;
+    const key = this.responseCacheService.buildKey(req, options, userId);
+    const ttl = options.ttlSeconds ?? DEFAULT_TTL;
+
+    return new Observable((observer) => {
+      this.responseCacheService.get(key).then((cached) => {
+        if (cached !== undefined && cached !== null) {
+          observer.next(cached);
+          observer.complete();
+          return;
+        }
+
+        next.handle().pipe(
+          tap((response) => {
+            this.responseCacheService.set(key, response, ttl).catch(() => {});
+          }),
+        ).subscribe({
+          next: (v) => observer.next(v),
+          error: (e) => observer.error(e),
+          complete: () => observer.complete(),
+        });
+      });
+    });
+  }
+}

--- a/src/currency/currency-converter.service.spec.ts
+++ b/src/currency/currency-converter.service.spec.ts
@@ -1,0 +1,116 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CurrencyConverterService } from './currency-converter.service';
+import { ExchangeRate } from './entities/exchange-rate.entity';
+import { CurrencyPreference } from './entities/currency-preference.entity';
+import { BaseForexProvider } from './providers/base-forex.provider';
+import { CacheService } from '../cache/cache.service';
+
+const mockRateRepo = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockPrefRepo = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockCacheService = {
+  get: jest.fn(),
+  setWithTTL: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockForexProvider = {
+  getRate: jest.fn(),
+  getSupportedCurrencies: jest.fn().mockResolvedValue(['USD', 'EUR', 'XLM']),
+};
+
+describe('CurrencyConverterService', () => {
+  let service: CurrencyConverterService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CurrencyConverterService,
+        { provide: getRepositoryToken(ExchangeRate), useValue: mockRateRepo },
+        { provide: getRepositoryToken(CurrencyPreference), useValue: mockPrefRepo },
+        { provide: CacheService, useValue: mockCacheService },
+        { provide: BaseForexProvider, useValue: mockForexProvider },
+      ],
+    }).compile();
+
+    service = module.get(CurrencyConverterService);
+  });
+
+  describe('getRate', () => {
+    it('returns 1 for same currency', async () => {
+      expect(await service.getRate('USD', 'USD')).toBe(1);
+    });
+
+    it('returns cached rate when available', async () => {
+      mockCacheService.get.mockResolvedValueOnce(1.08);
+      expect(await service.getRate('USD', 'EUR')).toBe(1.08);
+      expect(mockRateRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns stored DB rate on cache miss', async () => {
+      mockCacheService.get.mockResolvedValueOnce(undefined);
+      mockRateRepo.findOne.mockResolvedValueOnce({ rate: 1.07, baseCurrency: 'USD', quoteCurrency: 'EUR' });
+      expect(await service.getRate('USD', 'EUR')).toBe(1.07);
+    });
+
+    it('fetches live rate when DB and cache miss', async () => {
+      mockCacheService.get.mockResolvedValueOnce(undefined);
+      mockRateRepo.findOne.mockResolvedValueOnce(null);
+      mockForexProvider.getRate.mockResolvedValueOnce({
+        base: 'USD', quote: 'EUR', rate: 1.05, provider: 'fixer.io', fetchedAt: new Date(),
+      });
+      mockRateRepo.create.mockReturnValueOnce({});
+      mockRateRepo.save.mockResolvedValueOnce({});
+      expect(await service.getRate('USD', 'EUR')).toBe(1.05);
+    });
+  });
+
+  describe('convert', () => {
+    it('converts amount using rate', async () => {
+      mockCacheService.get.mockResolvedValueOnce(1.1);
+      const result = await service.convert(100, 'USD', 'EUR');
+      expect(result.result).toBeCloseTo(110, 5);
+      expect(result.rate).toBe(1.1);
+    });
+  });
+
+  describe('getUserPreferredCurrency', () => {
+    it('returns stored preference', async () => {
+      mockPrefRepo.findOne.mockResolvedValueOnce({ preferredCurrency: 'GBP' });
+      expect(await service.getUserPreferredCurrency('user-1')).toBe('GBP');
+    });
+
+    it('defaults to USD when no preference set', async () => {
+      mockPrefRepo.findOne.mockResolvedValueOnce(null);
+      expect(await service.getUserPreferredCurrency('user-1')).toBe('USD');
+    });
+  });
+
+  describe('setUserPreferredCurrency', () => {
+    it('creates new preference when none exists', async () => {
+      mockPrefRepo.findOne.mockResolvedValueOnce(null);
+      mockPrefRepo.create.mockReturnValueOnce({ userId: 'user-1', preferredCurrency: 'EUR' });
+      mockPrefRepo.save.mockResolvedValueOnce({ userId: 'user-1', preferredCurrency: 'EUR' });
+      const result = await service.setUserPreferredCurrency('user-1', 'EUR');
+      expect(result.preferredCurrency).toBe('EUR');
+    });
+
+    it('updates existing preference', async () => {
+      const existing = { userId: 'user-1', preferredCurrency: 'USD' };
+      mockPrefRepo.findOne.mockResolvedValueOnce(existing);
+      mockPrefRepo.save.mockResolvedValueOnce({ ...existing, preferredCurrency: 'JPY' });
+      const result = await service.setUserPreferredCurrency('user-1', 'JPY');
+      expect(result.preferredCurrency).toBe('JPY');
+    });
+  });
+});

--- a/src/currency/currency-converter.service.ts
+++ b/src/currency/currency-converter.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ExchangeRate } from './entities/exchange-rate.entity';
+import { CurrencyPreference } from './entities/currency-preference.entity';
+import { BaseForexProvider } from './providers/base-forex.provider';
+import { CacheService } from '../cache/cache.service';
+import { convertAmount } from './utils/rate-calculator';
+
+const RATE_CACHE_TTL = 300; // 5 min
+const RATE_CACHE_NS = 'stellarswipe:fx:';
+
+@Injectable()
+export class CurrencyConverterService {
+  private readonly logger = new Logger(CurrencyConverterService.name);
+
+  constructor(
+    @InjectRepository(ExchangeRate)
+    private readonly rateRepo: Repository<ExchangeRate>,
+    @InjectRepository(CurrencyPreference)
+    private readonly prefRepo: Repository<CurrencyPreference>,
+    private readonly cacheService: CacheService,
+    private readonly forexProvider: BaseForexProvider,
+  ) {}
+
+  async getRate(base: string, quote: string): Promise<number> {
+    if (base === quote) return 1;
+
+    const cacheKey = `${RATE_CACHE_NS}${base}:${quote}`;
+    const cached = await this.cacheService.get<number>(cacheKey);
+    if (cached !== undefined && cached !== null) return cached;
+
+    // Try DB first (latest stored rate)
+    const stored = await this.rateRepo.findOne({
+      where: { baseCurrency: base, quoteCurrency: quote },
+      order: { fetchedAt: 'DESC' },
+    });
+
+    if (stored) {
+      await this.cacheService.setWithTTL(cacheKey, stored.rate, RATE_CACHE_TTL);
+      return stored.rate;
+    }
+
+    // Fetch live from provider
+    const live = await this.forexProvider.getRate(base, quote);
+    await this.persistRate(live.base, live.quote, live.rate, live.provider);
+    await this.cacheService.setWithTTL(cacheKey, live.rate, RATE_CACHE_TTL);
+    return live.rate;
+  }
+
+  async convert(amount: number, from: string, to: string): Promise<{ result: number; rate: number }> {
+    const rate = await this.getRate(from, to);
+    return { result: convertAmount(amount, rate), rate };
+  }
+
+  async getUserPreferredCurrency(userId: string): Promise<string> {
+    const pref = await this.prefRepo.findOne({ where: { userId } });
+    return pref?.preferredCurrency ?? 'USD';
+  }
+
+  async setUserPreferredCurrency(userId: string, currency: string): Promise<CurrencyPreference> {
+    let pref = await this.prefRepo.findOne({ where: { userId } });
+    if (pref) {
+      pref.preferredCurrency = currency;
+    } else {
+      pref = this.prefRepo.create({ userId, preferredCurrency: currency });
+    }
+    return this.prefRepo.save(pref);
+  }
+
+  async getSupportedCurrencies(): Promise<string[]> {
+    return this.forexProvider.getSupportedCurrencies();
+  }
+
+  async refreshRates(pairs: { base: string; quote: string }[]): Promise<void> {
+    for (const { base, quote } of pairs) {
+      try {
+        const live = await this.forexProvider.getRate(base, quote);
+        await this.persistRate(live.base, live.quote, live.rate, live.provider);
+        const cacheKey = `${RATE_CACHE_NS}${base}:${quote}`;
+        await this.cacheService.setWithTTL(cacheKey, live.rate, RATE_CACHE_TTL);
+      } catch (err) {
+        this.logger.error(`Failed to refresh rate ${base}/${quote}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  private async persistRate(
+    base: string,
+    quote: string,
+    rate: number,
+    provider: string,
+  ): Promise<void> {
+    const entry = this.rateRepo.create({ baseCurrency: base, quoteCurrency: quote, rate, provider });
+    await this.rateRepo.save(entry);
+  }
+}

--- a/src/currency/currency.controller.ts
+++ b/src/currency/currency.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrencyConverterService } from './currency-converter.service';
+import { ConvertCurrencyDto } from './dto/convert-currency.dto';
+import { CurrencyPreferenceDto } from './dto/currency-preference.dto';
+import { CacheResponse } from '../cache/response-cache.service';
+
+@Controller('currency')
+export class CurrencyController {
+  constructor(private readonly currencyService: CurrencyConverterService) {}
+
+  @Get('supported')
+  @CacheResponse({ ttlSeconds: 3600, keyPrefix: 'currency:supported' })
+  getSupportedCurrencies() {
+    return this.currencyService.getSupportedCurrencies();
+  }
+
+  @Get('rate')
+  @CacheResponse({ ttlSeconds: 300 })
+  getRate(@Query('base') base: string, @Query('quote') quote: string) {
+    return this.currencyService.getRate(base, quote);
+  }
+
+  @Post('convert')
+  @HttpCode(HttpStatus.OK)
+  convert(@Body() dto: ConvertCurrencyDto) {
+    return this.currencyService.convert(dto.amount, dto.from, dto.to);
+  }
+
+  @Get('preference')
+  @UseGuards(JwtAuthGuard)
+  getPreference(@Request() req: any) {
+    return this.currencyService.getUserPreferredCurrency(req.user.sub ?? req.user.id);
+  }
+
+  @Post('preference')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  setPreference(@Request() req: any, @Body() dto: CurrencyPreferenceDto) {
+    return this.currencyService.setUserPreferredCurrency(
+      req.user.sub ?? req.user.id,
+      dto.preferredCurrency,
+    );
+  }
+}

--- a/src/currency/currency.module.ts
+++ b/src/currency/currency.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { ScheduleModule } from '@nestjs/schedule';
+import { ExchangeRate } from './entities/exchange-rate.entity';
+import { CurrencyPreference } from './entities/currency-preference.entity';
+import { CurrencyConverterService } from './currency-converter.service';
+import { CurrencyController } from './currency.controller';
+import { FixerIoProvider } from './providers/fixer-io.provider';
+import { BaseForexProvider } from './providers/base-forex.provider';
+import { UpdateExchangeRatesJob } from './jobs/update-exchange-rates.job';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ExchangeRate, CurrencyPreference]),
+    HttpModule,
+    ScheduleModule.forRoot(),
+  ],
+  controllers: [CurrencyController],
+  providers: [
+    CurrencyConverterService,
+    UpdateExchangeRatesJob,
+    FixerIoProvider,
+    { provide: BaseForexProvider, useExisting: FixerIoProvider },
+  ],
+  exports: [CurrencyConverterService],
+})
+export class CurrencyModule {}

--- a/src/currency/dto/convert-currency.dto.ts
+++ b/src/currency/dto/convert-currency.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNumber, IsPositive, Length } from 'class-validator';
+
+export class ConvertCurrencyDto {
+  @IsNumber()
+  @IsPositive()
+  amount: number;
+
+  @IsString()
+  @Length(3, 10)
+  from: string;
+
+  @IsString()
+  @Length(3, 10)
+  to: string;
+}

--- a/src/currency/dto/currency-preference.dto.ts
+++ b/src/currency/dto/currency-preference.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, Length } from 'class-validator';
+
+export class CurrencyPreferenceDto {
+  @IsString()
+  @Length(3, 10)
+  preferredCurrency: string;
+}

--- a/src/currency/dto/exchange-rate.dto.ts
+++ b/src/currency/dto/exchange-rate.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, Length } from 'class-validator';
+
+export class ExchangeRateDto {
+  @IsString()
+  @Length(3, 10)
+  base: string;
+
+  @IsString()
+  @Length(3, 10)
+  quote: string;
+}

--- a/src/currency/entities/currency-preference.entity.ts
+++ b/src/currency/entities/currency-preference.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, UpdateDateColumn, Index } from 'typeorm';
+
+@Entity('currency_preferences')
+@Index(['userId'], { unique: true })
+export class CurrencyPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ length: 10, default: 'USD' })
+  preferredCurrency: string;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/currency/entities/exchange-rate.entity.ts
+++ b/src/currency/entities/exchange-rate.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from 'typeorm';
+
+@Entity('exchange_rates')
+@Index(['baseCurrency', 'quoteCurrency', 'provider'])
+export class ExchangeRate {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 10 })
+  baseCurrency: string;
+
+  @Column({ length: 10 })
+  quoteCurrency: string;
+
+  @Column({ type: 'decimal', precision: 24, scale: 10 })
+  rate: number;
+
+  @Column({ length: 50 })
+  provider: string;
+
+  @CreateDateColumn()
+  fetchedAt: Date;
+}

--- a/src/currency/jobs/update-exchange-rates.job.ts
+++ b/src/currency/jobs/update-exchange-rates.job.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CurrencyConverterService } from '../currency-converter.service';
+
+const DEFAULT_PAIRS = [
+  { base: 'USD', quote: 'EUR' },
+  { base: 'USD', quote: 'GBP' },
+  { base: 'USD', quote: 'JPY' },
+  { base: 'USD', quote: 'XLM' },
+  { base: 'EUR', quote: 'USD' },
+  { base: 'XLM', quote: 'USD' },
+  { base: 'BTC', quote: 'USD' },
+  { base: 'ETH', quote: 'USD' },
+];
+
+@Injectable()
+export class UpdateExchangeRatesJob {
+  private readonly logger = new Logger(UpdateExchangeRatesJob.name);
+
+  constructor(private readonly currencyService: CurrencyConverterService) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async run(): Promise<void> {
+    this.logger.log('Refreshing exchange rates...');
+    await this.currencyService.refreshRates(DEFAULT_PAIRS);
+    this.logger.log('Exchange rates refreshed');
+  }
+}

--- a/src/currency/providers/base-forex.provider.ts
+++ b/src/currency/providers/base-forex.provider.ts
@@ -1,0 +1,15 @@
+export interface ForexRate {
+  base: string;
+  quote: string;
+  rate: number;
+  provider: string;
+  fetchedAt: Date;
+}
+
+export abstract class BaseForexProvider {
+  abstract readonly providerName: string;
+
+  abstract getRate(base: string, quote: string): Promise<ForexRate>;
+
+  abstract getSupportedCurrencies(): Promise<string[]>;
+}

--- a/src/currency/providers/coinmarketcap.provider.ts
+++ b/src/currency/providers/coinmarketcap.provider.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { BaseForexProvider, ForexRate } from './base-forex.provider';
+
+@Injectable()
+export class CoinMarketCapProvider extends BaseForexProvider {
+  readonly providerName = 'coinmarketcap';
+  private readonly logger = new Logger(CoinMarketCapProvider.name);
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    super();
+  }
+
+  async getRate(base: string, quote: string): Promise<ForexRate> {
+    const apiKey = this.configService.get<string>('COINMARKETCAP_API_KEY');
+    const url = `https://pro-api.coinmarketcap.com/v1/tools/price-conversion?amount=1&symbol=${base}&convert=${quote}`;
+
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get(url, { headers: { 'X-CMC_PRO_API_KEY': apiKey } }),
+      );
+      const rate = data?.data?.quote?.[quote]?.price;
+      if (!rate) throw new Error(`Rate not found for ${base}/${quote}`);
+      return { base, quote, rate, provider: this.providerName, fetchedAt: new Date() };
+    } catch (err) {
+      this.logger.error(`CoinMarketCap getRate failed: ${(err as Error).message}`);
+      throw err;
+    }
+  }
+
+  async getSupportedCurrencies(): Promise<string[]> {
+    return ['USD', 'EUR', 'GBP', 'JPY', 'BTC', 'ETH', 'XLM'];
+  }
+}

--- a/src/currency/providers/fixer-io.provider.ts
+++ b/src/currency/providers/fixer-io.provider.ts
@@ -1,0 +1,41 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { BaseForexProvider, ForexRate } from './base-forex.provider';
+
+@Injectable()
+export class FixerIoProvider extends BaseForexProvider {
+  readonly providerName = 'fixer.io';
+  private readonly logger = new Logger(FixerIoProvider.name);
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    super();
+  }
+
+  async getRate(base: string, quote: string): Promise<ForexRate> {
+    const apiKey = this.configService.get<string>('FIXER_IO_API_KEY');
+    const url = `https://data.fixer.io/api/latest?access_key=${apiKey}&base=${base}&symbols=${quote}`;
+
+    try {
+      const { data } = await firstValueFrom(this.httpService.get(url));
+      const rate = data?.rates?.[quote];
+      if (!rate) throw new Error(`Rate not found for ${base}/${quote}`);
+      return { base, quote, rate, provider: this.providerName, fetchedAt: new Date() };
+    } catch (err) {
+      this.logger.error(`FixerIo getRate failed: ${(err as Error).message}`);
+      throw err;
+    }
+  }
+
+  async getSupportedCurrencies(): Promise<string[]> {
+    const apiKey = this.configService.get<string>('FIXER_IO_API_KEY');
+    const { data } = await firstValueFrom(
+      this.httpService.get(`https://data.fixer.io/api/symbols?access_key=${apiKey}`),
+    );
+    return Object.keys(data?.symbols ?? {});
+  }
+}

--- a/src/currency/utils/currency-formatter.ts
+++ b/src/currency/utils/currency-formatter.ts
@@ -1,0 +1,15 @@
+/**
+ * Format a numeric amount as a localised currency string.
+ */
+export function formatCurrency(
+  amount: number,
+  currency: string,
+  locale = 'en-US',
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 8,
+  }).format(amount);
+}

--- a/src/currency/utils/rate-calculator.ts
+++ b/src/currency/utils/rate-calculator.ts
@@ -1,0 +1,21 @@
+/**
+ * Convert an amount using a known exchange rate.
+ */
+export function convertAmount(amount: number, rate: number): number {
+  return parseFloat((amount * rate).toFixed(10));
+}
+
+/**
+ * Calculate P&L in a target currency.
+ */
+export function calculatePnl(
+  entryPrice: number,
+  currentPrice: number,
+  quantity: number,
+  rate: number,
+): { pnl: number; pnlPercent: number } {
+  const pnlBase = (currentPrice - entryPrice) * quantity;
+  const pnl = convertAmount(pnlBase, rate);
+  const pnlPercent = entryPrice !== 0 ? ((currentPrice - entryPrice) / entryPrice) * 100 : 0;
+  return { pnl, pnlPercent: parseFloat(pnlPercent.toFixed(4)) };
+}

--- a/src/database/migrations/1705000000264-CreateExchangeRatesTable.ts
+++ b/src/database/migrations/1705000000264-CreateExchangeRatesTable.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateExchangeRatesTable1705000000264 implements MigrationInterface {
+  name = 'CreateExchangeRatesTable1705000000264';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "exchange_rates" (
+        "id"            UUID              NOT NULL DEFAULT uuid_generate_v4(),
+        "baseCurrency"  VARCHAR(10)       NOT NULL,
+        "quoteCurrency" VARCHAR(10)       NOT NULL,
+        "rate"          DECIMAL(24,10)    NOT NULL,
+        "provider"      VARCHAR(50)       NOT NULL,
+        "fetchedAt"     TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_exchange_rates" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_exchange_rates_pair_provider"
+        ON "exchange_rates" ("baseCurrency", "quoteCurrency", "provider")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "currency_preferences" (
+        "id"                UUID        NOT NULL DEFAULT uuid_generate_v4(),
+        "userId"            UUID        NOT NULL,
+        "preferredCurrency" VARCHAR(10) NOT NULL DEFAULT 'USD',
+        "updatedAt"         TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_currency_preferences" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_currency_preferences_userId" UNIQUE ("userId")
+      )
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "currency_preferences"`);
+    await queryRunner.query(`DROP INDEX "IDX_exchange_rates_pair_provider"`);
+    await queryRunner.query(`DROP TABLE "exchange_rates"`);
+  }
+}

--- a/src/import/import-validation.service.spec.ts
+++ b/src/import/import-validation.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource, QueryRunner } from 'typeorm';
+import {
+  ImportValidationService,
+  ImportRecord,
+  RowValidator,
+} from './import-validation.service';
+
+const mockQueryRunner = {
+  connect: jest.fn(),
+  startTransaction: jest.fn(),
+  commitTransaction: jest.fn(),
+  rollbackTransaction: jest.fn(),
+  release: jest.fn(),
+} as unknown as QueryRunner;
+
+const mockDataSource = {
+  createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+} as unknown as DataSource;
+
+describe('ImportValidationService', () => {
+  let service: ImportValidationService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ImportValidationService,
+        { provide: DataSource, useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get(ImportValidationService);
+  });
+
+  describe('validate', () => {
+    it('returns valid=true when all rows pass', () => {
+      const rows = [{ name: 'Alice' }, { name: 'Bob' }];
+      const validator = ImportValidationService.requiredFields<ImportRecord>(['name']);
+      const result = service.validate(rows, [validator]);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('returns errors for missing required fields', () => {
+      const rows = [{ name: '' }, { name: 'Bob' }];
+      const validator = ImportValidationService.requiredFields<ImportRecord>(['name']);
+      const result = service.validate(rows, [validator]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toMatchObject({ row: 0, field: 'name' });
+    });
+
+    it('collects errors from multiple validators', () => {
+      const rows = [{ name: 'A'.repeat(300), code: '' }];
+      const validators: RowValidator<ImportRecord>[] = [
+        ImportValidationService.requiredFields(['code']),
+        ImportValidationService.maxLength('name', 255),
+      ];
+      const result = service.validate(rows, validators);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(2);
+    });
+  });
+
+  describe('importWithRollback', () => {
+    it('commits when all rows are valid and persist succeeds', async () => {
+      const rows = [{ name: 'Alice' }];
+      const persistFn = jest.fn().mockResolvedValue(undefined);
+      const result = await service.importWithRollback(
+        rows,
+        [ImportValidationService.requiredFields(['name'])],
+        persistFn,
+      );
+      expect(result.imported).toBe(1);
+      expect(result.rolledBack).toBe(false);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it('rolls back and returns rolledBack=true when persist throws', async () => {
+      const rows = [{ name: 'Alice' }];
+      const persistFn = jest.fn().mockRejectedValue(new Error('DB error'));
+      const result = await service.importWithRollback(
+        rows,
+        [ImportValidationService.requiredFields(['name'])],
+        persistFn,
+      );
+      expect(result.rolledBack).toBe(true);
+      expect(result.imported).toBe(0);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+    });
+
+    it('skips transaction when validation fails', async () => {
+      const rows = [{ name: '' }];
+      const persistFn = jest.fn();
+      const result = await service.importWithRollback(
+        rows,
+        [ImportValidationService.requiredFields(['name'])],
+        persistFn,
+      );
+      expect(result.rolledBack).toBe(false);
+      expect(persistFn).not.toHaveBeenCalled();
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/import/import-validation.service.ts
+++ b/src/import/import-validation.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { DataSource, QueryRunner } from 'typeorm';
+
+export interface ImportRecord {
+  [key: string]: unknown;
+}
+
+export interface ImportValidationResult {
+  valid: boolean;
+  errors: { row: number; field: string; message: string }[];
+}
+
+export interface BulkImportResult {
+  imported: number;
+  failed: number;
+  errors: { row: number; field: string; message: string }[];
+  rolledBack: boolean;
+}
+
+export type RowValidator<T extends ImportRecord> = (
+  row: T,
+  index: number,
+) => { field: string; message: string }[] | null;
+
+@Injectable()
+export class ImportValidationService {
+  private readonly logger = new Logger(ImportValidationService.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  /**
+   * Validate all rows before any DB writes.
+   * Returns a result with all validation errors across every row.
+   */
+  validate<T extends ImportRecord>(
+    rows: T[],
+    validators: RowValidator<T>[],
+  ): ImportValidationResult {
+    const errors: ImportValidationResult['errors'] = [];
+
+    for (let i = 0; i < rows.length; i++) {
+      for (const validator of validators) {
+        const rowErrors = validator(rows[i], i);
+        if (rowErrors?.length) {
+          errors.push(...rowErrors.map((e) => ({ row: i, ...e })));
+        }
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  /**
+   * Validate then persist rows inside a single transaction.
+   * On any error the entire batch is rolled back.
+   */
+  async importWithRollback<T extends ImportRecord>(
+    rows: T[],
+    validators: RowValidator<T>[],
+    persistFn: (row: T, queryRunner: QueryRunner) => Promise<void>,
+  ): Promise<BulkImportResult> {
+    const validation = this.validate(rows, validators);
+
+    if (!validation.valid) {
+      return {
+        imported: 0,
+        failed: rows.length,
+        errors: validation.errors,
+        rolledBack: false,
+      };
+    }
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    let imported = 0;
+    const errors: BulkImportResult['errors'] = [];
+
+    try {
+      for (let i = 0; i < rows.length; i++) {
+        try {
+          await persistFn(rows[i], queryRunner);
+          imported++;
+        } catch (err) {
+          errors.push({
+            row: i,
+            field: 'persist',
+            message: (err as Error).message,
+          });
+          throw err; // trigger rollback
+        }
+      }
+
+      await queryRunner.commitTransaction();
+      this.logger.log(`Bulk import committed: ${imported} rows`);
+
+      return { imported, failed: 0, errors: [], rolledBack: false };
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      this.logger.warn(`Bulk import rolled back after row error: ${(err as Error).message}`);
+
+      return {
+        imported: 0,
+        failed: rows.length,
+        errors,
+        rolledBack: true,
+      };
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  /**
+   * Built-in required-field validator factory.
+   */
+  static requiredFields<T extends ImportRecord>(
+    fields: (keyof T)[],
+  ): RowValidator<T> {
+    return (row, _index) => {
+      const errors: { field: string; message: string }[] = [];
+      for (const field of fields) {
+        if (row[field as string] === undefined || row[field as string] === null || row[field as string] === '') {
+          errors.push({ field: field as string, message: `${String(field)} is required` });
+        }
+      }
+      return errors.length ? errors : null;
+    };
+  }
+
+  /**
+   * Built-in max-length validator factory.
+   */
+  static maxLength<T extends ImportRecord>(
+    field: keyof T,
+    max: number,
+  ): RowValidator<T> {
+    return (row, _index) => {
+      const val = row[field as string];
+      if (typeof val === 'string' && val.length > max) {
+        return [{ field: field as string, message: `${String(field)} exceeds max length of ${max}` }];
+      }
+      return null;
+    };
+  }
+}

--- a/src/import/import.module.ts
+++ b/src/import/import.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ImportValidationService } from './import-validation.service';
+
+@Module({
+  providers: [ImportValidationService],
+  exports: [ImportValidationService],
+})
+export class ImportModule {}


### PR DESCRIPTION
Bulk Import Validation & Rollback
src/import/import-validation.service.ts — ImportValidationService with:

validate() — runs all row validators before any DB writes, collects all errors across all rows closes #399

importWithRollback() — wraps persist calls in a TypeORM QueryRunner transaction; rolls back the entire batch on any single failure

Static validator factories: requiredFields() and maxLength()

src/import/import.module.ts

src/import/import-validation.service.spec.ts — 5 tests covering valid commit, rollback on persist error, validation short-circuit

— Endpoint-Level Auth Audit Trails
src/auth/auth-audit.service.ts — AuthAuditService with logLogin(), logLoginFailed(), logLogout(), plus AuthAudit()  closes #406 decorator and AuthAuditInterceptor for declarative per-handler audit logging

AuthService updated — injects AuthAuditService, calls it on every login success/failure path  closes #396 

AuthModule updated — imports AuditModule, registers AuthAuditService

src/auth/auth-audit.service.spec.ts — 5 tests covering all event types, error resilience, and IP extraction
Response Caching for Static Reference Data
src/cache/response-cache.service.ts — ResponseCacheService with get/set/invalidate, buildKey() (supports query params + per-user isolation), @CacheResponse() decorator, and ResponseCacheInterceptor (GET-only, cache-aside)

CacheModule updated — exports both ResponseCacheService and ResponseCacheInterceptor

src/cache/response-cache.service.spec.ts — 7 tests covering key building, cache hit/miss, set, and invalidation

  Multi-Currency Support
Full src/currency/ resource: entities, DTOs, providers (BaseForexProvider, FixerIoProvider, CoinMarketCapProvider), CurrencyConverterService (cache-aside rate lookup → DB → live fetch), CurrencyController (convert, rate, preference, supported currencies), UpdateExchangeRatesJob (cron closes #356