### PR TITLE
Feat/nested payload validator

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -406,3 +406,51 @@ Audit logs are retained for **2 years** (730 days). A scheduled job runs nightly
 1. Add the action to the `AuditAction` enum in `src/audit-log/entities/audit-log.entity.ts`.
 2. Apply `@Audit({ action: AuditAction.YOUR_ACTION, resource: 'resource-name' })` to the controller method.
 3. Ensure the controller's module imports `AuditModule` (or the module already exports `AuditLoggingInterceptor`).
+
+## Worker Tracing
+
+`WorkerTracingService` (`src/tracing/worker-tracing.service.ts`) extends the HTTP-layer tracing to asynchronous Bull worker jobs.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TRACING_ENABLED` | `false` | Set to `true` to activate tracing for both HTTP and worker paths |
+| `TRACING_SERVICE_NAME` | `stellarswipe-backend` | Service name embedded in outbound trace headers |
+
+### How it works
+
+When a Bull job is processed, the worker calls `WorkerTracingService.start(job)` which:
+
+1. Reads `job.data.traceId` (or the legacy `x-trace-id` key) to continue an existing trace started by an HTTP request.
+2. Generates a fresh UUID v4 when no trace ID is present, so every job execution is always identifiable.
+3. Logs `worker:start`, `worker:finish`, and `worker:error` events tagged with the trace ID, queue name, and job ID.
+
+### Propagating a trace ID from HTTP to a worker
+
+```typescript
+// In a controller or service that enqueues a job:
+const traceId = this.tracingService.fromRequest(req);
+const jobData = traceId
+  ? this.workerTracing.injectTraceId(payload, traceId)
+  : payload;
+await this.queue.add('my-job', jobData);
+```
+
+### Using in a Bull @Processor
+
+```typescript
+@Process('my-job')
+async handle(job: Job): Promise<void> {
+  const traceId = this.workerTracing.start(job);
+  try {
+    // ... do work ...
+    this.workerTracing.finish(traceId, job);
+  } catch (err) {
+    this.workerTracing.error(traceId, job, err as Error);
+    throw err;
+  }
+}
+```
+
+Inject `WorkerTracingService` by importing `TracingModule` into the feature module that owns the processor.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -454,3 +454,62 @@ async handle(job: Job): Promise<void> {
 ```
 
 Inject `WorkerTracingService` by importing `TracingModule` into the feature module that owns the processor.
+
+## Nested Payload Validation
+
+`NestedPayloadValidator` (`src/common/validators/nested-payload.validator.ts`) closes the gap where the global `CustomValidationPipe` only validates top-level DTO fields — nested objects decorated with `@ValidateNested()` are now fully traversed.
+
+### Validation options applied
+
+| Option | Value | Effect |
+|---|---|---|
+| `whitelist` | `true` | Strips undeclared properties at every nesting level |
+| `forbidNonWhitelisted` | `true` | Rejects requests that contain extra properties (prevents mass-assignment) |
+| `enableImplicitConversion` | `true` | Coerces primitive types (e.g. `"3"` → `3`) via `class-transformer` |
+| `stopAtFirstError` | `false` | Collects all errors before throwing so callers receive a complete error map |
+
+### Error format
+
+Errors are returned as a flat object keyed by dot-notation path:
+
+```json
+{
+  "message": "Validation failed",
+  "errors": {
+    "address.street": ["street should not be empty"],
+    "items.0.quantity": ["quantity must not be less than 1"]
+  }
+}
+```
+
+### Usage in a service or controller
+
+```typescript
+// Inject via constructor (requires ValidationModule or manual provider registration)
+constructor(private readonly nestedValidator: NestedPayloadValidator) {}
+
+async createOrder(body: unknown) {
+  const dto = await this.nestedValidator.validate(CreateOrderDto, body);
+  // dto is a fully validated CreateOrderDto instance
+}
+```
+
+### DTO requirements
+
+Nested objects must use `@ValidateNested()` + `@Type(() => NestedClass)` from `class-transformer`:
+
+```typescript
+import { ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class CreateOrderDto {
+  @ValidateNested()
+  @Type(() => AddressDto)
+  address: AddressDto;
+}
+```
+
+### Security
+
+- Extra properties at any nesting depth are rejected (not silently dropped), preventing mass-assignment attacks on nested objects.
+- No authentication or authorization logic is modified.

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,3 +1,6 @@
+// Nested Payload Validator
+export * from './nested-payload.validator';
+
 // Stellar Address Validators
 export * from './stellar-address.validator';
 

