### PR TITLE
feat: add Prometheus metrics and admin endpoints to CircuitBreakerService

### DIFF
--- a/src/http/circuit-breaker.service.spec.ts
+++ b/src/http/circuit-breaker.service.spec.ts
@@ -1,11 +1,14 @@
 import { ServiceUnavailableException } from '@nestjs/common';
+import { Registry } from 'prom-client';
 import { CircuitBreakerService, CircuitState } from './circuit-breaker.service';
 
 describe('CircuitBreakerService', () => {
   let service: CircuitBreakerService;
+  let registry: Registry;
 
   beforeEach(() => {
-    service = new CircuitBreakerService();
+    registry = new Registry();
+    service = new CircuitBreakerService(registry);
     jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
     jest.spyOn((service as any).logger, 'log').mockImplementation(() => {});
   });
@@ -142,6 +145,68 @@ describe('CircuitBreakerService', () => {
       const stats = service.getAllStats();
       expect(stats['svc-a']).toBeDefined();
       expect(stats['svc-b']).toBeDefined();
+    });
+  });
+
+  describe('Prometheus metrics', () => {
+    it('records calls counter on success', async () => {
+      const fn = jest.fn().mockResolvedValue('ok');
+      await service.execute('svc', fn);
+      const metrics = await registry.metrics();
+      expect(metrics).toContain('circuit_breaker_calls_total');
+      expect(metrics).toContain('outcome="success"');
+    });
+
+    it('records calls counter on failure', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('fail'));
+      await expect(service.execute('svc', fn, {}, () => 'fb')).resolves.toBe('fb');
+      const metrics = await registry.metrics();
+      expect(metrics).toContain('outcome="failure"');
+    });
+
+    it('records rejected outcome when circuit is OPEN', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('fail'));
+      const opts = { failureThreshold: 2, recoveryTimeMs: 60_000 };
+      for (let i = 0; i < 2; i++) {
+        await expect(service.execute('svc', fn, opts)).rejects.toThrow();
+      }
+      await expect(service.execute('svc', fn, opts)).rejects.toThrow(ServiceUnavailableException);
+      const metrics = await registry.metrics();
+      expect(metrics).toContain('outcome="rejected"');
+    });
+
+    it('records state gauge transitions', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('fail'));
+      const opts = { failureThreshold: 2, recoveryTimeMs: 60_000 };
+      for (let i = 0; i < 2; i++) {
+        await expect(service.execute('svc', fn, opts)).rejects.toThrow();
+      }
+      const metrics = await registry.metrics();
+      expect(metrics).toContain('circuit_breaker_state');
+      expect(metrics).toContain('circuit="svc"');
+    });
+
+    it('records transition counter on state change', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('fail'));
+      const opts = { failureThreshold: 2, recoveryTimeMs: 0, successThreshold: 1 };
+      // Open
+      for (let i = 0; i < 2; i++) {
+        await expect(service.execute('svc', fn, opts)).rejects.toThrow();
+      }
+      // Probe + recover
+      fn.mockResolvedValueOnce('ok');
+      await service.execute('svc', fn, opts);
+
+      const metrics = await registry.metrics();
+      expect(metrics).toContain('circuit_breaker_transitions_total');
+    });
+
+    it('works without a registry (no metrics injected)', async () => {
+      const bare = new CircuitBreakerService();
+      jest.spyOn((bare as any).logger, 'warn').mockImplementation(() => {});
+      jest.spyOn((bare as any).logger, 'log').mockImplementation(() => {});
+      const fn = jest.fn().mockResolvedValue('bare-ok');
+      await expect(bare.execute('svc', fn)).resolves.toBe('bare-ok');
     });
   });
 });

