### PR TITLE
Leaderboard indexing, multi-tenant isolation, event replay, slow query monitoring

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -9,6 +9,7 @@ import { ConnectionPoolMetricsService } from './connection-pool.metrics.service'
 import { MonitoringModule } from '../monitoring/monitoring.module';
 import { SchemaVersioningService } from './schema-versioning.service';
 import { SchemaVersion } from './schema-version.entity';
+import { QueryMonitorService } from './query-monitor.service';
 
 @Global()
 @Module({
@@ -23,6 +24,7 @@ import { SchemaVersion } from './schema-version.entity';
     MaterializedViewService,
     ConnectionPoolMetricsService,
     SchemaVersioningService,
+    QueryMonitorService,
   ],
   exports: [
     QueryAnalyzerService,
@@ -30,6 +32,7 @@ import { SchemaVersion } from './schema-version.entity';
     MaterializedViewService,
     ConnectionPoolMetricsService,
     SchemaVersioningService,
+    QueryMonitorService,
   ],
 })
 export class DatabaseOptimizationModule {}

--- a/src/database/query-monitor.service.spec.ts
+++ b/src/database/query-monitor.service.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  QueryMonitorService,
+  SLOW_QUERY_EVENT,
+  SLOW_RATE_EVENT,
+} from './query-monitor.service';
+
+const mockDataSource = () => ({
+  logger: {
+    logQuery: jest.fn(),
+    logQuerySlow: jest.fn(),
+  },
+});
+
+const mockEmitter = () => ({ emit: jest.fn() });
+
+describe('QueryMonitorService', () => {
+  let service: QueryMonitorService;
+  let emitter: ReturnType<typeof mockEmitter>;
+
+  beforeEach(async () => {
+    // Set a low threshold so tests don't need huge durations
+    process.env.SLOW_QUERY_THRESHOLD_MS = '100';
+    process.env.SLOW_QUERY_RATE_ALERT_THRESHOLD = '3';
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueryMonitorService,
+        { provide: getDataSourceToken(), useFactory: mockDataSource },
+        { provide: EventEmitter2, useFactory: mockEmitter },
+      ],
+    }).compile();
+
+    service = module.get(QueryMonitorService);
+    emitter = module.get(EventEmitter2);
+
+    // Initialise without starting the interval timer
+    jest.useFakeTimers();
+    service.onModuleInit();
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    service.reset();
+    jest.useRealTimers();
+  });
+
+  // ── record ────────────────────────────────────────────────────────────────
+
+  describe('record', () => {
+    it('does not emit for fast queries', () => {
+      service.record('SELECT 1', [], 50);
+      expect(emitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('emits SLOW_QUERY_EVENT for slow queries', () => {
+      service.record('SELECT * FROM signals', [], 250);
+      expect(emitter.emit).toHaveBeenCalledWith(
+        SLOW_QUERY_EVENT,
+        expect.objectContaining({ durationMs: 250 }),
+      );
+    });
+
+    it('truncates long queries to 300 chars', () => {
+      const longQuery = 'SELECT ' + 'x'.repeat(400);
+      service.record(longQuery, [], 300);
+
+      const [, payload] = (emitter.emit as jest.Mock).mock.calls[0];
+      expect(payload.query.length).toBeLessThanOrEqual(301); // 300 + ellipsis char
+    });
+
+    it('does not include raw parameter values in the record', () => {
+      service.record('SELECT $1', ['secret-value'], 300);
+      const [, payload] = (emitter.emit as jest.Mock).mock.calls[0];
+      expect(JSON.stringify(payload)).not.toContain('secret-value');
+      expect(payload.paramCount).toBe(1);
+    });
+  });
+
+  // ── getStats ──────────────────────────────────────────────────────────────
+
+  describe('getStats', () => {
+    it('returns correct counts after recording', () => {
+      service.record('fast', [], 10);
+      service.record('slow1', [], 200);
+      service.record('slow2', [], 300);
+
+      const stats = service.getStats();
+      expect(stats.totalRecorded).toBe(3);
+      expect(stats.slowQueryCount).toBe(2);
+      expect(stats.thresholdMs).toBe(100);
+    });
+
+    it('calculates p95 duration', () => {
+      for (let i = 1; i <= 20; i++) {
+        service.record(`q${i}`, [], i * 10);
+      }
+      const stats = service.getStats();
+      expect(stats.p95DurationMs).toBeGreaterThan(0);
+    });
+  });
+
+  // ── getSlowQueries ────────────────────────────────────────────────────────
+
+  describe('getSlowQueries', () => {
+    it('returns slow queries newest first', () => {
+      service.record('first slow', [], 150);
+      service.record('second slow', [], 250);
+
+      const results = service.getSlowQueries(10);
+      expect(results[0].query).toBe('second slow');
+      expect(results[1].query).toBe('first slow');
+    });
+
+    it('respects the limit parameter', () => {
+      for (let i = 0; i < 10; i++) {
+        service.record(`slow ${i}`, [], 200);
+      }
+      expect(service.getSlowQueries(3)).toHaveLength(3);
+    });
+  });
+
+  // ── rate alert ────────────────────────────────────────────────────────────
+
+  describe('slow query rate alert', () => {
+    it('emits SLOW_RATE_EVENT when rate threshold is exceeded', () => {
+      // Record 4 slow queries (threshold is 3)
+      for (let i = 0; i < 4; i++) {
+        service.record(`slow ${i}`, [], 200);
+      }
+
+      // Trigger the rate check
+      jest.advanceTimersByTime(60_000);
+
+      expect(emitter.emit).toHaveBeenCalledWith(
+        SLOW_RATE_EVENT,
+        expect.objectContaining({ count: 4 }),
+      );
+    });
+
+    it('does not emit SLOW_RATE_EVENT when below threshold', () => {
+      service.record('slow', [], 200); // only 1, threshold is 3
+
+      jest.advanceTimersByTime(60_000);
+
+      const rateCalls = (emitter.emit as jest.Mock).mock.calls.filter(
+        ([name]) => name === SLOW_RATE_EVENT,
+      );
+      expect(rateCalls).toHaveLength(0);
+    });
+  });
+
+  // ── reset ─────────────────────────────────────────────────────────────────
+
+  describe('reset', () => {
+    it('clears all history', () => {
+      service.record('slow', [], 300);
+      service.reset();
+
+      const stats = service.getStats();
+      expect(stats.totalRecorded).toBe(0);
+      expect(stats.slowQueryCount).toBe(0);
+    });
+  });
+});

--- a/src/database/query-monitor.service.ts
+++ b/src/database/query-monitor.service.ts
@@ -1,0 +1,248 @@
+/**
+ * QueryMonitorService
+ *
+ * Detects slow database queries at runtime and raises alerts via the
+ * application event bus and structured logs.
+ *
+ * How it works
+ * ────────────
+ * 1. TypeORM's `logger` option is set to a custom logger that calls
+ *    `QueryMonitorService.record()` for every executed query.
+ * 2. Queries that exceed `SLOW_QUERY_THRESHOLD_MS` are flagged, logged at
+ *    WARN level, and emitted as `db.query.slow` events.
+ * 3. A sliding-window counter tracks the slow-query rate per minute.
+ *    When the rate exceeds `SLOW_QUERY_RATE_ALERT_THRESHOLD`, a
+ *    `db.query.slow_rate_exceeded` event is emitted (e.g. for PagerDuty).
+ * 4. The service exposes `getStats()` and `getSlowQueries()` for health
+ *    endpoints and admin dashboards.
+ *
+ * Security
+ * ────────
+ * • Query parameters are sanitised before logging to prevent credential
+ *   or PII leakage in log aggregators.
+ * • The service does not expose raw query parameters through any API.
+ */
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+export const SLOW_QUERY_EVENT = 'db.query.slow';
+export const SLOW_RATE_EVENT = 'db.query.slow_rate_exceeded';
+
+export interface SlowQueryRecord {
+  query: string;
+  durationMs: number;
+  detectedAt: Date;
+  /** Sanitised — no raw parameter values. */
+  paramCount: number;
+}
+
+export interface QueryMonitorStats {
+  totalRecorded: number;
+  slowQueryCount: number;
+  slowQueriesLastMinute: number;
+  averageDurationMs: number;
+  p95DurationMs: number;
+  thresholdMs: number;
+}
+
+const MAX_HISTORY = 500;
+const RATE_WINDOW_MS = 60_000;
+
+@Injectable()
+export class QueryMonitorService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(QueryMonitorService.name);
+
+  private readonly thresholdMs: number;
+  private readonly rateAlertThreshold: number;
+
+  private readonly slowQueries: SlowQueryRecord[] = [];
+  private readonly allDurations: number[] = [];
+  private totalRecorded = 0;
+
+  /** Timestamps of slow queries within the current rate window. */
+  private readonly slowQueryTimestamps: number[] = [];
+
+  private rateCheckTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
+    this.thresholdMs = parseInt(
+      process.env.SLOW_QUERY_THRESHOLD_MS ?? '200',
+      10,
+    );
+    this.rateAlertThreshold = parseInt(
+      process.env.SLOW_QUERY_RATE_ALERT_THRESHOLD ?? '10',
+      10,
+    );
+  }
+
+  onModuleInit(): void {
+    // Patch TypeORM's data source logger to intercept slow queries.
+    this.patchDataSourceLogger();
+
+    // Check slow-query rate every 60 s.
+    this.rateCheckTimer = setInterval(
+      () => this.checkSlowQueryRate(),
+      RATE_WINDOW_MS,
+    );
+
+    this.logger.log(
+      `QueryMonitorService started. ` +
+        `Threshold: ${this.thresholdMs}ms, ` +
+        `Rate alert: ${this.rateAlertThreshold} slow queries/min`,
+    );
+  }
+
+  onModuleDestroy(): void {
+    if (this.rateCheckTimer) {
+      clearInterval(this.rateCheckTimer);
+      this.rateCheckTimer = null;
+    }
+  }
+
+  /**
+   * Record a query execution.  Called by the patched TypeORM logger and
+   * directly from services that wrap their own queries.
+   */
+  record(query: string, params: unknown[], durationMs: number): void {
+    this.totalRecorded++;
+
+    // Keep a bounded duration history for percentile calculations.
+    this.allDurations.push(durationMs);
+    if (this.allDurations.length > MAX_HISTORY) this.allDurations.shift();
+
+    if (durationMs < this.thresholdMs) return;
+
+    const record: SlowQueryRecord = {
+      query: this.truncate(query, 300),
+      durationMs,
+      detectedAt: new Date(),
+      paramCount: Array.isArray(params) ? params.length : 0,
+    };
+
+    this.slowQueries.push(record);
+    if (this.slowQueries.length > MAX_HISTORY) this.slowQueries.shift();
+
+    this.slowQueryTimestamps.push(Date.now());
+
+    this.logger.warn(
+      `Slow query detected (${durationMs.toFixed(1)}ms > ${this.thresholdMs}ms): ` +
+        `${record.query}`,
+    );
+
+    this.eventEmitter.emit(SLOW_QUERY_EVENT, record);
+  }
+
+  /** Returns aggregated statistics for health/admin endpoints. */
+  getStats(): QueryMonitorStats {
+    const sorted = [...this.allDurations].sort((a, b) => a - b);
+    const p95Idx = Math.max(0, Math.floor(sorted.length * 0.95) - 1);
+    const avg =
+      sorted.length > 0
+        ? sorted.reduce((s, v) => s + v, 0) / sorted.length
+        : 0;
+
+    return {
+      totalRecorded: this.totalRecorded,
+      slowQueryCount: this.slowQueries.length,
+      slowQueriesLastMinute: this.countRecentSlowQueries(),
+      averageDurationMs: Math.round(avg * 100) / 100,
+      p95DurationMs: sorted[p95Idx] ?? 0,
+      thresholdMs: this.thresholdMs,
+    };
+  }
+
+  /** Returns the most recent slow queries, newest first. */
+  getSlowQueries(limit = 50): SlowQueryRecord[] {
+    return [...this.slowQueries].reverse().slice(0, limit);
+  }
+
+  /** Clears in-memory history (useful in tests / after a maintenance window). */
+  reset(): void {
+    this.slowQueries.length = 0;
+    this.allDurations.length = 0;
+    this.slowQueryTimestamps.length = 0;
+    this.totalRecorded = 0;
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  /**
+   * Patches the TypeORM DataSource logger so every slow query is forwarded
+   * to `record()` without requiring callers to instrument their code.
+   */
+  private patchDataSourceLogger(): void {
+    try {
+      const original = (this.dataSource as any).logger;
+      if (!original) return;
+
+      const self = this;
+      const originalLogQuery = original.logQuery?.bind(original);
+      const originalLogSlow = original.logQuerySlow?.bind(original);
+
+      original.logQuery = function (
+        query: string,
+        params?: unknown[],
+      ): void {
+        originalLogQuery?.(query, params);
+      };
+
+      original.logQuerySlow = function (
+        time: number,
+        query: string,
+        params?: unknown[],
+      ): void {
+        originalLogSlow?.(time, query, params);
+        self.record(query, params ?? [], time);
+      };
+
+      this.logger.log('TypeORM logger patched for slow query monitoring');
+    } catch (err) {
+      this.logger.warn(
+        `Could not patch TypeORM logger: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private checkSlowQueryRate(): void {
+    const count = this.countRecentSlowQueries();
+
+    if (count >= this.rateAlertThreshold) {
+      this.logger.error(
+        `Slow query rate alert: ${count} slow queries in the last minute ` +
+          `(threshold: ${this.rateAlertThreshold})`,
+      );
+      this.eventEmitter.emit(SLOW_RATE_EVENT, {
+        count,
+        thresholdMs: this.thresholdMs,
+        rateAlertThreshold: this.rateAlertThreshold,
+        timestamp: new Date(),
+      });
+    }
+  }
+
+  private countRecentSlowQueries(): number {
+    const cutoff = Date.now() - RATE_WINDOW_MS;
+    // Prune old timestamps while counting
+    while (
+      this.slowQueryTimestamps.length > 0 &&
+      this.slowQueryTimestamps[0] < cutoff
+    ) {
+      this.slowQueryTimestamps.shift();
+    }
+    return this.slowQueryTimestamps.length;
+  }
+
+  private truncate(str: string, maxLen: number): string {
+    return str.length > maxLen ? str.slice(0, maxLen) + '…' : str;
+  }
+}

--- a/src/events/event-replay.service.spec.ts
+++ b/src/events/event-replay.service.spec.ts
@@ -1,0 +1,178 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  EventReplayService,
+  ReplayOptions,
+  REPLAY_EVENT,
+  REPLAY_COMPLETE_EVENT,
+} from './event-replay.service';
+import { AuditLog, AuditAction, AuditStatus } from '../audit-log/entities/audit-log.entity';
+
+const mockAuditRepo = () => ({ find: jest.fn() });
+const mockEmitter = () => ({ emit: jest.fn() });
+
+const makeLog = (overrides: Partial<AuditLog> = {}): AuditLog =>
+  ({
+    id: 'log-1',
+    userId: 'user-1',
+    action: AuditAction.TRADE_EXECUTED,
+    resource: 'trade',
+    resourceId: 'trade-1',
+    metadata: { amount: 100 },
+    ipAddress: '127.0.0.1',
+    userAgent: 'test',
+    status: AuditStatus.SUCCESS,
+    errorMessage: null,
+    sessionId: 'sess-1',
+    requestId: 'req-1',
+    createdAt: new Date('2024-01-15T10:00:00Z'),
+    ...overrides,
+  } as AuditLog);
+
+describe('EventReplayService', () => {
+  let service: EventReplayService;
+  let auditRepo: ReturnType<typeof mockAuditRepo>;
+  let emitter: ReturnType<typeof mockEmitter>;
+
+  const baseOptions: ReplayOptions = {
+    from: new Date('2024-01-01'),
+    to: new Date('2024-01-31'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventReplayService,
+        { provide: getRepositoryToken(AuditLog), useFactory: mockAuditRepo },
+        { provide: EventEmitter2, useFactory: mockEmitter },
+      ],
+    }).compile();
+
+    service = module.get(EventReplayService);
+    auditRepo = module.get(getRepositoryToken(AuditLog));
+    emitter = module.get(EventEmitter2);
+  });
+
+  // ── validation ────────────────────────────────────────────────────────────
+
+  describe('validation', () => {
+    it('throws when from >= to', async () => {
+      auditRepo.find.mockResolvedValue([]);
+      await expect(
+        service.replay({ from: new Date('2024-02-01'), to: new Date('2024-01-01') }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws when window exceeds 90 days', async () => {
+      await expect(
+        service.replay({
+          from: new Date('2024-01-01'),
+          to: new Date('2024-05-01'), // ~120 days
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── dry-run ───────────────────────────────────────────────────────────────
+
+  describe('dry-run', () => {
+    it('does not emit REPLAY_EVENT in dry-run mode', async () => {
+      auditRepo.find.mockResolvedValue([makeLog()]);
+
+      const result = await service.replay({ ...baseOptions, dryRun: true });
+
+      const replayEmitCalls = (emitter.emit as jest.Mock).mock.calls.filter(
+        ([name]) => name === REPLAY_EVENT,
+      );
+      expect(replayEmitCalls).toHaveLength(0);
+      expect(result.dryRun).toBe(true);
+      expect(result.replayed).toBe(1);
+    });
+
+    it('still emits REPLAY_COMPLETE_EVENT in dry-run mode', async () => {
+      auditRepo.find.mockResolvedValue([makeLog()]);
+      await service.replay({ ...baseOptions, dryRun: true });
+
+      expect(emitter.emit).toHaveBeenCalledWith(
+        REPLAY_COMPLETE_EVENT,
+        expect.objectContaining({ dryRun: true }),
+      );
+    });
+  });
+
+  // ── live replay ───────────────────────────────────────────────────────────
+
+  describe('live replay', () => {
+    it('emits REPLAY_EVENT for each event', async () => {
+      auditRepo.find.mockResolvedValue([makeLog({ id: 'a' }), makeLog({ id: 'b' })]);
+
+      const result = await service.replay({ ...baseOptions, throttleMs: 0 });
+
+      const replayCalls = (emitter.emit as jest.Mock).mock.calls.filter(
+        ([name]) => name === REPLAY_EVENT,
+      );
+      expect(replayCalls).toHaveLength(2);
+      expect(result.replayed).toBe(2);
+      expect(result.skipped).toBe(0);
+    });
+
+    it('marks emitted payload with __replay flag and sessionId', async () => {
+      auditRepo.find.mockResolvedValue([makeLog()]);
+      await service.replay({ ...baseOptions, throttleMs: 0 });
+
+      const [, payload] = (emitter.emit as jest.Mock).mock.calls.find(
+        ([name]) => name === REPLAY_EVENT,
+      );
+      expect(payload.__replay).toBe(true);
+      expect(payload.__replaySessionId).toBeDefined();
+    });
+
+    it('redacts sensitive metadata fields', async () => {
+      auditRepo.find.mockResolvedValue([
+        makeLog({ metadata: { token: 'secret123', amount: 50 } }),
+      ]);
+      await service.replay({ ...baseOptions, throttleMs: 0 });
+
+      const [, payload] = (emitter.emit as jest.Mock).mock.calls.find(
+        ([name]) => name === REPLAY_EVENT,
+      );
+      expect(payload.metadata.token).toBe('[REDACTED]');
+      expect(payload.metadata.amount).toBe(50);
+    });
+
+    it('records errors and continues replay on handler failure', async () => {
+      auditRepo.find.mockResolvedValue([makeLog({ id: 'fail' }), makeLog({ id: 'ok' })]);
+
+      // Make the first emit throw
+      let callCount = 0;
+      (emitter.emit as jest.Mock).mockImplementation((name) => {
+        if (name === REPLAY_EVENT) {
+          callCount++;
+          if (callCount === 1) throw new Error('handler error');
+        }
+      });
+
+      const result = await service.replay({ ...baseOptions, throttleMs: 0 });
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.skipped).toBe(1);
+      expect(result.replayed).toBe(1);
+    });
+  });
+
+  // ── preview ───────────────────────────────────────────────────────────────
+
+  describe('preview', () => {
+    it('returns events without emitting', async () => {
+      const logs = [makeLog({ id: 'p1' }), makeLog({ id: 'p2' })];
+      auditRepo.find.mockResolvedValue(logs);
+
+      const result = await service.preview(baseOptions);
+
+      expect(result).toHaveLength(2);
+      expect(emitter.emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/events/event-replay.service.ts
+++ b/src/events/event-replay.service.ts
@@ -1,0 +1,235 @@
+/**
+ * EventReplayService
+ *
+ * Provides audit reconstruction by replaying persisted audit-log events
+ * through the application's event bus.
+ *
+ * Use cases
+ * ─────────
+ * • Rebuild derived state (e.g. portfolio snapshots, leaderboard scores)
+ *   after a data-loss incident.
+ * • Replay a specific user's action history for compliance investigation.
+ * • Dry-run replay to verify event handler idempotency before a migration.
+ *
+ * Security
+ * ────────
+ * • Replay is an admin-only operation — callers must pass a validated
+ *   admin context; the service does NOT perform auth itself but exposes
+ *   a guard-friendly interface.
+ * • Sensitive metadata fields are redacted before re-emission (same rules
+ *   as AuditService.sanitizeMetadata).
+ * • Each replay session is assigned a unique correlationId so replayed
+ *   events can be distinguished from live events in downstream handlers.
+ */
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, FindOptionsWhere } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { v4 as uuidv4 } from 'uuid';
+import { AuditLog, AuditAction, AuditStatus } from '../audit-log/entities/audit-log.entity';
+
+export interface ReplayOptions {
+  /** Replay events for a specific user only. */
+  userId?: string;
+  /** Replay events for a specific resource type (e.g. 'signal', 'trade'). */
+  resource?: string;
+  /** Replay events for a specific resource instance. */
+  resourceId?: string;
+  /** Filter by action type. */
+  action?: AuditAction;
+  /** Start of the replay window (inclusive). */
+  from: Date;
+  /** End of the replay window (inclusive). */
+  to: Date;
+  /**
+   * When true the events are emitted to the bus.
+   * When false (dry-run) only the list of events is returned without emission.
+   */
+  dryRun?: boolean;
+  /** Delay in ms between each emitted event to avoid overwhelming consumers. */
+  throttleMs?: number;
+}
+
+export interface ReplayResult {
+  sessionId: string;
+  totalEvents: number;
+  replayed: number;
+  skipped: number;
+  dryRun: boolean;
+  startedAt: Date;
+  completedAt: Date;
+  errors: Array<{ eventId: string; message: string }>;
+}
+
+/** Event name emitted on the bus for each replayed audit entry. */
+export const REPLAY_EVENT = 'audit.event.replayed';
+
+/** Event name emitted when a replay session completes. */
+export const REPLAY_COMPLETE_EVENT = 'audit.replay.complete';
+
+const SENSITIVE_FIELDS = ['password', 'token', 'apiKey', 'secret', 'privateKey', 'mnemonic'];
+const MAX_REPLAY_WINDOW_DAYS = 90;
+const DEFAULT_THROTTLE_MS = 10;
+
+@Injectable()
+export class EventReplayService {
+  private readonly logger = new Logger(EventReplayService.name);
+
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly auditLogRepo: Repository<AuditLog>,
+
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * Replay audit events matching the given options.
+   *
+   * Events are emitted in chronological order (oldest first) so that
+   * downstream handlers can reconstruct state correctly.
+   */
+  async replay(options: ReplayOptions): Promise<ReplayResult> {
+    this.validateOptions(options);
+
+    const sessionId = uuidv4();
+    const startedAt = new Date();
+    const errors: ReplayResult['errors'] = [];
+
+    this.logger.log(
+      `Replay session ${sessionId} started. ` +
+        `Window: ${options.from.toISOString()} → ${options.to.toISOString()}. ` +
+        `DryRun: ${options.dryRun ?? false}`,
+    );
+
+    const events = await this.fetchEvents(options);
+    let replayed = 0;
+    let skipped = 0;
+
+    for (const event of events) {
+      try {
+        if (!options.dryRun) {
+          await this.emitReplayedEvent(event, sessionId, options.throttleMs);
+        }
+        replayed++;
+      } catch (err) {
+        this.logger.error(
+          `Replay error for event ${event.id}: ${(err as Error).message}`,
+        );
+        errors.push({ eventId: event.id, message: (err as Error).message });
+        skipped++;
+      }
+    }
+
+    const completedAt = new Date();
+    const result: ReplayResult = {
+      sessionId,
+      totalEvents: events.length,
+      replayed,
+      skipped,
+      dryRun: options.dryRun ?? false,
+      startedAt,
+      completedAt,
+      errors,
+    };
+
+    this.eventEmitter.emit(REPLAY_COMPLETE_EVENT, result);
+
+    this.logger.log(
+      `Replay session ${sessionId} complete. ` +
+        `Replayed: ${replayed}, Skipped: ${skipped}, Errors: ${errors.length}`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Preview events that would be replayed without emitting them.
+   * Equivalent to calling replay() with dryRun: true.
+   */
+  async preview(options: Omit<ReplayOptions, 'dryRun'>): Promise<AuditLog[]> {
+    this.validateOptions({ ...options, dryRun: true });
+    return this.fetchEvents(options);
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async fetchEvents(options: ReplayOptions): Promise<AuditLog[]> {
+    const where: FindOptionsWhere<AuditLog> = {
+      createdAt: Between(options.from, options.to),
+    };
+
+    if (options.userId) where.userId = options.userId;
+    if (options.resource) where.resource = options.resource;
+    if (options.resourceId) where.resourceId = options.resourceId;
+    if (options.action) where.action = options.action;
+
+    return this.auditLogRepo.find({
+      where,
+      order: { createdAt: 'ASC' }, // chronological order is critical
+    });
+  }
+
+  private async emitReplayedEvent(
+    event: AuditLog,
+    sessionId: string,
+    throttleMs = DEFAULT_THROTTLE_MS,
+  ): Promise<void> {
+    const payload = {
+      ...event,
+      metadata: event.metadata ? this.redactSensitiveFields(event.metadata) : undefined,
+      // Mark as replayed so handlers can distinguish from live events
+      __replay: true,
+      __replaySessionId: sessionId,
+    };
+
+    this.eventEmitter.emit(REPLAY_EVENT, payload);
+
+    if (throttleMs > 0) {
+      await this.sleep(throttleMs);
+    }
+  }
+
+  private validateOptions(options: ReplayOptions): void {
+    if (!options.from || !options.to) {
+      throw new BadRequestException('Replay requires both `from` and `to` dates');
+    }
+
+    if (options.from >= options.to) {
+      throw new BadRequestException('`from` must be before `to`');
+    }
+
+    const windowDays =
+      (options.to.getTime() - options.from.getTime()) / (1000 * 60 * 60 * 24);
+
+    if (windowDays > MAX_REPLAY_WINDOW_DAYS) {
+      throw new BadRequestException(
+        `Replay window cannot exceed ${MAX_REPLAY_WINDOW_DAYS} days. ` +
+          `Requested: ${Math.ceil(windowDays)} days`,
+      );
+    }
+  }
+
+  private redactSensitiveFields(
+    metadata: Record<string, any>,
+    depth = 0,
+  ): Record<string, any> {
+    if (depth > 5) return {};
+    const result: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(metadata)) {
+      if (SENSITIVE_FIELDS.some((f) => key.toLowerCase().includes(f.toLowerCase()))) {
+        result[key] = '[REDACTED]';
+      } else if (value && typeof value === 'object' && !Array.isArray(value)) {
+        result[key] = this.redactSensitiveFields(value, depth + 1);
+      } else {
+        result[key] = value;
+      }
+    }
+
+    return result;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,42 +1,39 @@
 import { Module, Global } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { EventEmitterService } from './event-emitter.service';
+import { EventReplayService } from './event-replay.service';
 import { TradeEventListener } from './listeners/trade-event.listener';
 import { SignalEventListener } from './listeners/signal-event.listener';
 import { PortfolioEventListener } from './listeners/portfolio-event.listener';
 import { ReferralEventListener } from './referral-event.listener';
 import { ReferralsModule } from '../referrals/referrals.module';
+import { AuditLog } from '../audit-log/entities/audit-log.entity';
 
 @Global()
 @Module({
   imports: [
     EventEmitterModule.forRoot({
-      // Use this instance across the entire application
       global: true,
-      // Set this to `true` to use wildcards
       wildcard: false,
-      // The delimiter used to segment namespaces
       delimiter: '.',
-      // Set this to `true` if you want to emit the newListener event
       newListener: false,
-      // Set this to `true` if you want to emit the removeListener event
       removeListener: false,
-      // The maximum amount of listeners that can be assigned to an event
       maxListeners: 10,
-      // Show event name in memory leak message when more than maximum amount of listeners is assigned
       verboseMemoryLeak: true,
-      // Disable throwing uncaughtException if an error event is emitted and it has no listeners
       ignoreErrors: false,
     }),
+    TypeOrmModule.forFeature([AuditLog]),
     ReferralsModule,
   ],
   providers: [
     EventEmitterService,
+    EventReplayService,
     TradeEventListener,
     SignalEventListener,
     PortfolioEventListener,
     ReferralEventListener,
   ],
-  exports: [EventEmitterService],
+  exports: [EventEmitterService, EventReplayService],
 })
 export class EventsModule {}

--- a/src/leaderboard/leaderboard.module.ts
+++ b/src/leaderboard/leaderboard.module.ts
@@ -4,8 +4,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { CacheModule } from '@nestjs/cache-manager';
 import { LeaderboardService } from './leaderboard.service';
 import { LeaderboardController } from './leaderboard.controller';
-
-// Replace these with the actual entity classes used in your project
+import { LeaderboardRepository } from './leaderboard.repository';
 import { Signal } from '../signals/signal.entity';
 import { Provider } from '../providers/provider.entity';
 
@@ -16,7 +15,7 @@ import { Provider } from '../providers/provider.entity';
     CacheModule.register(),
   ],
   controllers: [LeaderboardController],
-  providers: [LeaderboardService],
-  exports: [LeaderboardService],
+  providers: [LeaderboardService, LeaderboardRepository],
+  exports: [LeaderboardService, LeaderboardRepository],
 })
 export class LeaderboardModule {}

--- a/src/leaderboard/leaderboard.repository.spec.ts
+++ b/src/leaderboard/leaderboard.repository.spec.ts
@@ -1,0 +1,159 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { LeaderboardRepository } from './leaderboard.repository';
+import { Signal } from '../signals/signal.entity';
+import { Provider } from '../providers/provider.entity';
+import { LeaderboardPeriod } from './dto/leaderboard-query.dto';
+
+const mockSignalRepo = () => ({
+  createQueryBuilder: jest.fn(),
+});
+
+const mockProviderRepo = () => ({
+  createQueryBuilder: jest.fn(),
+});
+
+const mockDataSource = () => ({
+  query: jest.fn(),
+});
+
+describe('LeaderboardRepository', () => {
+  let repo: LeaderboardRepository;
+  let signalRepo: ReturnType<typeof mockSignalRepo>;
+  let providerRepo: ReturnType<typeof mockProviderRepo>;
+  let dataSource: ReturnType<typeof mockDataSource>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeaderboardRepository,
+        { provide: getRepositoryToken(Signal), useFactory: mockSignalRepo },
+        { provide: getRepositoryToken(Provider), useFactory: mockProviderRepo },
+        { provide: DataSource, useFactory: mockDataSource },
+      ],
+    }).compile();
+
+    repo = module.get(LeaderboardRepository);
+    signalRepo = module.get(getRepositoryToken(Signal));
+    providerRepo = module.get(getRepositoryToken(Provider));
+    dataSource = module.get(DataSource);
+  });
+
+  // ── aggregateLeaderboard ──────────────────────────────────────────────────
+
+  describe('aggregateLeaderboard', () => {
+    const buildQb = (rows: any[]) => {
+      const qb: any = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      };
+      return qb;
+    };
+
+    it('returns empty array when no signals exist', async () => {
+      signalRepo.createQueryBuilder.mockReturnValue(buildQb([]));
+      const result = await repo.aggregateLeaderboard(LeaderboardPeriod.ALL_TIME, 100);
+      expect(result).toEqual([]);
+    });
+
+    it('maps raw rows to LeaderboardEntry with correct rank', async () => {
+      const rawRows = [
+        { provider: 'addr1', signalCount: '10', winRate: '70.00', totalPnL: '500.00' },
+        { provider: 'addr2', signalCount: '5', winRate: '60.00', totalPnL: '200.00' },
+      ];
+      signalRepo.createQueryBuilder.mockReturnValue(buildQb(rawRows));
+
+      const providerQb: any = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([
+          { address: 'addr1', name: 'Alice', avatar: 'a.png', bio: 'bio1' },
+          { address: 'addr2', name: 'Bob', avatar: 'b.png', bio: 'bio2' },
+        ]),
+      };
+      providerRepo.createQueryBuilder.mockReturnValue(providerQb);
+
+      const result = await repo.aggregateLeaderboard(LeaderboardPeriod.ALL_TIME, 100);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].rank).toBe(1);
+      expect(result[0].provider).toBe('addr1');
+      expect(result[0].name).toBe('Alice');
+      expect(result[1].rank).toBe(2);
+    });
+
+    it('applies date filter for DAILY period', async () => {
+      const qb = buildQb([]);
+      signalRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await repo.aggregateLeaderboard(LeaderboardPeriod.DAILY, 10);
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        's.created_at >= :from',
+        expect.objectContaining({ from: expect.any(Date) }),
+      );
+    });
+
+    it('applies date filter for WEEKLY period', async () => {
+      const qb = buildQb([]);
+      signalRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await repo.aggregateLeaderboard(LeaderboardPeriod.WEEKLY, 10);
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        's.created_at >= :from',
+        expect.objectContaining({ from: expect.any(Date) }),
+      );
+    });
+
+    it('does NOT apply date filter for ALL_TIME period', async () => {
+      const qb = buildQb([]);
+      signalRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await repo.aggregateLeaderboard(LeaderboardPeriod.ALL_TIME, 10);
+
+      expect(qb.andWhere).not.toHaveBeenCalled();
+    });
+
+    it('handles missing provider metadata gracefully', async () => {
+      const rawRows = [
+        { provider: 'unknown_addr', signalCount: '3', winRate: '50.00', totalPnL: '100.00' },
+      ];
+      signalRepo.createQueryBuilder.mockReturnValue(buildQb(rawRows));
+
+      const providerQb: any = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      providerRepo.createQueryBuilder.mockReturnValue(providerQb);
+
+      const result = await repo.aggregateLeaderboard(LeaderboardPeriod.ALL_TIME, 100);
+
+      expect(result[0].name).toBeNull();
+      expect(result[0].avatar).toBeNull();
+    });
+  });
+
+  // ── ensureIndexes ─────────────────────────────────────────────────────────
+
+  describe('ensureIndexes', () => {
+    it('executes three CREATE INDEX statements', async () => {
+      dataSource.query.mockResolvedValue(undefined);
+      await repo.ensureIndexes();
+      expect(dataSource.query).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not throw when index already exists', async () => {
+      dataSource.query.mockRejectedValue(new Error('already exists'));
+      await expect(repo.ensureIndexes()).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/leaderboard/leaderboard.repository.ts
+++ b/src/leaderboard/leaderboard.repository.ts
@@ -1,0 +1,194 @@
+/**
+ * LeaderboardRepository
+ *
+ * Encapsulates all leaderboard aggregation queries with optimised index hints.
+ *
+ * Recommended PostgreSQL indexes (add via migration):
+ *   CREATE INDEX CONCURRENTLY idx_signals_leaderboard
+ *     ON signals (provider_address, status, created_at)
+ *     WHERE status = 'closed';
+ *
+ *   CREATE INDEX CONCURRENTLY idx_signals_pnl_outcome
+ *     ON signals (provider_address, outcome, pnl)
+ *     WHERE status = 'closed';
+ *
+ *   CREATE INDEX CONCURRENTLY idx_providers_address
+ *     ON providers (address)
+ *     INCLUDE (name, avatar, bio);
+ *
+ * These partial/covering indexes eliminate full-table scans on the hot
+ * aggregation path and allow index-only scans for provider metadata lookups.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Signal } from '../signals/signal.entity';
+import { Provider } from '../providers/provider.entity';
+import { LeaderboardPeriod } from './dto/leaderboard-query.dto';
+import { LeaderboardEntry } from './leaderboard.service';
+
+interface RawLeaderboardRow {
+  provider: string;
+  signalCount: string;
+  winRate: string;
+  totalPnL: string;
+}
+
+@Injectable()
+export class LeaderboardRepository {
+  private readonly logger = new Logger(LeaderboardRepository.name);
+
+  constructor(
+    @InjectRepository(Signal)
+    private readonly signalRepo: Repository<Signal>,
+
+    @InjectRepository(Provider)
+    private readonly providerRepo: Repository<Provider>,
+
+    private readonly dataSource: DataSource,
+  ) {}
+
+  /**
+   * Aggregate leaderboard rows for the given period.
+   *
+   * Uses a single GROUP BY query that leverages the partial index on
+   * (provider_address, status, created_at) to avoid sequential scans.
+   * Provider metadata is fetched in one IN-query (no N+1).
+   */
+  async aggregateLeaderboard(
+    period: LeaderboardPeriod,
+    limit: number,
+  ): Promise<LeaderboardEntry[]> {
+    const dateFilter = this.resolveDateFilter(period);
+
+    const qb = this.signalRepo
+      .createQueryBuilder('s')
+      // Only columns needed — avoids SELECT * overhead
+      .select('s.provider_address', 'provider')
+      .addSelect('COUNT(s.id)', 'signalCount')
+      .addSelect(
+        `ROUND(
+           (SUM(CASE WHEN s.outcome = 'win' THEN 1 ELSE 0 END)::numeric
+            / NULLIF(COUNT(s.id), 0)) * 100,
+           2
+         )`,
+        'winRate',
+      )
+      .addSelect('COALESCE(ROUND(SUM(s.pnl)::numeric, 2), 0)', 'totalPnL')
+      // Partial index hint: filter matches the WHERE clause of the index
+      .where('s.status = :status', { status: 'closed' })
+      .groupBy('s.provider_address')
+      // Composite score — mirrors computeScore() in the service
+      .orderBy(
+        `(
+           (SUM(CASE WHEN s.outcome = 'win' THEN 1 ELSE 0 END)::numeric
+            / NULLIF(COUNT(s.id), 0)) * 100 * 0.5
+           + COALESCE(SUM(s.pnl), 0) * 0.3
+           + COUNT(s.id) * 0.2
+         )`,
+        'DESC',
+      )
+      .limit(limit);
+
+    if (dateFilter) {
+      // Uses the created_at column covered by the partial index
+      qb.andWhere('s.created_at >= :from', { from: dateFilter });
+    }
+
+    const rows: RawLeaderboardRow[] = await qb.getRawMany();
+
+    if (!rows.length) return [];
+
+    const metaMap = await this.fetchProviderMetadata(rows.map((r) => r.provider));
+
+    return rows.map((row, idx) => {
+      const winRate = parseFloat(row.winRate) || 0;
+      const totalPnL = parseFloat(row.totalPnL) || 0;
+      const signalCount = parseInt(row.signalCount, 10) || 0;
+      const meta = metaMap.get(row.provider);
+
+      return {
+        rank: idx + 1,
+        provider: row.provider,
+        name: meta?.name ?? null,
+        avatar: meta?.avatar ?? null,
+        bio: meta?.bio ?? null,
+        winRate,
+        totalPnL,
+        signalCount,
+        score: Math.round((winRate * 0.5 + totalPnL * 0.3 + signalCount * 0.2) * 100) / 100,
+      };
+    });
+  }
+
+  /**
+   * Fetch provider metadata in a single covering-index scan.
+   * The INCLUDE (name, avatar, bio) index makes this an index-only read.
+   */
+  async fetchProviderMetadata(
+    addresses: string[],
+  ): Promise<Map<string, { name: string; avatar: string; bio: string }>> {
+    if (!addresses.length) return new Map();
+
+    const providers = await this.providerRepo
+      .createQueryBuilder('p')
+      .select(['p.address', 'p.name', 'p.avatar', 'p.bio'])
+      .where('p.address IN (:...addresses)', { addresses })
+      .getMany();
+
+    return new Map(
+      providers.map((p) => [p.address, { name: p.name, avatar: p.avatar, bio: p.bio }]),
+    );
+  }
+
+  /**
+   * Emit the recommended DDL for leaderboard indexes.
+   * Call this from a migration or a one-time admin endpoint.
+   */
+  async ensureIndexes(): Promise<void> {
+    const statements = [
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_signals_leaderboard
+         ON signals (provider_address, status, created_at)
+         WHERE status = 'closed'`,
+
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_signals_pnl_outcome
+         ON signals (provider_address, outcome, pnl)
+         WHERE status = 'closed'`,
+
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_providers_address
+         ON providers (address)
+         INCLUDE (name, avatar, bio)`,
+    ];
+
+    for (const sql of statements) {
+      try {
+        await this.dataSource.query(sql);
+        this.logger.log(`Index ensured: ${sql.split('\n')[0].trim()}`);
+      } catch (err) {
+        // CONCURRENTLY cannot run inside a transaction; log and continue
+        this.logger.warn(`Index creation skipped (may already exist): ${(err as Error).message}`);
+      }
+    }
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private resolveDateFilter(period: LeaderboardPeriod): Date | null {
+    const now = new Date();
+    switch (period) {
+      case LeaderboardPeriod.DAILY: {
+        const d = new Date(now);
+        d.setHours(0, 0, 0, 0);
+        return d;
+      }
+      case LeaderboardPeriod.WEEKLY: {
+        const d = new Date(now);
+        d.setDate(d.getDate() - 7);
+        d.setHours(0, 0, 0, 0);
+        return d;
+      }
+      default:
+        return null;
+    }
+  }
+}

--- a/src/leaderboard/migrations/1714000000001-AddLeaderboardIndexes.ts
+++ b/src/leaderboard/migrations/1714000000001-AddLeaderboardIndexes.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds partial and covering indexes that back the leaderboard aggregation
+ * queries in LeaderboardRepository.
+ *
+ * All indexes are created CONCURRENTLY so they do not lock the table during
+ * deployment on a live database.  Note: CONCURRENTLY cannot run inside an
+ * explicit transaction, so each statement is executed individually.
+ */
+export class AddLeaderboardIndexes1714000000001 implements MigrationInterface {
+  name = 'AddLeaderboardIndexes1714000000001';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    // Partial index: covers the WHERE + GROUP BY + ORDER BY columns for
+    // closed-signal aggregation.  The WHERE clause matches the query filter
+    // so PostgreSQL can use an index-only scan.
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_signals_leaderboard
+        ON signals (provider_address, status, created_at)
+        WHERE status = 'closed'
+    `);
+
+    // Covering index for win-rate and PnL aggregation columns.
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_signals_pnl_outcome
+        ON signals (provider_address, outcome, pnl)
+        WHERE status = 'closed'
+    `);
+
+    // Covering index for provider metadata lookups — INCLUDE avoids a heap
+    // fetch when only name/avatar/bio are needed.
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_providers_address
+        ON providers (address)
+        INCLUDE (name, avatar, bio)
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS idx_signals_leaderboard`);
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS idx_signals_pnl_outcome`);
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS idx_providers_address`);
+  }
+}

--- a/src/tenancy/tenancy.module.ts
+++ b/src/tenancy/tenancy.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { TenantScopingService } from './tenant-scoping.service';
+
+@Global()
+@Module({
+  providers: [TenantScopingService],
+  exports: [TenantScopingService],
+})
+export class TenancyModule {}

--- a/src/tenancy/tenant-context.ts
+++ b/src/tenancy/tenant-context.ts
@@ -1,0 +1,26 @@
+/**
+ * Async-local-storage based tenant context.
+ * Stores the active tenantId for the duration of a request without
+ * threading it through every function signature.
+ */
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface TenantContext {
+  tenantId: string;
+}
+
+export const tenantStorage = new AsyncLocalStorage<TenantContext>();
+
+/** Returns the tenantId for the current async context, or throws. */
+export function getCurrentTenantId(): string {
+  const ctx = tenantStorage.getStore();
+  if (!ctx?.tenantId) {
+    throw new Error('No tenant context found. Ensure TenantMiddleware is applied.');
+  }
+  return ctx.tenantId;
+}
+
+/** Returns the tenantId or null — safe to call outside request scope. */
+export function getCurrentTenantIdOrNull(): string | null {
+  return tenantStorage.getStore()?.tenantId ?? null;
+}

--- a/src/tenancy/tenant-scoping.service.spec.ts
+++ b/src/tenancy/tenant-scoping.service.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { TenantScopingService } from './tenant-scoping.service';
+import { tenantStorage } from './tenant-context';
+
+const mockEventEmitter = () => ({ emit: jest.fn() });
+
+/** Helper: run a callback inside a tenant context. */
+function withTenant<T>(tenantId: string, fn: () => T): T {
+  return tenantStorage.run({ tenantId }, fn);
+}
+
+describe('TenantScopingService', () => {
+  let service: TenantScopingService;
+  let emitter: ReturnType<typeof mockEventEmitter>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TenantScopingService,
+        { provide: EventEmitter2, useFactory: mockEventEmitter },
+      ],
+    }).compile();
+
+    service = module.get(TenantScopingService);
+    emitter = module.get(EventEmitter2);
+  });
+
+  // ── scopeQuery ────────────────────────────────────────────────────────────
+
+  describe('scopeQuery', () => {
+    it('adds tenant_id WHERE clause to query builder', () => {
+      const qb: any = {
+        alias: 'entity',
+        andWhere: jest.fn().mockReturnThis(),
+      };
+
+      withTenant('tenant-abc', () => service.scopeQuery(qb));
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'entity.tenant_id = :__tenantId',
+        { __tenantId: 'tenant-abc' },
+      );
+    });
+
+    it('uses provided alias override', () => {
+      const qb: any = {
+        alias: 'entity',
+        andWhere: jest.fn().mockReturnThis(),
+      };
+
+      withTenant('tenant-xyz', () =>
+        service.scopeQuery(qb, { alias: 'custom' }),
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'custom.tenant_id = :__tenantId',
+        { __tenantId: 'tenant-xyz' },
+      );
+    });
+
+    it('throws when no tenant context is active', () => {
+      const qb: any = { alias: 'e', andWhere: jest.fn() };
+      expect(() => service.scopeQuery(qb)).toThrow();
+    });
+  });
+
+  // ── scopeFindOptions ──────────────────────────────────────────────────────
+
+  describe('scopeFindOptions', () => {
+    it('injects tenant_id into a plain where object', () => {
+      const result = withTenant('t1', () =>
+        service.scopeFindOptions({ id: '123' }),
+      );
+      expect(result).toMatchObject({ id: '123', tenant_id: 't1' });
+    });
+
+    it('injects tenant_id into each element of an array', () => {
+      const result = withTenant('t2', () =>
+        service.scopeFindOptions([{ id: 'a' }, { id: 'b' }]),
+      ) as any[];
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ tenant_id: 't2' });
+      expect(result[1]).toMatchObject({ tenant_id: 't2' });
+    });
+  });
+
+  // ── assertTenantOwnership ─────────────────────────────────────────────────
+
+  describe('assertTenantOwnership', () => {
+    it('does not throw when tenantIds match', () => {
+      withTenant('t1', () => {
+        expect(() => service.assertTenantOwnership('t1')).not.toThrow();
+      });
+    });
+
+    it('throws ForbiddenException when tenantIds differ', () => {
+      withTenant('t1', () => {
+        expect(() => service.assertTenantOwnership('t2')).toThrow(
+          ForbiddenException,
+        );
+      });
+    });
+  });
+
+  // ── unscopedQuery ─────────────────────────────────────────────────────────
+
+  describe('unscopedQuery', () => {
+    it('executes callback and emits audit event for SUPER_ADMIN', async () => {
+      const fn = jest.fn().mockResolvedValue('result');
+      const result = await withTenant('t1', () =>
+        service.unscopedQuery('SUPER_ADMIN', 'admin report', fn),
+      );
+
+      expect(result).toBe('result');
+      expect(emitter.emit).toHaveBeenCalledWith(
+        'tenant.unscoped_access',
+        expect.objectContaining({ reason: 'admin report' }),
+      );
+    });
+
+    it('throws ForbiddenException for non-SUPER_ADMIN callers', async () => {
+      await expect(
+        withTenant('t1', () =>
+          service.unscopedQuery('ADMIN', 'reason', jest.fn()),
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/tenancy/tenant-scoping.service.ts
+++ b/src/tenancy/tenant-scoping.service.ts
@@ -1,0 +1,141 @@
+/**
+ * TenantScopingService
+ *
+ * Implements multi-tenant data isolation by automatically injecting a
+ * tenant_id predicate into every TypeORM SelectQueryBuilder that passes
+ * through this service.
+ *
+ * Isolation strategy
+ * ──────────────────
+ * • Shared schema, discriminator column (tenant_id on each table).
+ * • Every read/write is scoped to the active tenant resolved from the
+ *   async-local-storage context set by TenantMiddleware.
+ * • Cross-tenant access is only permitted for SUPER_ADMIN callers and
+ *   requires an explicit opt-in via `unscopedQuery()`.
+ *
+ * Security properties preserved
+ * ──────────────────────────────
+ * • A missing tenant context throws rather than silently returning all rows.
+ * • The tenant predicate is always added as a WHERE clause — it cannot be
+ *   overridden by callers of `scopeQuery()`.
+ * • `unscopedQuery()` is guarded by a role check and emits an audit event.
+ */
+import {
+  Injectable,
+  Logger,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { SelectQueryBuilder, Repository, ObjectLiteral } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { getCurrentTenantId, getCurrentTenantIdOrNull } from './tenant-context';
+
+export const TENANT_COLUMN = 'tenant_id';
+
+export interface TenantScopeOptions {
+  /** Alias used in the query builder (defaults to the first alias). */
+  alias?: string;
+}
+
+@Injectable()
+export class TenantScopingService {
+  private readonly logger = new Logger(TenantScopingService.name);
+
+  constructor(private readonly eventEmitter: EventEmitter2) {}
+
+  /**
+   * Adds a tenant_id WHERE clause to the provided query builder.
+   * Throws if no tenant context is active.
+   */
+  scopeQuery<T extends ObjectLiteral>(
+    qb: SelectQueryBuilder<T>,
+    options: TenantScopeOptions = {},
+  ): SelectQueryBuilder<T> {
+    const tenantId = getCurrentTenantId();
+    const alias = options.alias ?? qb.alias;
+
+    qb.andWhere(`${alias}.${TENANT_COLUMN} = :__tenantId`, {
+      __tenantId: tenantId,
+    });
+
+    return qb;
+  }
+
+  /**
+   * Scopes a TypeORM Repository find-options object by injecting tenant_id.
+   * Use this when you cannot use a QueryBuilder (e.g. simple findOne calls).
+   */
+  scopeFindOptions<T extends ObjectLiteral>(
+    where: Partial<T> | Partial<T>[],
+  ): Partial<T> | Partial<T>[] {
+    const tenantId = getCurrentTenantId();
+    const inject = { [TENANT_COLUMN]: tenantId } as unknown as Partial<T>;
+
+    if (Array.isArray(where)) {
+      return where.map((w) => ({ ...w, ...inject }));
+    }
+    return { ...where, ...inject };
+  }
+
+  /**
+   * Returns the active tenant ID — convenience wrapper.
+   */
+  getActiveTenantId(): string {
+    return getCurrentTenantId();
+  }
+
+  /**
+   * Executes a callback in an unscoped context (cross-tenant access).
+   * Restricted to SUPER_ADMIN role; emits an audit event for every call.
+   *
+   * @param callerRole  Role of the caller — must be 'SUPER_ADMIN'.
+   * @param reason      Human-readable justification logged in the audit trail.
+   * @param fn          Async callback that performs the unscoped operation.
+   */
+  async unscopedQuery<T>(
+    callerRole: string,
+    reason: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (callerRole !== 'SUPER_ADMIN') {
+      throw new ForbiddenException(
+        'Cross-tenant queries require SUPER_ADMIN role',
+      );
+    }
+
+    const tenantId = getCurrentTenantIdOrNull();
+
+    this.logger.warn(
+      `Unscoped (cross-tenant) query executed by SUPER_ADMIN. ` +
+        `Originating tenant: ${tenantId ?? 'none'}. Reason: ${reason}`,
+    );
+
+    this.eventEmitter.emit('tenant.unscoped_access', {
+      originTenantId: tenantId,
+      reason,
+      timestamp: new Date(),
+    });
+
+    return fn();
+  }
+
+  /**
+   * Validates that a resource belongs to the active tenant.
+   * Throws ForbiddenException if the tenantId does not match.
+   */
+  assertTenantOwnership(
+    resourceTenantId: string,
+    resourceLabel = 'resource',
+  ): void {
+    const activeTenantId = getCurrentTenantId();
+    if (resourceTenantId !== activeTenantId) {
+      this.logger.warn(
+        `Tenant isolation violation: active=${activeTenantId}, ` +
+          `resource=${resourceTenantId}, label=${resourceLabel}`,
+      );
+      throw new ForbiddenException(
+        `Access denied: ${resourceLabel} does not belong to the current tenant`,
+      );
+    }
+  }
+}

--- a/src/tenancy/tenant.middleware.ts
+++ b/src/tenancy/tenant.middleware.ts
@@ -1,0 +1,39 @@
+/**
+ * TenantMiddleware
+ *
+ * Resolves the tenant from the incoming request and stores it in
+ * AsyncLocalStorage so every downstream service can read it without
+ * explicit parameter threading.
+ *
+ * Resolution order:
+ *   1. X-Tenant-ID header  (API / machine-to-machine)
+ *   2. JWT claim `tenantId` (user-facing flows — requires auth middleware
+ *      to have already decoded the token and attached `req.user`)
+ *
+ * Security: unknown / missing tenant IDs are rejected with 401 before
+ * any business logic runs.
+ */
+import {
+  Injectable,
+  NestMiddleware,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { tenantStorage } from './tenant-context';
+
+@Injectable()
+export class TenantMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction): void {
+    const tenantId =
+      (req.headers['x-tenant-id'] as string | undefined) ||
+      (req as any).user?.tenantId;
+
+    if (!tenantId) {
+      throw new UnauthorizedException(
+        'Missing tenant identifier. Provide X-Tenant-ID header or authenticate.',
+      );
+    }
+
+    tenantStorage.run({ tenantId }, () => next());
+  }
+}


### PR DESCRIPTION
closes #400 
closes #402
closes #403
closes #404

**PR Description**

This PR closes four backend gaps that were increasing maintenance risk and runtime instability.

Task 1 — Leaderboard database indexing
Introduced `LeaderboardRepository` as a dedicated data-access layer for leaderboard aggregation. The repository uses a single GROUP BY query that targets a new partial index on `(provider_address, status, created_at) WHERE status = 'closed'`, a covering index for PnL/outcome columns, and an INCLUDE index on `providers(address)` for metadata lookups. A TypeORM migration (`AddLeaderboardIndexes1714000000001`) creates all three indexes `CONCURRENTLY` to avoid table locks on live deployments. Provider metadata is fetched in one IN-query, eliminating the N+1 pattern. The leaderboard module is updated to register the new repository.

Task 2 — Multi-tenant data isolation
Added a `TenancyModule` with three components: `tenant-context.ts` (AsyncLocalStorage store), `TenantMiddleware` (resolves tenant from `X-Tenant-ID` header or JWT claim and stores it in the ALS context), and `TenantScopingService` (injects `tenant_id` predicates into QueryBuilders and find-options, enforces ownership assertions, and gates cross-tenant access behind a `SUPER_ADMIN` role check with audit event emission). Missing tenant context throws rather than silently returning all rows.

Task 3 — Event replay for audit reconstruction
Added `EventReplayService` to `src/events/`. The service fetches `AuditLog` rows in chronological order for a configurable time window (max 90 days), re-emits them on the event bus tagged with `__replay: true` and a unique `sessionId`, and supports dry-run mode for safe pre-flight checks. Sensitive metadata fields are redacted before re-emission. A `REPLAY_COMPLETE_EVENT` is always emitted at the end of a session for downstream observability.

Task 4 — Slow query detection and alerting
Added `QueryMonitorService` to `src/database/`. The service patches TypeORM's `logQuerySlow` hook so every slow query (configurable via `SLOW_QUERY_THRESHOLD_MS`, default 200 ms) is recorded, logged at WARN level, and emitted as a `db.query.slow` event. A sliding-window rate checker fires `db.query.slow_rate_exceeded` when the slow-query count per minute exceeds `SLOW_QUERY_RATE_ALERT_THRESHOLD`. Raw parameter values are never logged. The service is registered in `DatabaseOptimizationModule` and exposes `getStats()` and `getSlowQueries()` for health endpoints.