--- a/src/common/validators/nested-payload.validator.ts
+++ b/src/common/validators/nested-payload.validator.ts
@@ -1,0 +1,91 @@
+import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { validate, ValidationError } from 'class-validator';
+import { plainToInstance, ClassConstructor } from 'class-transformer';
+
+/**
+ * Flattens a tree of class-validator ValidationErrors into a plain object
+ * keyed by dot-notation path (e.g. `"address.city": ["must be a string"]`).
+ */
+function flattenErrors(
+  errors: ValidationError[],
+  prefix = '',
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  for (const err of errors) {
+    const path = prefix ? `${prefix}.${err.property}` : err.property;
+
+    if (err.constraints && Object.keys(err.constraints).length > 0) {
+      result[path] = Object.values(err.constraints);
+    }
+
+    if (err.children && err.children.length > 0) {
+      Object.assign(result, flattenErrors(err.children, path));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * NestedPayloadValidator
+ *
+ * Validates arbitrarily-deep nested request payloads against a DTO class.
+ * Addresses the gap where the existing CustomValidationPipe only validates
+ * the top-level object — nested objects decorated with @ValidateNested()
+ * are fully traversed here.
+ *
+ * Key options applied:
+ *  - `whitelist: true`          — strips undeclared properties
+ *  - `forbidNonWhitelisted: true` — rejects requests with extra properties
+ *  - `enableImplicitConversion: true` — coerces primitive types (string→number etc.)
+ *  - `stopAtFirstError: false`  — collects all errors before throwing
+ *
+ * Security: preserves existing access-control semantics — no auth/authz
+ * logic is touched.  Stripping undeclared properties prevents mass-assignment
+ * attacks on nested objects that the middleware layer cannot catch.
+ *
+ * Usage:
+ *   const validated = await this.nestedPayloadValidator.validate(CreateOrderDto, body);
+ */
+@Injectable()
+export class NestedPayloadValidator {
+  private readonly logger = new Logger(NestedPayloadValidator.name);
+
+  /**
+   * Transform `plain` into an instance of `cls` and run full nested validation.
+   *
+   * @throws BadRequestException with a structured `errors` map when validation fails.
+   * @returns The validated (and whitelist-stripped) class instance.
+   */
+  async validate<T extends object>(
+    cls: ClassConstructor<T>,
+    plain: unknown,
+  ): Promise<T> {
+    const instance = plainToInstance(cls, plain, {
+      enableImplicitConversion: true,
+      excludeExtraneousValues: false, // rely on whitelist instead
+    });
+
+    const errors = await validate(instance as object, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      stopAtFirstError: false,
+    });
+
+    if (errors.length > 0) {
+      const flat = flattenErrors(errors);
+      this.logger.warn(
+        `Nested payload validation failed for ${cls.name}: ${JSON.stringify(flat)}`,
+      );
+      throw new BadRequestException({
+        message: 'Validation failed',
+        errors: flat,
+      });
+    }
+
+    return instance;
+  }
+}
+
+export { flattenErrors };

--- a/src/tracing/tracing.module.ts
+++ b/src/tracing/tracing.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TracingService, TracingMiddleware } from './tracing.service';
+import { WorkerTracingService } from './worker-tracing.service';
 
 @Module({
-  providers: [TracingService, TracingMiddleware],
-  exports: [TracingService, TracingMiddleware],
+  providers: [TracingService, TracingMiddleware, WorkerTracingService],
+  exports: [TracingService, TracingMiddleware, WorkerTracingService],
 })
 export class TracingModule {}

--- a/src/tracing/worker-tracing.service.ts
+++ b/src/tracing/worker-tracing.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Job } from 'bull';
+import { TracingService, TRACE_ID_HEADER } from './tracing.service';
+
+export const WORKER_TRACE_ID_KEY = 'traceId';
+
+/**
+ * WorkerTracingService — tracing support for asynchronous worker/job execution.
+ *
+ * Bridges the gap between HTTP-layer tracing (TracingMiddleware) and Bull
+ * worker processors.  A trace ID is:
+ *   - Propagated from the job's data payload when the enqueuing caller
+ *     embedded one (end-to-end correlation).
+ *   - Generated fresh (UUID v4) when no trace ID is present, so every job
+ *     execution is always identifiable in logs.
+ *
+ * Usage in a Bull @Processor:
+ *
+ *   @Process('my-job')
+ *   async handle(job: Job): Promise<void> {
+ *     const traceId = this.workerTracing.start(job);
+ *     try {
+ *       // ... do work ...
+ *       this.workerTracing.finish(traceId, job);
+ *     } catch (err) {
+ *       this.workerTracing.error(traceId, job, err as Error);
+ *       throw err;
+ *     }
+ *   }
+ *
+ * Security: no authentication tokens or secrets are logged.  The service
+ * only reads/writes the traceId field and delegates all structured logging
+ * to TracingService, preserving existing access-control semantics.
+ */
+@Injectable()
+export class WorkerTracingService {
+  private readonly logger = new Logger(WorkerTracingService.name);
+
+  constructor(private readonly tracingService: TracingService) {}
+
+  /**
+   * Begin tracing a worker job.
+   *
+   * Extracts an existing trace ID from `job.data[WORKER_TRACE_ID_KEY]` or
+   * from the legacy HTTP header key stored in job data, falling back to a
+   * freshly generated UUID.
+   *
+   * @returns The trace ID that should be threaded through the job execution.
+   */
+  start(job: Job): string {
+    if (!this.tracingService.isEnabled) {
+      return '';
+    }
+
+    const traceId =
+      (job.data as Record<string, unknown>)?.[WORKER_TRACE_ID_KEY] as string |
+      undefined ??
+      (job.data as Record<string, unknown>)?.[TRACE_ID_HEADER] as string |
+      undefined ??
+      randomUUID();
+
+    this.tracingService.log(
+      traceId,
+      `worker:start queue="${job.queue.name}" job=${job.id} name="${job.name}"`,
+    );
+
+    return traceId;
+  }
+
+  /**
+   * Record successful completion of a worker job.
+   */
+  finish(traceId: string, job: Job): void {
+    if (!this.tracingService.isEnabled || !traceId) return;
+
+    this.tracingService.log(
+      traceId,
+      `worker:finish queue="${job.queue.name}" job=${job.id} name="${job.name}"`,
+    );
+  }
+
+  /**
+   * Record a worker job failure.
+   */
+  error(traceId: string, job: Job, err: Error): void {
+    if (!this.tracingService.isEnabled || !traceId) return;
+
+    this.logger.error(
+      `[trace:${traceId}] worker:error queue="${job.queue.name}" job=${job.id} name="${job.name}": ${err.message}`,
+    );
+  }
+
+  /**
+   * Build job data that carries the current trace ID forward so downstream
+   * workers can continue the same trace.
+   *
+   * @param payload   The original job payload.
+   * @param traceId   The trace ID to embed (e.g. from an HTTP request).
+   */
+  injectTraceId(
+    payload: Record<string, unknown>,
+    traceId: string,
+  ): Record<string, unknown> {
+    return { ...payload, [WORKER_TRACE_ID_KEY]: traceId };
+  }
+}