--- a/src/http/circuit-breaker.service.ts
+++ b/src/http/circuit-breaker.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { Injectable, Logger, Optional, ServiceUnavailableException } from '@nestjs/common';
+import { Counter, Gauge, Registry } from 'prom-client';
 
 export enum CircuitState {
   CLOSED = 'CLOSED',   // Normal operation
@@ -23,6 +24,13 @@ interface CircuitStats {
   openedAt?: Date;
 }
 
+/** Numeric encoding for Prometheus gauge: CLOSED=0, HALF_OPEN=1, OPEN=2 */
+const STATE_VALUE: Record<CircuitState, number> = {
+  [CircuitState.CLOSED]: 0,
+  [CircuitState.HALF_OPEN]: 1,
+  [CircuitState.OPEN]: 2,
+};
+
 /**
  * CircuitBreakerService
  *
@@ -33,6 +41,11 @@ interface CircuitStats {
  *  CLOSED     → normal; failures are counted
  *  OPEN       → requests rejected immediately with ServiceUnavailableException
  *  HALF_OPEN  → one probe request allowed; success closes, failure re-opens
+ *
+ * Prometheus metrics exposed (when a Registry is injected):
+ *  circuit_breaker_state          gauge   – current state (0=CLOSED, 1=HALF_OPEN, 2=OPEN)
+ *  circuit_breaker_transitions_total counter – state transitions labelled by direction
+ *  circuit_breaker_calls_total    counter – total executions (labelled outcome: success|failure|rejected)
  *
  * Usage:
  *   const result = await this.circuitBreaker.execute('stellar-horizon', () =>
@@ -50,6 +63,36 @@ export class CircuitBreakerService {
     successThreshold: 2,
   };
 
+  // Prometheus metrics – optional so the service remains usable without a registry
+  private stateGauge?: Gauge;
+  private transitionsCounter?: Counter;
+  private callsCounter?: Counter;
+
+  constructor(@Optional() private readonly prometheusRegistry?: Registry) {
+    if (prometheusRegistry) {
+      this.stateGauge = new Gauge({
+        name: 'circuit_breaker_state',
+        help: 'Current circuit breaker state: 0=CLOSED, 1=HALF_OPEN, 2=OPEN',
+        labelNames: ['circuit'],
+        registers: [prometheusRegistry],
+      });
+
+      this.transitionsCounter = new Counter({
+        name: 'circuit_breaker_transitions_total',
+        help: 'Total circuit breaker state transitions',
+        labelNames: ['circuit', 'from', 'to'],
+        registers: [prometheusRegistry],
+      });
+
+      this.callsCounter = new Counter({
+        name: 'circuit_breaker_calls_total',
+        help: 'Total calls routed through circuit breakers',
+        labelNames: ['circuit', 'outcome'],
+        registers: [prometheusRegistry],
+      });
+    }
+  }
+
   /**
    * Execute `fn` through the named circuit breaker.
    * Throws ServiceUnavailableException when the circuit is OPEN.
@@ -65,10 +108,11 @@ export class CircuitBreakerService {
 
     if (circuit.state === CircuitState.OPEN) {
       if (this.shouldAttemptRecovery(circuit, opts)) {
-        circuit.state = CircuitState.HALF_OPEN;
+        this.transition(name, circuit, CircuitState.HALF_OPEN);
         this.logger.log(`[CircuitBreaker] "${name}" → HALF_OPEN (probing)`);
       } else {
         this.logger.warn(`[CircuitBreaker] "${name}" is OPEN — rejecting request`);
+        this.callsCounter?.inc({ circuit: name, outcome: 'rejected' });
         if (fallback) return fallback();
         throw new ServiceUnavailableException(
           `Service "${name}" is temporarily unavailable. Please try again later.`,
@@ -78,9 +122,11 @@ export class CircuitBreakerService {
 
     try {
       const result = await fn();
+      this.callsCounter?.inc({ circuit: name, outcome: 'success' });
       this.onSuccess(name, circuit, opts);
       return result;
     } catch (error) {
+      this.callsCounter?.inc({ circuit: name, outcome: 'failure' });
       this.onFailure(name, circuit, opts);
       if (fallback) return fallback();
       throw error;
@@ -103,7 +149,13 @@ export class CircuitBreakerService {
 
   /** Manually reset a circuit to CLOSED (admin use). */
   reset(name: string): void {
-    this.circuits.delete(name);
+    const circuit = this.circuits.get(name);
+    if (circuit) {
+      const prev = circuit.state;
+      this.circuits.delete(name);
+      this.transitionsCounter?.inc({ circuit: name, from: prev, to: CircuitState.CLOSED });
+      this.stateGauge?.set({ circuit: name }, STATE_VALUE[CircuitState.CLOSED]);
+    }
     this.logger.log(`[CircuitBreaker] "${name}" manually reset to CLOSED`);
   }
 
@@ -113,9 +165,19 @@ export class CircuitBreakerService {
 
   private getOrCreate(name: string): CircuitStats {
     if (!this.circuits.has(name)) {
-      this.circuits.set(name, { state: CircuitState.CLOSED, failures: 0, successes: 0 });
+      const stats: CircuitStats = { state: CircuitState.CLOSED, failures: 0, successes: 0 };
+      this.circuits.set(name, stats);
+      this.stateGauge?.set({ circuit: name }, STATE_VALUE[CircuitState.CLOSED]);
     }
     return this.circuits.get(name)!;
+  }
+
+  /** Record a state transition in both the internal map and Prometheus. */
+  private transition(name: string, circuit: CircuitStats, next: CircuitState): void {
+    const prev = circuit.state;
+    circuit.state = next;
+    this.transitionsCounter?.inc({ circuit: name, from: prev, to: next });
+    this.stateGauge?.set({ circuit: name }, STATE_VALUE[next]);
   }
 
   private onSuccess(name: string, circuit: CircuitStats, opts: Required<CircuitBreakerOptions>): void {
@@ -124,8 +186,8 @@ export class CircuitBreakerService {
     if (circuit.state === CircuitState.HALF_OPEN) {
       circuit.successes += 1;
       if (circuit.successes >= opts.successThreshold) {
-        circuit.state = CircuitState.CLOSED;
         circuit.successes = 0;
+        this.transition(name, circuit, CircuitState.CLOSED);
         this.logger.log(`[CircuitBreaker] "${name}" → CLOSED (recovered)`);
       }
     }
@@ -136,16 +198,16 @@ export class CircuitBreakerService {
     circuit.lastFailureAt = new Date();
 
     if (circuit.state === CircuitState.HALF_OPEN) {
-      circuit.state = CircuitState.OPEN;
       circuit.openedAt = new Date();
       circuit.successes = 0;
+      this.transition(name, circuit, CircuitState.OPEN);
       this.logger.warn(`[CircuitBreaker] "${name}" → OPEN (probe failed)`);
       return;
     }
 
     if (circuit.failures >= opts.failureThreshold) {
-      circuit.state = CircuitState.OPEN;
       circuit.openedAt = new Date();
+      this.transition(name, circuit, CircuitState.OPEN);
       this.logger.warn(
         `[CircuitBreaker] "${name}" → OPEN after ${circuit.failures} consecutive failures`,
       );

--- a/src/http/http.module.ts
+++ b/src/http/http.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { HttpRetryService } from './http-retry.service';
 import { CircuitBreakerService } from './circuit-breaker.service';
+import { MonitoringModule } from '../monitoring/monitoring.module';
+import { PrometheusService } from '../monitoring/metrics/prometheus.service';
+import { Registry } from 'prom-client';
 
 /**
  * HttpRetryModule
@@ -20,8 +23,17 @@ import { CircuitBreakerService } from './circuit-breaker.service';
       timeout: 10_000,
       maxRedirects: 3,
     }),
+    MonitoringModule,
   ],
-  providers: [HttpRetryService, CircuitBreakerService],
+  providers: [
+    HttpRetryService,
+    {
+      provide: CircuitBreakerService,
+      useFactory: (prometheus: PrometheusService) =>
+        new CircuitBreakerService(prometheus.registry),
+      inject: [PrometheusService],
+    },
+  ],
   exports: [HttpRetryService, CircuitBreakerService],
 })
 export class HttpRetryModule {}

--- a/src/monitoring/monitoring.controller.ts
+++ b/src/monitoring/monitoring.controller.ts
@@ -1,15 +1,41 @@
-import { Controller, Get, Header, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Header, Param, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PrometheusService } from './metrics/prometheus.service';
+import { CircuitBreakerService } from '../http/circuit-breaker.service';
 import { HealthMetricsAuthGuard } from '../common/guards/health-metrics-auth.guard';
 
+@ApiTags('monitoring')
 @Controller('metrics')
 @UseGuards(HealthMetricsAuthGuard)
 export class MonitoringController {
-  constructor(private readonly prometheus: PrometheusService) {}
+  constructor(
+    private readonly prometheus: PrometheusService,
+    private readonly circuitBreaker: CircuitBreakerService,
+  ) {}
 
   @Get()
   @Header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+  @ApiOperation({ summary: 'Prometheus metrics scrape endpoint' })
   async getMetrics(): Promise<string> {
     return this.prometheus.getMetrics();
+  }
+
+  @Get('circuit-breakers')
+  @ApiOperation({ summary: 'Get current state of all circuit breakers' })
+  @ApiResponse({
+    status: 200,
+    description: 'Map of circuit name → state, failures, successes, timestamps',
+  })
+  getCircuitBreakers(): Record<string, unknown> {
+    return this.circuitBreaker.getAllStats();
+  }
+
+  @Delete('circuit-breakers/:name')
+  @ApiOperation({ summary: 'Manually reset a named circuit breaker to CLOSED' })
+  @ApiParam({ name: 'name', description: 'Circuit breaker name (e.g. stellar-horizon)' })
+  @ApiResponse({ status: 200, description: 'Circuit reset successfully' })
+  resetCircuitBreaker(@Param('name') name: string): { reset: boolean; circuit: string } {
+    this.circuitBreaker.reset(name);
+    return { reset: true, circuit: name };
   }
 }

--- a/src/monitoring/monitoring.module.ts
+++ b/src/monitoring/monitoring.module.ts
@@ -4,12 +4,22 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor';
 import { MonitoringController } from './monitoring.controller';
 import { AuthModule } from '../auth/auth.module';
 import { ApiKeysModule } from '../api-keys/api-keys.module';
+import { CircuitBreakerService } from '../http/circuit-breaker.service';
 
 @Global()
 @Module({
   imports: [AuthModule, ApiKeysModule],
-  providers: [PrometheusService, MetricsInterceptor],
+  providers: [
+    PrometheusService,
+    MetricsInterceptor,
+    {
+      provide: CircuitBreakerService,
+      useFactory: (prometheus: PrometheusService) =>
+        new CircuitBreakerService(prometheus.registry),
+      inject: [PrometheusService],
+    },
+  ],
   controllers: [MonitoringController],
-  exports: [PrometheusService, MetricsInterceptor],
+  exports: [PrometheusService, MetricsInterceptor, CircuitBreakerService],
 })
 export class MonitoringModule {}


### PR DESCRIPTION
## Summary

- Injects an optional `prom-client` `Registry` into `CircuitBreakerService` so Prometheus metrics are recorded on every state transition and call
- Adds `circuit_breaker_state` gauge (0=CLOSED, 1=HALF_OPEN, 2=OPEN), `circuit_breaker_transitions_total` counter, and `circuit_breaker_calls_total` counter (labelled `outcome: success | failure | rejected`)
- Wires `CircuitBreakerService` to the `PrometheusService` registry in `HttpRetryModule` so all outbound HTTP calls through the circuit breaker are observable
- Exposes `GET /metrics/circuit-breakers` and `DELETE /metrics/circuit-breakers/:name` admin endpoints in `MonitoringController`
- Extends the existing spec with Prometheus metric assertions and a no-registry fallback test

## Test plan

- [ ] Unit tests in `circuit-breaker.service.spec.ts` pass (`npm test`)
- [ ] `GET /metrics` scrape includes `circuit_breaker_*` metrics after exercising an external call
- [ ] `GET /metrics/circuit-breakers` returns current circuit state map
- [ ] `DELETE /metrics/circuit-breakers/stellar-horizon` resets the circuit to CLOSED

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)