### PR TITLE
feat: add WorkerTracingService for async worker tracing

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -406,3 +406,51 @@ Audit logs are retained for **2 years** (730 days). A scheduled job runs nightly
 1. Add the action to the `AuditAction` enum in `src/audit-log/entities/audit-log.entity.ts`.
 2. Apply `@Audit({ action: AuditAction.YOUR_ACTION, resource: 'resource-name' })` to the controller method.
 3. Ensure the controller's module imports `AuditModule` (or the module already exports `AuditLoggingInterceptor`).
+
+## Worker Tracing
+
+`WorkerTracingService` (`src/tracing/worker-tracing.service.ts`) extends the HTTP-layer tracing to asynchronous Bull worker jobs.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TRACING_ENABLED` | `false` | Set to `true` to activate tracing for both HTTP and worker paths |
+| `TRACING_SERVICE_NAME` | `stellarswipe-backend` | Service name embedded in outbound trace headers |
+
+### How it works
+
+When a Bull job is processed, the worker calls `WorkerTracingService.start(job)` which:
+
+1. Reads `job.data.traceId` (or the legacy `x-trace-id` key) to continue an existing trace started by an HTTP request.
+2. Generates a fresh UUID v4 when no trace ID is present, so every job execution is always identifiable.
+3. Logs `worker:start`, `worker:finish`, and `worker:error` events tagged with the trace ID, queue name, and job ID.
+
+### Propagating a trace ID from HTTP to a worker
+
+```typescript
+// In a controller or service that enqueues a job:
+const traceId = this.tracingService.fromRequest(req);
+const jobData = traceId
+  ? this.workerTracing.injectTraceId(payload, traceId)
+  : payload;
+await this.queue.add('my-job', jobData);
+```
+
+### Using in a Bull @Processor
+
+```typescript
+@Process('my-job')
+async handle(job: Job): Promise<void> {
+  const traceId = this.workerTracing.start(job);
+  try {
+    // ... do work ...
+    this.workerTracing.finish(traceId, job);
+  } catch (err) {
+    this.workerTracing.error(traceId, job, err as Error);
+    throw err;
+  }
+}
+```
+
+Inject `WorkerTracingService` by importing `TracingModule` into the feature module that owns the processor.

--- a/src/tracing/tracing.module.ts
+++ b/src/tracing/tracing.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TracingService, TracingMiddleware } from './tracing.service';
+import { WorkerTracingService } from './worker-tracing.service';
 
 @Module({
-  providers: [TracingService, TracingMiddleware],
-  exports: [TracingService, TracingMiddleware],
+  providers: [TracingService, TracingMiddleware, WorkerTracingService],
+  exports: [TracingService, TracingMiddleware, WorkerTracingService],
 })
 export class TracingModule {}

--- a/src/tracing/worker-tracing.service.ts
+++ b/src/tracing/worker-tracing.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Job } from 'bull';
+import { TracingService, TRACE_ID_HEADER } from './tracing.service';
+
+export const WORKER_TRACE_ID_KEY = 'traceId';
+
+/**
+ * WorkerTracingService — tracing support for asynchronous worker/job execution.
+ *
+ * Bridges the gap between HTTP-layer tracing (TracingMiddleware) and Bull
+ * worker processors.  A trace ID is:
+ *   - Propagated from the job's data payload when the enqueuing caller
+ *     embedded one (end-to-end correlation).
+ *   - Generated fresh (UUID v4) when no trace ID is present, so every job
+ *     execution is always identifiable in logs.
+ *
+ * Usage in a Bull @Processor:
+ *
+ *   @Process('my-job')
+ *   async handle(job: Job): Promise<void> {
+ *     const traceId = this.workerTracing.start(job);
+ *     try {
+ *       // ... do work ...
+ *       this.workerTracing.finish(traceId, job);
+ *     } catch (err) {
+ *       this.workerTracing.error(traceId, job, err as Error);
+ *       throw err;
+ *     }
+ *   }
+ *
+ * Security: no authentication tokens or secrets are logged.  The service
+ * only reads/writes the traceId field and delegates all structured logging
+ * to TracingService, preserving existing access-control semantics.
+ */
+@Injectable()
+export class WorkerTracingService {
+  private readonly logger = new Logger(WorkerTracingService.name);
+
+  constructor(private readonly tracingService: TracingService) {}
+
+  /**
+   * Begin tracing a worker job.
+   *
+   * Extracts an existing trace ID from `job.data[WORKER_TRACE_ID_KEY]` or
+   * from the legacy HTTP header key stored in job data, falling back to a
+   * freshly generated UUID.
+   *
+   * @returns The trace ID that should be threaded through the job execution.
+   */
+  start(job: Job): string {
+    if (!this.tracingService.isEnabled) {
+      return '';
+    }
+
+    const traceId =
+      (job.data as Record<string, unknown>)?.[WORKER_TRACE_ID_KEY] as string |
+      undefined ??
+      (job.data as Record<string, unknown>)?.[TRACE_ID_HEADER] as string |
+      undefined ??
+      randomUUID();
+
+    this.tracingService.log(
+      traceId,
+      `worker:start queue="${job.queue.name}" job=${job.id} name="${job.name}"`,
+    );
+
+    return traceId;
+  }
+
+  /**
+   * Record successful completion of a worker job.
+   */
+  finish(traceId: string, job: Job): void {
+    if (!this.tracingService.isEnabled || !traceId) return;
+
+    this.tracingService.log(
+      traceId,
+      `worker:finish queue="${job.queue.name}" job=${job.id} name="${job.name}"`,
+    );
+  }
+
+  /**
+   * Record a worker job failure.
+   */
+  error(traceId: string, job: Job, err: Error): void {
+    if (!this.tracingService.isEnabled || !traceId) return;
+
+    this.logger.error(
+      `[trace:${traceId}] worker:error queue="${job.queue.name}" job=${job.id} name="${job.name}": ${err.message}`,
+    );
+  }
+
+  /**
+   * Build job data that carries the current trace ID forward so downstream
+   * workers can continue the same trace.
+   *
+   * @param payload   The original job payload.
+   * @param traceId   The trace ID to embed (e.g. from an HTTP request).
+   */
+  injectTraceId(
+    payload: Record<string, unknown>,
+    traceId: string,
+  ): Record<string, unknown> {
+    return { ...payload, [WORKER_TRACE_ID_KEY]: traceId };
+  }
+}

--- a/test/worker-tracing.service.spec.ts
+++ b/test/worker-tracing.service.spec.ts
@@ -1,0 +1,198 @@
+// Mock the tracing.service module to avoid the pre-existing class-ordering TDZ
+// issue in tracing.service.ts (TracingMiddleware declared before TracingService).
+jest.mock('../src/tracing/tracing.service', () => {
+  const TRACE_ID_HEADER = 'x-trace-id';
+
+  class TracingService {
+    get isEnabled(): boolean { return false; }
+    get serviceName(): string { return 'stellarswipe-backend'; }
+    fromRequest(_req: any) { return undefined; }
+    outboundHeaders(traceId: string) { return { [TRACE_ID_HEADER]: traceId }; }
+    log(_traceId: string, _message: string) {}
+  }
+
+  class TracingMiddleware {
+    constructor(private readonly tracingService: TracingService) {}
+    use(_req: any, _res: any, next: () => void) { next(); }
+  }
+
+  return { TracingService, TracingMiddleware, TRACE_ID_HEADER };
+});
+
+import { TracingService, TRACE_ID_HEADER } from '../src/tracing/tracing.service';
+import { WorkerTracingService, WORKER_TRACE_ID_KEY } from '../src/tracing/worker-tracing.service';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const makeJob = (data: Record<string, unknown> = {}, name = 'test-job') =>
+  ({
+    id: 'job-1',
+    name,
+    data,
+    queue: { name: 'test-queue' },
+  }) as any;
+
+const makeTracingService = (enabled: boolean): TracingService => {
+  const svc = new (TracingService as any)();
+  jest.spyOn(svc, 'isEnabled', 'get').mockReturnValue(enabled);
+  jest.spyOn(svc, 'log').mockImplementation(() => undefined);
+  return svc;
+};
+
+// ── WorkerTracingService ──────────────────────────────────────────────────────
+
+describe('WorkerTracingService', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('start()', () => {
+    it('returns empty string when tracing is disabled', () => {
+      const svc = new WorkerTracingService(makeTracingService(false));
+      expect(svc.start(makeJob())).toBe('');
+    });
+
+    it('propagates traceId from job.data[WORKER_TRACE_ID_KEY]', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const job = makeJob({ [WORKER_TRACE_ID_KEY]: 'existing-trace' });
+
+      const traceId = svc.start(job);
+
+      expect(traceId).toBe('existing-trace');
+      expect(ts.log).toHaveBeenCalledWith(
+        'existing-trace',
+        expect.stringContaining('worker:start'),
+      );
+    });
+
+    it('propagates traceId from legacy x-trace-id key in job data', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const job = makeJob({ [TRACE_ID_HEADER]: 'http-trace' });
+
+      expect(svc.start(job)).toBe('http-trace');
+    });
+
+    it('generates a UUID v4 when no trace ID is present in job data', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+
+      const traceId = svc.start(makeJob());
+
+      expect(traceId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it('assigns unique trace IDs to concurrent jobs without a pre-set ID', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+
+      const id1 = svc.start(makeJob());
+      const id2 = svc.start(makeJob());
+
+      expect(id1).not.toBe(id2);
+    });
+
+    it('logs the queue name and job id on start', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const job = makeJob({ [WORKER_TRACE_ID_KEY]: 'trace-abc' });
+
+      svc.start(job);
+
+      expect(ts.log).toHaveBeenCalledWith(
+        'trace-abc',
+        expect.stringContaining('test-queue'),
+      );
+      expect(ts.log).toHaveBeenCalledWith(
+        'trace-abc',
+        expect.stringContaining('job-1'),
+      );
+    });
+  });
+
+  describe('finish()', () => {
+    it('is a no-op when tracing is disabled', () => {
+      const ts = makeTracingService(false);
+      const svc = new WorkerTracingService(ts);
+      svc.finish('trace-id', makeJob());
+      expect(ts.log).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when traceId is empty', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      svc.finish('', makeJob());
+      expect(ts.log).not.toHaveBeenCalled();
+    });
+
+    it('logs finish with trace ID and job details', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+
+      svc.finish('trace-xyz', makeJob());
+
+      expect(ts.log).toHaveBeenCalledWith(
+        'trace-xyz',
+        expect.stringContaining('worker:finish'),
+      );
+    });
+  });
+
+  describe('error()', () => {
+    it('is a no-op when tracing is disabled', () => {
+      const ts = makeTracingService(false);
+      const svc = new WorkerTracingService(ts);
+      const logSpy = jest.spyOn((svc as any).logger, 'error').mockImplementation(() => undefined);
+      svc.error('trace-id', makeJob(), new Error('boom'));
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when traceId is empty', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const logSpy = jest.spyOn((svc as any).logger, 'error').mockImplementation(() => undefined);
+      svc.error('', makeJob(), new Error('boom'));
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs the error message with trace ID', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const logSpy = jest.spyOn((svc as any).logger, 'error').mockImplementation(() => undefined);
+
+      svc.error('trace-err', makeJob(), new Error('something went wrong'));
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('trace-err'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('something went wrong'),
+      );
+    });
+  });
+
+  describe('injectTraceId()', () => {
+    it('merges traceId into the payload without mutating the original', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const original = { userId: 'u1' };
+
+      const result = svc.injectTraceId(original, 'trace-inject');
+
+      expect(result[WORKER_TRACE_ID_KEY]).toBe('trace-inject');
+      expect(result['userId']).toBe('u1');
+      expect(original).not.toHaveProperty(WORKER_TRACE_ID_KEY);
+    });
+
+    it('overwrites an existing traceId in the payload', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const payload = { [WORKER_TRACE_ID_KEY]: 'old-trace' };
+
+      const result = svc.injectTraceId(payload, 'new-trace');
+
+      expect(result[WORKER_TRACE_ID_KEY]).toBe('new-trace');
+    });
+  });
+});


### PR DESCRIPTION
closes #407
- Add src/tracing/worker-tracing.service.ts with start/finish/error/injectTraceId
- Propagates existing trace IDs from job data (traceId or x-trace-id keys)
- Falls back to a fresh UUID v4 when no trace ID is present
- Export WorkerTracingService from TracingModule
- Add 14 regression tests in test/worker-tracing.service.spec.ts
- Document configuration and usage in docs/CONFIGURATION.md

Closes: worker tracing gap for async Bull job execution paths