--- a/test/nested-payload.validator.spec.ts
+++ b/test/nested-payload.validator.spec.ts
@@ -1,0 +1,239 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  IsString,
+  IsInt,
+  IsEmail,
+  IsNotEmpty,
+  ValidateNested,
+  IsOptional,
+  IsArray,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  NestedPayloadValidator,
+  flattenErrors,
+} from '../src/common/validators/nested-payload.validator';
+
+// ── fixture DTOs ──────────────────────────────────────────────────────────────
+
+class AddressDto {
+  @IsString()
+  @IsNotEmpty()
+  street: string;
+
+  @IsString()
+  @IsNotEmpty()
+  city: string;
+}
+
+class ItemDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsInt()
+  @Min(1)
+  quantity: number;
+}
+
+class OrderDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsEmail()
+  email: string;
+
+  @ValidateNested()
+  @Type(() => AddressDto)
+  address: AddressDto;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ItemDto)
+  items: ItemDto[];
+
+  @IsOptional()
+  @IsString()
+  note?: string;
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const validPayload = () => ({
+  userId: 'user-1',
+  email: 'user@example.com',
+  address: { street: '1 Main St', city: 'Springfield' },
+  items: [{ name: 'Widget', quantity: 2 }],
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('NestedPayloadValidator', () => {
+  let validator: NestedPayloadValidator;
+
+  beforeEach(() => {
+    validator = new NestedPayloadValidator();
+  });
+
+  it('returns a validated instance for a fully valid payload', async () => {
+    const result = await validator.validate(OrderDto, validPayload());
+    expect(result).toBeInstanceOf(OrderDto);
+    expect(result.userId).toBe('user-1');
+  });
+
+  it('validates nested object fields (address)', async () => {
+    const payload = { ...validPayload(), address: { street: '', city: 'X' } };
+    await expect(validator.validate(OrderDto, payload)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('reports the nested field path in the error map', async () => {
+    const payload = { ...validPayload(), address: { street: '', city: 'X' } };
+    try {
+      await validator.validate(OrderDto, payload);
+      fail('expected to throw');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(BadRequestException);
+      const errors = err.response.errors as Record<string, string[]>;
+      // street is empty — should appear under address.street
+      expect(Object.keys(errors).some((k) => k.includes('address'))).toBe(true);
+    }
+  });
+
+  it('validates each element of a nested array (items)', async () => {
+    const payload = {
+      ...validPayload(),
+      items: [{ name: 'Widget', quantity: 0 }], // quantity < 1
+    };
+    await expect(validator.validate(OrderDto, payload)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('reports nested array element path in the error map', async () => {
+    const payload = {
+      ...validPayload(),
+      items: [{ name: '', quantity: 1 }],
+    };
+    try {
+      await validator.validate(OrderDto, payload);
+      fail('expected to throw');
+    } catch (err: any) {
+      const errors = err.response.errors as Record<string, string[]>;
+      expect(Object.keys(errors).some((k) => k.includes('items'))).toBe(true);
+    }
+  });
+
+  it('rejects undeclared top-level properties (forbidNonWhitelisted)', async () => {
+    // With forbidNonWhitelisted:true, extra properties throw rather than being
+    // silently stripped — this is the stricter, more secure behavior.
+    const payload = { ...validPayload(), __admin: true };
+    await expect(validator.validate(OrderDto, payload)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects payloads with extra (non-whitelisted) properties', async () => {
+    const payload = { ...validPayload(), extraField: 'injected' };
+    await expect(validator.validate(OrderDto, payload)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects when a required top-level field is missing', async () => {
+    const { userId: _omit, ...payload } = validPayload();
+    await expect(validator.validate(OrderDto, payload as any)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects an invalid email at the top level', async () => {
+    const payload = { ...validPayload(), email: 'not-an-email' };
+    await expect(validator.validate(OrderDto, payload)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('accepts an optional field when omitted', async () => {
+    const payload = validPayload(); // note is absent
+    await expect(validator.validate(OrderDto, payload)).resolves.toBeDefined();
+  });
+
+  it('accepts an optional field when present and valid', async () => {
+    const payload = { ...validPayload(), note: 'leave at door' };
+    const result = await validator.validate(OrderDto, payload);
+    expect(result.note).toBe('leave at door');
+  });
+
+  it('collects multiple errors in a single pass (stopAtFirstError=false)', async () => {
+    const payload = {
+      ...validPayload(),
+      email: 'bad',
+      address: { street: '', city: '' },
+    };
+    try {
+      await validator.validate(OrderDto, payload);
+      fail('expected to throw');
+    } catch (err: any) {
+      const errors = err.response.errors as Record<string, string[]>;
+      // Should have errors for both email and address fields
+      expect(Object.keys(errors).length).toBeGreaterThan(1);
+    }
+  });
+
+  it('coerces string numbers to integers via implicit conversion', async () => {
+    const payload = {
+      ...validPayload(),
+      items: [{ name: 'Widget', quantity: '3' }], // string instead of number
+    };
+    const result = await validator.validate(OrderDto, payload);
+    expect(result.items[0].quantity).toBe(3);
+  });
+});
+
+// ── flattenErrors unit tests ──────────────────────────────────────────────────
+
+describe('flattenErrors()', () => {
+  it('returns empty object for no errors', () => {
+    expect(flattenErrors([])).toEqual({});
+  });
+
+  it('flattens a single top-level error', () => {
+    const err = {
+      property: 'email',
+      constraints: { isEmail: 'email must be an email' },
+      children: [],
+    } as any;
+    expect(flattenErrors([err])).toEqual({
+      email: ['email must be an email'],
+    });
+  });
+
+  it('flattens nested errors with dot-notation paths', () => {
+    const child = {
+      property: 'street',
+      constraints: { isNotEmpty: 'street should not be empty' },
+      children: [],
+    } as any;
+    const parent = {
+      property: 'address',
+      constraints: {},
+      children: [child],
+    } as any;
+    const result = flattenErrors([parent]);
+    expect(result['address.street']).toEqual(['street should not be empty']);
+  });
+
+  it('handles a prefix for array element paths', () => {
+    const child = {
+      property: 'name',
+      constraints: { isNotEmpty: 'name should not be empty' },
+      children: [],
+    } as any;
+    const result = flattenErrors([child], 'items.0');
+    expect(result['items.0.name']).toEqual(['name should not be empty']);
+  });
+});

--- a/test/worker-tracing.service.spec.ts
+++ b/test/worker-tracing.service.spec.ts
@@ -1,0 +1,198 @@
+// Mock the tracing.service module to avoid the pre-existing class-ordering TDZ
+// issue in tracing.service.ts (TracingMiddleware declared before TracingService).
+jest.mock('../src/tracing/tracing.service', () => {
+  const TRACE_ID_HEADER = 'x-trace-id';
+
+  class TracingService {
+    get isEnabled(): boolean { return false; }
+    get serviceName(): string { return 'stellarswipe-backend'; }
+    fromRequest(_req: any) { return undefined; }
+    outboundHeaders(traceId: string) { return { [TRACE_ID_HEADER]: traceId }; }
+    log(_traceId: string, _message: string) {}
+  }
+
+  class TracingMiddleware {
+    constructor(private readonly tracingService: TracingService) {}
+    use(_req: any, _res: any, next: () => void) { next(); }
+  }
+
+  return { TracingService, TracingMiddleware, TRACE_ID_HEADER };
+});
+
+import { TracingService, TRACE_ID_HEADER } from '../src/tracing/tracing.service';
+import { WorkerTracingService, WORKER_TRACE_ID_KEY } from '../src/tracing/worker-tracing.service';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const makeJob = (data: Record<string, unknown> = {}, name = 'test-job') =>
+  ({
+    id: 'job-1',
+    name,
+    data,
+    queue: { name: 'test-queue' },
+  }) as any;
+
+const makeTracingService = (enabled: boolean): TracingService => {
+  const svc = new (TracingService as any)();
+  jest.spyOn(svc, 'isEnabled', 'get').mockReturnValue(enabled);
+  jest.spyOn(svc, 'log').mockImplementation(() => undefined);
+  return svc;
+};
+
+// ── WorkerTracingService ──────────────────────────────────────────────────────
+
+describe('WorkerTracingService', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('start()', () => {
+    it('returns empty string when tracing is disabled', () => {
+      const svc = new WorkerTracingService(makeTracingService(false));
+      expect(svc.start(makeJob())).toBe('');
+    });
+
+    it('propagates traceId from job.data[WORKER_TRACE_ID_KEY]', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const job = makeJob({ [WORKER_TRACE_ID_KEY]: 'existing-trace' });
+
+      const traceId = svc.start(job);
+
+      expect(traceId).toBe('existing-trace');
+      expect(ts.log).toHaveBeenCalledWith(
+        'existing-trace',
+        expect.stringContaining('worker:start'),
+      );
+    });
+
+    it('propagates traceId from legacy x-trace-id key in job data', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const job = makeJob({ [TRACE_ID_HEADER]: 'http-trace' });
+
+      expect(svc.start(job)).toBe('http-trace');
+    });
+
+    it('generates a UUID v4 when no trace ID is present in job data', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+
+      const traceId = svc.start(makeJob());
+
+      expect(traceId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it('assigns unique trace IDs to concurrent jobs without a pre-set ID', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+
+      const id1 = svc.start(makeJob());
+      const id2 = svc.start(makeJob());
+
+      expect(id1).not.toBe(id2);
+    });
+
+    it('logs the queue name and job id on start', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const job = makeJob({ [WORKER_TRACE_ID_KEY]: 'trace-abc' });
+
+      svc.start(job);
+
+      expect(ts.log).toHaveBeenCalledWith(
+        'trace-abc',
+        expect.stringContaining('test-queue'),
+      );
+      expect(ts.log).toHaveBeenCalledWith(
+        'trace-abc',
+        expect.stringContaining('job-1'),
+      );
+    });
+  });
+
+  describe('finish()', () => {
+    it('is a no-op when tracing is disabled', () => {
+      const ts = makeTracingService(false);
+      const svc = new WorkerTracingService(ts);
+      svc.finish('trace-id', makeJob());
+      expect(ts.log).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when traceId is empty', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      svc.finish('', makeJob());
+      expect(ts.log).not.toHaveBeenCalled();
+    });
+
+    it('logs finish with trace ID and job details', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+
+      svc.finish('trace-xyz', makeJob());
+
+      expect(ts.log).toHaveBeenCalledWith(
+        'trace-xyz',
+        expect.stringContaining('worker:finish'),
+      );
+    });
+  });
+
+  describe('error()', () => {
+    it('is a no-op when tracing is disabled', () => {
+      const ts = makeTracingService(false);
+      const svc = new WorkerTracingService(ts);
+      const logSpy = jest.spyOn((svc as any).logger, 'error').mockImplementation(() => undefined);
+      svc.error('trace-id', makeJob(), new Error('boom'));
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when traceId is empty', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const logSpy = jest.spyOn((svc as any).logger, 'error').mockImplementation(() => undefined);
+      svc.error('', makeJob(), new Error('boom'));
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs the error message with trace ID', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const logSpy = jest.spyOn((svc as any).logger, 'error').mockImplementation(() => undefined);
+
+      svc.error('trace-err', makeJob(), new Error('something went wrong'));
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('trace-err'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('something went wrong'),
+      );
+    });
+  });
+
+  describe('injectTraceId()', () => {
+    it('merges traceId into the payload without mutating the original', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const original = { userId: 'u1' };
+
+      const result = svc.injectTraceId(original, 'trace-inject');
+
+      expect(result[WORKER_TRACE_ID_KEY]).toBe('trace-inject');
+      expect(result['userId']).toBe('u1');
+      expect(original).not.toHaveProperty(WORKER_TRACE_ID_KEY);
+    });
+
+    it('overwrites an existing traceId in the payload', () => {
+      const ts = makeTracingService(true);
+      const svc = new WorkerTracingService(ts);
+      const payload = { [WORKER_TRACE_ID_KEY]: 'old-trace' };
+
+      const result = svc.injectTraceId(payload, 'new-trace');
+
+      expect(result[WORKER_TRACE_ID_KEY]).toBe('new-trace');
+    });
+  });
+});


### PR DESCRIPTION
closes #415 
- src/common/validators/nested-payload.validator.ts — new NestedPayloadValidator injectable service with:
  - validate<T>(cls, plain) — transforms plain object to DTO instance via class-transformer then runs full nested validation with class-validator
  - flattenErrors() — converts the ValidationError tree into a flat { "address.street": [...] } map
  - Options: whitelist, forbidNonWhitelisted, enableImplicitConversion, stopAtFirstError: false

- src/common/validators/index.ts — exports the new validator

- test/nested-payload.validator.spec.ts — 17 regression tests covering: nested object validation, nested array element validation, dot-notation error paths, whitelist 
rejection, multi-error collection, implicit type coercion, optional fields, and flattenErrors unit tests

- docs/CONFIGURATION.md — "Nested Payload Validation" section documenting options, error format, usage, DTO requirements, and security properties

The gap closed: the existing CustomValidationPipe validates top-level DTO fields but nested objects passed as plain objects bypass @ValidateNested() constraints. 
NestedPayloadValidator uses plainToInstance to materialize the full class hierarchy before validation, so every nested field is checked.