### PR TITLE
feat: static asset caching, audit logging, rate limiting, tax report export (#474 #481 #482 #484)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -66,6 +66,7 @@ import { CurrencyModule } from './currency/currency.module';
 import { ImportModule } from './import/import.module';
 import { ExportsModule } from './exports/exports.module';
 import { HttpRetryModule } from './http/http.module';
+import { AuditModule } from './audit-log/audit.module';
  main
  main
  main
@@ -195,6 +196,7 @@ import { HttpRetryModule } from './http/http.module';
     ImportModule,
     ExportsModule,
     HttpRetryModule,
+    AuditModule,
  main
  main
  main

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -7,10 +7,36 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  Header,
+  Res,
+  Req,
 } from '@nestjs/common';
+import { Response, Request } from 'express';
+import * as crypto from 'crypto';
 import { AssetsService } from './assets.service';
 import { CreateAssetDto, AssetPriceDto, AssetDto, AssetPairDto } from './dto/asset-price.dto';
 import { Asset } from './entities/asset.entity';
+
+/** Cache-Control max-age for static asset metadata (1 hour) */
+const ASSET_CACHE_TTL = 3600;
+/** Cache-Control max-age for live price data (30 seconds) */
+const PRICE_CACHE_TTL = 30;
+
+function generateETag(data: unknown): string {
+  return `"${crypto.createHash('md5').update(JSON.stringify(data)).digest('hex')}"`;
+}
+
+function setCacheHeaders(
+  res: Response,
+  data: unknown,
+  maxAge: number,
+): boolean {
+  const etag = generateETag(data);
+  res.setHeader('ETag', etag);
+  res.setHeader('Cache-Control', `public, max-age=${maxAge}, stale-while-revalidate=${maxAge * 2}`);
+  res.setHeader('Vary', 'Accept-Encoding');
+  return etag === res.req?.headers?.['if-none-match'];
+}
 
 @Controller('assets')
 export class AssetsController {
@@ -21,8 +47,13 @@ export class AssetsController {
    * GET /assets
    */
   @Get()
-  async getAllAssets(): Promise<AssetDto[]> {
-    return this.assetsService.getAllAssets();
+  async getAllAssets(@Res({ passthrough: true }) res: Response): Promise<AssetDto[] | void> {
+    const data = await this.assetsService.getAllAssets();
+    if (setCacheHeaders(res, data, ASSET_CACHE_TTL)) {
+      res.status(304).end();
+      return;
+    }
+    return data;
   }
 
   /**
@@ -30,8 +61,13 @@ export class AssetsController {
    * GET /assets/pairs
    */
   @Get('pairs')
-  async getAssetPairs(): Promise<AssetPairDto[]> {
-    return this.assetsService.getAssetPairs();
+  async getAssetPairs(@Res({ passthrough: true }) res: Response): Promise<AssetPairDto[] | void> {
+    const data = await this.assetsService.getAssetPairs();
+    if (setCacheHeaders(res, data, ASSET_CACHE_TTL)) {
+      res.status(304).end();
+      return;
+    }
+    return data;
   }
 
   /**
@@ -40,7 +76,10 @@ export class AssetsController {
    * Example: GET /assets/price/XLM/USDC
    */
   @Get('price/:pair')
-  async getAssetPrice(@Param('pair') pair: string): Promise<AssetPriceDto | { error: string }> {
+  async getAssetPrice(
+    @Param('pair') pair: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<AssetPriceDto | { error: string } | void> {
     if (!pair || !pair.includes('/')) {
       throw new BadRequestException('Invalid pair format. Use BASE/COUNTER format.');
     }
@@ -51,6 +90,10 @@ export class AssetsController {
       return { error: `Unable to fetch price for pair ${pair}` };
     }
 
+    if (setCacheHeaders(res, price, PRICE_CACHE_TTL)) {
+      res.status(304).end();
+      return;
+    }
     return price;
   }
 
@@ -62,13 +105,15 @@ export class AssetsController {
   async validateAssetPair(
     @Param('baseCode') baseCode: string,
     @Param('counterCode') counterCode: string,
-  ): Promise<{ isValid: boolean; pair: string }> {
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ isValid: boolean; pair: string } | void> {
     const isValid = await this.assetsService.validateAssetPair(baseCode, counterCode);
-
-    return {
-      isValid,
-      pair: `${baseCode}/${counterCode}`,
-    };
+    const data = { isValid, pair: `${baseCode}/${counterCode}` };
+    if (setCacheHeaders(res, data, ASSET_CACHE_TTL)) {
+      res.status(304).end();
+      return;
+    }
+    return data;
   }
 
   /**
@@ -76,9 +121,12 @@ export class AssetsController {
    * GET /assets/:code
    */
   @Get(':code')
-  async getAssetByCode(@Param('code') code: string): Promise<AssetDto> {
+  async getAssetByCode(
+    @Param('code') code: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<AssetDto | void> {
     const asset = await this.assetsService.getAssetByCode(code);
-    return {
+    const data: AssetDto = {
       id: asset.id,
       code: asset.code,
       issuer: asset.issuer,
@@ -90,6 +138,11 @@ export class AssetsController {
       type: asset.type,
       createdAt: asset.createdAt,
     };
+    if (setCacheHeaders(res, data, ASSET_CACHE_TTL)) {
+      res.status(304).end();
+      return;
+    }
+    return data;
   }
 
   /**

--- a/src/audit-log/audit.controller.ts
+++ b/src/audit-log/audit.controller.ts
@@ -17,6 +17,8 @@ import {
   ApiOkResponse,
   ApiParam,
 } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from '../admin/guards/admin-role.guard';
 import { AuditService, AuditLogPage } from './audit.service';
 import { AuditQueryDto } from './dto/audit-query.dto';
 import { AuditLog } from './entities/audit-log.entity';
@@ -24,16 +26,18 @@ import { AuditLog } from './entities/audit-log.entity';
 /**
  * Audit Controller — read-only query surface for audit logs.
  * Mutating operations (create / update / delete) are intentionally absent.
+ * All endpoints require admin authentication (issue #481).
  */
 @ApiTags('Audit Logs')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
 @Controller('audit')
 export class AuditController {
   constructor(private readonly auditService: AuditService) {}
 
-  @Get()
+  @Get('logs')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Query audit logs with filtering and pagination' })
+  @ApiOperation({ summary: 'Query audit logs with filtering and pagination (admin only)' })
   @ApiOkResponse({ description: 'Paginated audit log results' })
   async query(@Query() dto: AuditQueryDto): Promise<AuditLogPage> {
     return this.auditService.query(dto);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import { AuthChallengeDto } from './dto/auth-challenge.dto';
 import { VerifySignatureDto } from './dto/verify-signature.dto';
 import { Audit } from '../audit-log/interceptors/audit-logging.interceptor';
 import { AuditAction } from '../audit-log/entities/audit-log.entity';
+import { RateLimit, RateLimitTier } from '../common/decorators/rate-limit.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -12,6 +13,7 @@ export class AuthController {
 
     @Post('challenge')
     @HttpCode(HttpStatus.OK)
+    @RateLimit({ tier: RateLimitTier.PUBLIC, limit: 20, window: 60 })
     async getChallenge(@Body() dto: AuthChallengeDto) {
         if (!dto.publicKey) {
             throw new Error('Public Key is required for now');
@@ -22,6 +24,7 @@ export class AuthController {
     @Post('verify')
     @Audit({ action: AuditAction.LOGIN, resource: 'auth' })
     @HttpCode(HttpStatus.OK)
+    @RateLimit({ tier: RateLimitTier.PUBLIC, limit: 10, window: 60 })
     async verify(@Body() dto: VerifySignatureDto) {
         return this.authService.verifySignature(dto);
     }

--- a/src/common/guards/rate-limit.guard.spec.ts
+++ b/src/common/guards/rate-limit.guard.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { RateLimitGuard } from './rate-limit.guard';
+import { RateLimitTier, RATE_LIMIT_KEY } from '../decorators/rate-limit.decorator';
+
+const mockCacheManager = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+
+const mockReflector = {
+  get: jest.fn(),
+};
+
+function buildContext(
+  user?: { id: string },
+  ip = '127.0.0.1',
+): ExecutionContext {
+  const response = { setHeader: jest.fn() };
+  return {
+    getHandler: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => ({
+        user,
+        headers: {},
+        socket: { remoteAddress: ip },
+      }),
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('RateLimitGuard (issue #482)', () => {
+  let guard: RateLimitGuard;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateLimitGuard,
+        { provide: Reflector, useValue: mockReflector },
+        { provide: CACHE_MANAGER, useValue: mockCacheManager },
+      ],
+    }).compile();
+
+    guard = module.get(RateLimitGuard);
+  });
+
+  it('allows request when under limit', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.PUBLIC });
+    mockCacheManager.get.mockResolvedValue({ count: 5, resetTime: Date.now() + 60_000 });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    await expect(guard.canActivate(buildContext(undefined, '10.0.0.1'))).resolves.toBe(true);
+  });
+
+  it('returns 429 when limit exceeded', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.PUBLIC });
+    mockCacheManager.get.mockResolvedValue({ count: 100, resetTime: Date.now() + 60_000 });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    await expect(guard.canActivate(buildContext(undefined, '10.0.0.2'))).rejects.toThrow(
+      new HttpException(
+        expect.objectContaining({ statusCode: HttpStatus.TOO_MANY_REQUESTS }),
+        HttpStatus.TOO_MANY_REQUESTS,
+      ),
+    );
+  });
+
+  it('uses user ID as identifier for authenticated tier', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.AUTHENTICATED });
+    mockCacheManager.get.mockResolvedValue(null);
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    await expect(guard.canActivate(buildContext({ id: 'user-abc' }))).resolves.toBe(true);
+
+    const cacheKey: string = mockCacheManager.set.mock.calls[0][0];
+    expect(cacheKey).toContain('user:user-abc');
+  });
+
+  it('resets counter after window expires', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.TRADE });
+    mockCacheManager.get.mockResolvedValue({ count: 10, resetTime: Date.now() - 1 });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    await expect(guard.canActivate(buildContext({ id: 'user-xyz' }))).resolves.toBe(true);
+  });
+
+  it('respects custom limit from per-endpoint decorator', async () => {
+    // Simulate @RateLimit({ tier: PUBLIC, limit: 5, window: 60 })
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.PUBLIC, limit: 5, window: 60 });
+    mockCacheManager.get.mockResolvedValue({ count: 5, resetTime: Date.now() + 60_000 });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    await expect(guard.canActivate(buildContext(undefined, '10.0.0.3'))).rejects.toThrow(
+      new HttpException(
+        expect.objectContaining({ statusCode: HttpStatus.TOO_MANY_REQUESTS }),
+        HttpStatus.TOO_MANY_REQUESTS,
+      ),
+    );
+  });
+
+  it('sets X-RateLimit-* headers on successful request', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.AUTHENTICATED, limit: 100 });
+    mockCacheManager.get.mockResolvedValue({ count: 10, resetTime: Date.now() + 60_000 });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    const ctx = buildContext({ id: 'user-headers' });
+    await guard.canActivate(ctx);
+
+    const response = ctx.switchToHttp().getResponse() as { setHeader: jest.Mock };
+    expect(response.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', expect.any(Number));
+    expect(response.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', expect.any(Number));
+    expect(response.setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', expect.any(Number));
+  });
+});

--- a/src/common/rate-limit.module.ts
+++ b/src/common/rate-limit.module.ts
@@ -1,5 +1,6 @@
 import { Module, Global } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { RateLimitGuard } from './guards/rate-limit.guard';
 import { CacheModule } from '../cache/cache.module';
 
@@ -7,6 +8,10 @@ import { CacheModule } from '../cache/cache.module';
 @Module({
   imports: [CacheModule],
   providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
     {
       provide: APP_GUARD,
       useClass: RateLimitGuard,

--- a/src/exports/dto/tax-report.dto.ts
+++ b/src/exports/dto/tax-report.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsOptional, IsDateString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ExportFormat } from '../entities/bulk-export.entity';
+
+export class TaxReportDto {
+  @ApiProperty({ description: 'Start of the tax reporting period (ISO 8601)' })
+  @IsDateString()
+  startDate!: string;
+
+  @ApiProperty({ description: 'End of the tax reporting period (ISO 8601)' })
+  @IsDateString()
+  endDate!: string;
+
+  @ApiPropertyOptional({ enum: ExportFormat, default: ExportFormat.CSV })
+  @IsOptional()
+  @IsEnum(ExportFormat)
+  format?: ExportFormat;
+}

--- a/src/exports/entities/bulk-export.entity.ts
+++ b/src/exports/entities/bulk-export.entity.ts
@@ -24,6 +24,7 @@ export enum ExportType {
   CONTEST_RESULTS = 'contest_results',
   SIGNALS = 'signals',
   PORTFOLIO = 'portfolio',
+  TAX_REPORT = 'tax_report',
 }
 
 @Entity('bulk_exports')

--- a/src/exports/exports.controller.ts
+++ b/src/exports/exports.controller.ts
@@ -14,8 +14,11 @@ import {
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ExportsService } from './exports.service';
 import { InitiateExportDto } from './dto/initiate-export.dto';
+import { TaxReportDto } from './dto/tax-report.dto';
 import { Audit } from '../audit-log/interceptors/audit-logging.interceptor';
 import { AuditAction } from '../audit-log/entities/audit-log.entity';
+import { ExportType } from './entities/bulk-export.entity';
+import { RateLimit, RateLimitTier } from '../common/decorators/rate-limit.decorator';
 
 @UseGuards(JwtAuthGuard)
 @Controller('exports')
@@ -30,11 +33,34 @@ export class ExportsController {
   @Post()
   @HttpCode(HttpStatus.ACCEPTED)
   @Audit({ action: AuditAction.BULK_EXPORT_INITIATED, resource: 'export' })
+  @RateLimit({ tier: RateLimitTier.AUTHENTICATED, limit: 10, window: 3600 })
   initiate(
     @Request() req: { user: { id: string } },
     @Body() dto: InitiateExportDto,
   ) {
     return this.exportsService.initiate(req.user.id, dto);
+  }
+
+  /**
+   * POST /exports/tax-report
+   * Request a tax report export for the authenticated user.
+   * Supports date range filtering and CSV/JSON formats.
+   * Processing is asynchronous — poll GET /exports/:id for status.
+   */
+  @Post('tax-report')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @Audit({ action: AuditAction.BULK_EXPORT_INITIATED, resource: 'tax-report' })
+  @RateLimit({ tier: RateLimitTier.AUTHENTICATED, limit: 5, window: 3600 })
+  initiateTaxReport(
+    @Request() req: { user: { id: string } },
+    @Body() dto: TaxReportDto,
+  ) {
+    return this.exportsService.initiate(req.user.id, {
+      type: ExportType.TAX_REPORT,
+      format: dto.format,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+    });
   }
 
   /**

--- a/src/exports/tax-report.controller.spec.ts
+++ b/src/exports/tax-report.controller.spec.ts
@@ -1,0 +1,87 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
+import { ExportsController } from './exports.controller';
+import { ExportsService } from './exports.service';
+import { ExportFormat, ExportStatus, ExportType } from './entities/bulk-export.entity';
+import { TaxReportDto } from './dto/tax-report.dto';
+
+const mockExportsService = {
+  initiate: jest.fn(),
+  listForUser: jest.fn(),
+  findOne: jest.fn(),
+  validateDownload: jest.fn(),
+};
+
+const mockReq = { user: { id: 'user-123' } };
+
+describe('ExportsController — tax-report (issue #484)', () => {
+  let controller: ExportsController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExportsController],
+      providers: [{ provide: ExportsService, useValue: mockExportsService }],
+    })
+      .overrideGuard(require('../auth/guards/jwt-auth.guard').JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ExportsController>(ExportsController);
+  });
+
+  it('initiates a tax report export with date range', async () => {
+    const dto: TaxReportDto = {
+      startDate: '2025-01-01',
+      endDate: '2025-12-31',
+      format: ExportFormat.CSV,
+    };
+
+    const expected = {
+      id: 'exp-tax-1',
+      userId: 'user-123',
+      type: ExportType.TAX_REPORT,
+      format: ExportFormat.CSV,
+      status: ExportStatus.PENDING,
+    };
+
+    mockExportsService.initiate.mockResolvedValue(expected);
+
+    const result = await controller.initiateTaxReport(mockReq, dto);
+
+    expect(mockExportsService.initiate).toHaveBeenCalledWith('user-123', {
+      type: ExportType.TAX_REPORT,
+      format: ExportFormat.CSV,
+      startDate: '2025-01-01',
+      endDate: '2025-12-31',
+    });
+    expect(result).toEqual(expected);
+  });
+
+  it('defaults to CSV format when format is not specified', async () => {
+    const dto: TaxReportDto = {
+      startDate: '2025-01-01',
+      endDate: '2025-12-31',
+    };
+
+    mockExportsService.initiate.mockResolvedValue({ id: 'exp-tax-2', status: ExportStatus.PENDING });
+
+    await controller.initiateTaxReport(mockReq, dto);
+
+    expect(mockExportsService.initiate).toHaveBeenCalledWith('user-123', {
+      type: ExportType.TAX_REPORT,
+      format: undefined,
+      startDate: '2025-01-01',
+      endDate: '2025-12-31',
+    });
+  });
+
+  it('passes through service errors (e.g. too many active exports)', async () => {
+    const dto: TaxReportDto = { startDate: '2025-01-01', endDate: '2025-12-31' };
+    mockExportsService.initiate.mockRejectedValue(new Error('Too many active exports'));
+
+    await expect(controller.initiateTaxReport(mockReq, dto)).rejects.toThrow(
+      'Too many active exports',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR resolves four issues in a single feature branch.

---

### #474 — Implement backend caching for static asset serving

**Changes:** `src/assets/assets.controller.ts`

- Added `ETag` header (MD5 hash of response body) to all GET endpoints.
- Added `Cache-Control: public, max-age=<ttl>, stale-while-revalidate` headers:
  - Price endpoints (`/assets/price/:pair`): **30-second TTL** (live data).
  - Metadata endpoints (`/assets`, `/assets/pairs`, `/assets/:code`, `/assets/validate`): **1-hour TTL**.
- Added `Vary: Accept-Encoding` header for CDN compatibility.
- Implemented **304 Not Modified** support via `If-None-Match` / ETag comparison.
- Compression is already enabled globally via `compression` middleware in `main.ts`.

---

### #481 — Add Audit Logging for Admin Actions

**Changes:** `src/audit-log/audit.controller.ts`, `src/app.module.ts`

- Applied `JwtAuthGuard` + `AdminRoleGuard` to the entire `AuditController` (all endpoints now require admin authentication).
- Renamed `GET /audit` → `GET /audit/logs` to make the admin-only intent explicit.
- Imported `AuditModule` into `AppModule` so audit routes are registered in the application.
- Sensitive data is already redacted in `AuditService.sanitizeMetadata()`.
- Retention policy (2-year cleanup cron) already implemented in `AuditService`.

---

### #482 — Build API Rate Limiting

**Changes:** `src/common/rate-limit.module.ts`, `src/auth/auth.controller.ts`, `src/exports/exports.controller.ts`, `src/common/guards/rate-limit.guard.spec.ts`

- Registered NestJS built-in `ThrottlerGuard` globally alongside the existing Redis-backed `RateLimitGuard` (both applied via `APP_GUARD`).
- Added per-endpoint `@RateLimit` decorators:
  - `POST /auth/challenge`: 20 req/min (public)
  - `POST /auth/verify`: 10 req/min (public) — brute-force protection
  - `POST /exports`: 10 req/hr (authenticated)
- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers set on every response.
- `Retry-After` header + HTTP 429 returned when limit exceeded.
- Unit tests cover: under-limit pass, 429 on exceed, user-ID keying, window reset, custom per-endpoint limits, and header injection.

---

### #484 — Implement Data Export for Tax Reporting

**Changes:** `src/exports/entities/bulk-export.entity.ts`, `src/exports/dto/tax-report.dto.ts`, `src/exports/exports.controller.ts`, `src/exports/tax-report.controller.spec.ts`

- Added `TAX_REPORT = 'tax_report'` to the `ExportType` enum.
- Created `TaxReportDto` with `startDate`, `endDate` (ISO 8601, required), and `format` (CSV/JSON, optional).
- Added `POST /exports/tax-report` endpoint:
  - Protected by `JwtAuthGuard` (users can only export their own data).
  - Rate-limited to **5 requests/hour** per user.
  - Audit-logged with `BULK_EXPORT_INITIATED` action.
  - Delegates to the existing async export pipeline (Bull queue + processor).
  - Returns 202 Accepted immediately; poll `GET /exports/:id` for status.
  - Secure download via expiring token (`GET /exports/:id/download?token=...`).
- Unit tests cover: date range forwarding, default format, and service error propagation.

---

## Testing

- `src/common/guards/rate-limit.guard.spec.ts` — 6 unit tests for rate limiting
- `src/exports/tax-report.controller.spec.ts` — 3 unit tests for tax report endpoint

## Closes

Closes #474
Closes #481
Closes #482
Closes #484