### PR TITLE
feat(compliance): add rule engine for trade eligibility (#540)

### DIFF
--- a/src/compliance/compliance.controller.ts
+++ b/src/compliance/compliance.controller.ts
@@ -1,8 +1,23 @@
-import { Controller, Get, Post, Query, UseGuards, Req, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  UseGuards,
+  Req,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
 import { GeoBlockService } from './geo-blocking/geo-block.service';
 import { SanctionsScreeningService } from './geo-blocking/sanctions-screening.service';
 import { ComplianceReportingService } from './compliance-reporting.service';
 import { ComplianceService } from './compliance.service';
+import { ComplianceRuleEngineService } from './rule-engine/compliance-rule-engine.service';
+import { EvaluateTradeDto } from './rule-engine/dto/evaluate-trade.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ExportRequestDto } from './dto/export-request.dto';
 import { ComplianceReportDto } from './dto/compliance-report.dto';
@@ -15,13 +30,17 @@ export class ComplianceController {
     private sanctionsService: SanctionsScreeningService,
     private reportingService: ComplianceReportingService,
     private complianceService: ComplianceService,
+    private ruleEngineService: ComplianceRuleEngineService,
   ) {}
 
   @Post('export/user-data')
   @HttpCode(HttpStatus.ACCEPTED)
   async exportUserData(@Req() req: any, @Body() dto: ExportRequestDto) {
     const userId = req.user.id;
-    const filePath = await this.complianceService.exportUserData(userId, dto.format);
+    const filePath = await this.complianceService.exportUserData(
+      userId,
+      dto.format,
+    );
 
     return {
       message: 'Export initiated successfully',
@@ -36,7 +55,11 @@ export class ComplianceController {
     const startDate = new Date(dto.startDate);
     const endDate = new Date(dto.endDate);
 
-    const report = await this.complianceService.generateComplianceReport(dto.type, startDate, endDate);
+    const report = await this.complianceService.generateComplianceReport(
+      dto.type,
+      startDate,
+      endDate,
+    );
 
     return {
       reportType: dto.type,
@@ -70,7 +93,9 @@ export class ComplianceController {
   }
 
   @Post('screen-user')
-  async screenUser(@Body() data: { walletAddress?: string; email?: string; name?: string }) {
+  async screenUser(
+    @Body() data: { walletAddress?: string; email?: string; name?: string },
+  ) {
     return this.sanctionsService.screenUser(data);
   }
 
@@ -84,8 +109,13 @@ export class ComplianceController {
   }
 
   @Get('report')
-  async getComplianceReport(@Query('startDate') startDate: string, @Query('endDate') endDate: string) {
-    const start = startDate ? new Date(startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  async getComplianceReport(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+  ) {
+    const start = startDate
+      ? new Date(startDate)
+      : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const end = endDate ? new Date(endDate) : new Date();
 
     return this.reportingService.generateReport(start, end);
@@ -93,7 +123,9 @@ export class ComplianceController {
 
   @Get('recent-blocks')
   async getRecentBlocks(@Query('limit') limit?: number) {
-    return this.reportingService.getRecentBlocks(limit ? parseInt(limit as any) : 100);
+    return this.reportingService.getRecentBlocks(
+      limit ? parseInt(limit as any) : 100,
+    );
   }
 
   @Get('health')
@@ -103,7 +135,43 @@ export class ComplianceController {
       geoBlocking: 'active',
       sanctionsScreening: 'active',
       dataExport: 'active',
+      ruleEngine: 'active',
       timestamp: new Date().toISOString(),
     };
+  }
+
+  // ── Rule Engine endpoints ──────────────────────────────────────────────────
+
+  /**
+   * Evaluate trade eligibility without executing the trade.
+   * Returns the full rule-by-rule breakdown and a persisted decision ID.
+   */
+  @Post('rule-engine/evaluate')
+  @HttpCode(HttpStatus.OK)
+  async evaluateTradeEligibility(
+    @Req() req: any,
+    @Body() dto: EvaluateTradeDto,
+  ) {
+    const userId = dto.userId ?? req.user.id;
+    const ipAddress = dto.ipAddress ?? req.ip;
+    return this.ruleEngineService.previewTradeEligibility({
+      userId,
+      amount: dto.amount,
+      asset: dto.asset,
+      counterAsset: dto.counterAsset,
+      ipAddress,
+    });
+  }
+
+  /**
+   * Retrieve the compliance decision audit log for a specific user.
+   */
+  @Get('rule-engine/decisions/:userId')
+  async getDecisionsForUser(
+    @Param('userId') userId: string,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset: number,
+  ) {
+    return this.ruleEngineService.getDecisionsForUser(userId, limit, offset);
   }
 }

--- a/src/compliance/compliance.module.ts
+++ b/src/compliance/compliance.module.ts
@@ -24,12 +24,28 @@ import { AuditTrailExporterService } from './exporters/audit-trail-exporter.serv
 import { GdprReportGenerator } from './reports/gdpr-report.generator';
 import { FinancialReportGenerator } from './reports/financial-report.generator';
 import { TransactionLimitsModule } from './transaction-limits/transaction-limits.module';
+// Rule engine
+import { ComplianceRuleEngineService } from './rule-engine/compliance-rule-engine.service';
+import { KycStatusRule } from './rule-engine/rules/kyc-status.rule';
+import { GeographicRestrictionRule } from './rule-engine/rules/geographic-restriction.rule';
+import { AmlStatusRule } from './rule-engine/rules/aml-status.rule';
+import { AssetClassRestrictionRule } from './rule-engine/rules/asset-class-restriction.rule';
+import { TransactionLimitRule } from './rule-engine/rules/transaction-limit.rule';
+import { TradeEligibilityDecision } from './rule-engine/entities/trade-eligibility-decision.entity';
 
 @Module({
   imports: [
     ConfigModule,
     ScheduleModule.forRoot(),
-    TypeOrmModule.forFeature([ComplianceLog, SuspiciousActivity, Trade, User, Signal, AuditLog]),
+    TypeOrmModule.forFeature([
+      ComplianceLog,
+      SuspiciousActivity,
+      Trade,
+      User,
+      Signal,
+      AuditLog,
+      TradeEligibilityDecision,
+    ]),
     BullModule.registerQueue({ name: AML_QUEUE }),
     TransactionLimitsModule,
   ],
@@ -46,6 +62,13 @@ import { TransactionLimitsModule } from './transaction-limits/transaction-limits
     AuditTrailExporterService,
     GdprReportGenerator,
     FinancialReportGenerator,
+    // Rule engine
+    ComplianceRuleEngineService,
+    KycStatusRule,
+    GeographicRestrictionRule,
+    AmlStatusRule,
+    AssetClassRestrictionRule,
+    TransactionLimitRule,
   ],
   controllers: [ComplianceController],
   exports: [
@@ -55,6 +78,7 @@ import { TransactionLimitsModule } from './transaction-limits/transaction-limits
     ComplianceService,
     AmlMonitoringService,
     TransactionLimitsModule,
+    ComplianceRuleEngineService,
   ],
 })
 export class ComplianceModule implements NestModule {

--- a/src/compliance/rule-engine/compliance-rule-engine.service.spec.ts
+++ b/src/compliance/rule-engine/compliance-rule-engine.service.spec.ts
@@ -1,0 +1,599 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, BadRequestException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+
+import { ComplianceRuleEngineService } from './compliance-rule-engine.service';
+import { KycStatusRule } from './rules/kyc-status.rule';
+import { GeographicRestrictionRule } from './rules/geographic-restriction.rule';
+import { AmlStatusRule } from './rules/aml-status.rule';
+import { AssetClassRestrictionRule } from './rules/asset-class-restriction.rule';
+import { TransactionLimitRule } from './rules/transaction-limit.rule';
+import {
+  TradeEligibilityDecision,
+  EligibilityDecisionOutcome,
+} from './entities/trade-eligibility-decision.entity';
+import { User, KycStatus, UserTier } from '../../users/entities/user.entity';
+import { AmlMonitoringService } from '../aml/aml-monitoring.service';
+import { GeoBlockService } from '../geo-blocking/geo-block.service';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-001',
+    username: 'trader',
+    kycStatus: KycStatus.VERIFIED,
+    tier: UserTier.GOLD,
+    isActive: true,
+    reputationScore: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    signals: [],
+    trades: [],
+    sessions: [],
+    ...overrides,
+  } as User;
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe('ComplianceRuleEngineService', () => {
+  let service: ComplianceRuleEngineService;
+  let userRepository: { findOne: jest.Mock };
+  let decisionRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+  };
+  let amlMonitoringService: { getUserRiskScore: jest.Mock };
+  let geoBlockService: { getGeoLocation: jest.Mock };
+
+  const baseInput = {
+    userId: 'user-001',
+    amount: 1000,
+    asset: 'XLM',
+    counterAsset: 'USDC',
+    ipAddress: '192.168.1.1',
+  };
+
+  beforeEach(async () => {
+    userRepository = { findOne: jest.fn() };
+    decisionRepository = {
+      create: jest
+        .fn()
+        .mockImplementation((dto) => ({ ...dto, id: 'decision-uuid' })),
+      save: jest
+        .fn()
+        .mockImplementation((entity) =>
+          Promise.resolve({ ...entity, id: 'decision-uuid' }),
+        ),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    amlMonitoringService = { getUserRiskScore: jest.fn().mockResolvedValue(0) };
+    geoBlockService = {
+      getGeoLocation: jest.fn().mockResolvedValue({
+        country: 'Local',
+        countryCode: 'XX',
+        isVPN: false,
+        isProxy: false,
+        isTor: false,
+        ip: '192.168.1.1',
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ComplianceRuleEngineService,
+        KycStatusRule,
+        AmlStatusRule,
+        TransactionLimitRule,
+        {
+          provide: GeographicRestrictionRule,
+          useFactory: (cfg: ConfigService) =>
+            new GeographicRestrictionRule(cfg),
+          inject: [ConfigService],
+        },
+        {
+          provide: AssetClassRestrictionRule,
+          useFactory: (cfg: ConfigService) =>
+            new AssetClassRestrictionRule(cfg),
+          inject: [ConfigService],
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: string) => {
+              if (key === 'BLOCKED_COUNTRIES') return 'CU,IR,KP,SY';
+              if (key === 'RESTRICTED_ASSETS') return 'SCAM,FAKE';
+              return defaultValue;
+            }),
+          },
+        },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        {
+          provide: getRepositoryToken(TradeEligibilityDecision),
+          useValue: decisionRepository,
+        },
+        { provide: AmlMonitoringService, useValue: amlMonitoringService },
+        { provide: GeoBlockService, useValue: geoBlockService },
+      ],
+    }).compile();
+
+    service = module.get<ComplianceRuleEngineService>(
+      ComplianceRuleEngineService,
+    );
+  });
+
+  // ── Compliant scenarios ────────────────────────────────────────────────────
+
+  describe('compliant trade scenarios', () => {
+    it('approves a fully compliant trade', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+
+      const result = await service.evaluateTrade(baseInput);
+
+      expect(result.eligible).toBe(true);
+      expect(result.outcome).toBe('approved');
+      expect(result.reasons).toHaveLength(0);
+      expect(result.ruleResults.every((r) => r.passed)).toBe(true);
+      expect(result.decisionId).toBe('decision-uuid');
+    });
+
+    it('persists an APPROVED decision record', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+
+      await service.evaluateTrade(baseInput);
+
+      expect(decisionRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: EligibilityDecisionOutcome.APPROVED,
+        }),
+      );
+    });
+
+    it('approves a PLATINUM user trading at the tier limit', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ tier: UserTier.PLATINUM }),
+      );
+
+      const result = await service.evaluateTrade({
+        ...baseInput,
+        amount: 100_000,
+      });
+
+      expect(result.eligible).toBe(true);
+    });
+
+    it('approves when no country code is available (geo rule skips)', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+      geoBlockService.getGeoLocation.mockRejectedValue(new Error('timeout'));
+
+      const result = await service.evaluateTrade(baseInput);
+
+      expect(result.eligible).toBe(true);
+    });
+
+    it('approves when AML service is unavailable (falls back to amount check)', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+      amlMonitoringService.getUserRiskScore.mockRejectedValue(
+        new Error('AML down'),
+      );
+
+      const result = await service.evaluateTrade(baseInput);
+
+      expect(result.eligible).toBe(true);
+    });
+  });
+
+  // ── Non-compliant scenarios ────────────────────────────────────────────────
+
+  describe('non-compliant trade scenarios', () => {
+    it('rejects a trade when KYC is PENDING', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ kycStatus: KycStatus.PENDING }),
+      );
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a trade when KYC is NONE', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ kycStatus: KycStatus.NONE }),
+      );
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a trade when KYC is REJECTED', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ kycStatus: KycStatus.REJECTED }),
+      );
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a trade from a blocked country (IR)', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+      geoBlockService.getGeoLocation.mockResolvedValue({
+        country: 'Iran',
+        countryCode: 'IR',
+        isVPN: false,
+        isProxy: false,
+        isTor: false,
+        ip: '1.2.3.4',
+      });
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a trade from a blocked country (KP)', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+      geoBlockService.getGeoLocation.mockResolvedValue({
+        country: 'North Korea',
+        countryCode: 'KP',
+        isVPN: false,
+        isProxy: false,
+        isTor: false,
+        ip: '5.6.7.8',
+      });
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a trade when the user has open AML flags', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+      amlMonitoringService.getUserRiskScore.mockResolvedValue(75);
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a trade that exceeds the AML hard threshold', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ tier: UserTier.PLATINUM }),
+      );
+
+      await expect(
+        service.evaluateTrade({ ...baseInput, amount: 1_500_000 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects a trade involving a restricted asset', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+
+      await expect(
+        service.evaluateTrade({ ...baseInput, asset: 'SCAM' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects a trade involving a restricted counter asset', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+
+      await expect(
+        service.evaluateTrade({ ...baseInput, counterAsset: 'FAKE' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects a BASIC-tier trade that exceeds the 1000 limit', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ tier: UserTier.BASIC }),
+      );
+
+      await expect(
+        service.evaluateTrade({ ...baseInput, amount: 1_500 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('rejects a SILVER-tier trade that exceeds the 5000 limit', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ tier: UserTier.SILVER }),
+      );
+
+      await expect(
+        service.evaluateTrade({ ...baseInput, amount: 6_000 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('includes rejection reasons in the ForbiddenException body', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ kycStatus: KycStatus.PENDING }),
+      );
+
+      try {
+        await service.evaluateTrade(baseInput);
+        fail('Expected ForbiddenException');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ForbiddenException);
+        const body = (err as ForbiddenException).getResponse() as Record<
+          string,
+          unknown
+        >;
+        expect(body.reasons).toBeInstanceOf(Array);
+        expect((body.reasons as string[]).length).toBeGreaterThan(0);
+        expect(body.decisionId).toBeDefined();
+      }
+    });
+
+    it('persists a REJECTED decision record', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ kycStatus: KycStatus.PENDING }),
+      );
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow();
+
+      expect(decisionRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: EligibilityDecisionOutcome.REJECTED,
+        }),
+      );
+    });
+  });
+
+  // ── Preview (non-throwing) ─────────────────────────────────────────────────
+
+  describe('previewTradeEligibility', () => {
+    it('returns eligible=true for a compliant trade', async () => {
+      userRepository.findOne.mockResolvedValue(makeUser());
+
+      const result = await service.previewTradeEligibility(baseInput);
+
+      expect(result.eligible).toBe(true);
+      expect(result.outcome).toBe('approved');
+    });
+
+    it('returns eligible=false without throwing for a non-compliant trade', async () => {
+      userRepository.findOne.mockResolvedValue(
+        makeUser({ kycStatus: KycStatus.PENDING }),
+      );
+
+      const result = await service.previewTradeEligibility(baseInput);
+
+      expect(result.eligible).toBe(false);
+      expect(result.outcome).toBe('rejected');
+      expect(result.reasons.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── User not found ─────────────────────────────────────────────────────────
+
+  describe('user not found', () => {
+    it('throws BadRequestException when user does not exist', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.evaluateTrade(baseInput)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ── Audit log retrieval ────────────────────────────────────────────────────
+
+  describe('getDecisionsForUser', () => {
+    it('returns decisions for a user', async () => {
+      const mockDecisions = [
+        {
+          id: 'd1',
+          userId: 'user-001',
+          outcome: EligibilityDecisionOutcome.APPROVED,
+        },
+      ];
+      decisionRepository.find.mockResolvedValue(mockDecisions);
+
+      const result = await service.getDecisionsForUser('user-001');
+
+      expect(result).toEqual(mockDecisions);
+      expect(decisionRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user-001' } }),
+      );
+    });
+  });
+});
+
+// ─── Individual rule unit tests ───────────────────────────────────────────────
+
+describe('KycStatusRule', () => {
+  const rule = new KycStatusRule();
+
+  it('passes for VERIFIED status', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      kycStatus: KycStatus.VERIFIED,
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails for PENDING status', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      kycStatus: KycStatus.PENDING,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('KYC status');
+  });
+
+  it('fails when kycStatus is undefined', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+    });
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('AmlStatusRule', () => {
+  const rule = new AmlStatusRule();
+
+  it('passes when no AML flags and amount is below threshold', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 500,
+      asset: 'XLM',
+      hasAmlFlags: false,
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when user has open AML flags', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 500,
+      asset: 'XLM',
+      hasAmlFlags: true,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('AML');
+  });
+
+  it('fails when amount exceeds hard threshold', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 2_000_000,
+      asset: 'XLM',
+      hasAmlFlags: false,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('threshold');
+  });
+});
+
+describe('TransactionLimitRule', () => {
+  const rule = new TransactionLimitRule();
+
+  it.each([
+    [UserTier.BASIC, 1000, true],
+    [UserTier.BASIC, 1001, false],
+    [UserTier.SILVER, 5000, true],
+    [UserTier.SILVER, 5001, false],
+    [UserTier.GOLD, 20000, true],
+    [UserTier.GOLD, 20001, false],
+    [UserTier.PLATINUM, 100000, true],
+    [UserTier.PLATINUM, 100001, false],
+  ])('%s tier: amount=%d → passed=%s', async (tier, amount, expected) => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount,
+      asset: 'XLM',
+      userTier: tier,
+    });
+    expect(result.passed).toBe(expected);
+  });
+});
+
+describe('GeographicRestrictionRule', () => {
+  const configService = {
+    get: (key: string, def: string) =>
+      key === 'BLOCKED_COUNTRIES' ? 'CU,IR,KP' : def,
+  } as unknown as ConfigService;
+
+  const rule = new GeographicRestrictionRule(configService);
+
+  it('passes for an allowed country', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      countryCode: 'US',
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails for a blocked country', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      countryCode: 'IR',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('IR');
+  });
+
+  it('passes when no country code is provided', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it('is case-insensitive for country codes', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      countryCode: 'ir',
+    });
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('AssetClassRestrictionRule', () => {
+  const configService = {
+    get: (key: string, def: string) =>
+      key === 'RESTRICTED_ASSETS' ? 'SCAM,FAKE' : def,
+  } as unknown as ConfigService;
+
+  const rule = new AssetClassRestrictionRule(configService);
+
+  it('passes for unrestricted assets', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      counterAsset: 'USDC',
+    });
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails when base asset is restricted', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'SCAM',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('SCAM');
+  });
+
+  it('fails when counter asset is restricted', async () => {
+    const result = await rule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'XLM',
+      counterAsset: 'FAKE',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('FAKE');
+  });
+
+  it('passes when RESTRICTED_ASSETS is empty', async () => {
+    const emptyCfg = {
+      get: (_k: string, d: string) => d,
+    } as unknown as ConfigService;
+    const emptyRule = new AssetClassRestrictionRule(emptyCfg);
+    const result = await emptyRule.evaluate({
+      userId: 'u1',
+      amount: 100,
+      asset: 'ANYTHING',
+    });
+    expect(result.passed).toBe(true);
+  });
+});

--- a/src/compliance/rule-engine/compliance-rule-engine.service.ts
+++ b/src/compliance/rule-engine/compliance-rule-engine.service.ts
@@ -1,0 +1,268 @@
+import {
+  Injectable,
+  Logger,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User, KycStatus } from '../../users/entities/user.entity';
+import { AmlMonitoringService } from '../aml/aml-monitoring.service';
+import { GeoBlockService } from '../geo-blocking/geo-block.service';
+import {
+  ITradeEligibilityRule,
+  RuleResult,
+  TradeEligibilityContext,
+} from './interfaces/trade-eligibility-rule.interface';
+import { KycStatusRule } from './rules/kyc-status.rule';
+import { GeographicRestrictionRule } from './rules/geographic-restriction.rule';
+import { AmlStatusRule } from './rules/aml-status.rule';
+import { AssetClassRestrictionRule } from './rules/asset-class-restriction.rule';
+import { TransactionLimitRule } from './rules/transaction-limit.rule';
+import {
+  TradeEligibilityDecision,
+  EligibilityDecisionOutcome,
+} from './entities/trade-eligibility-decision.entity';
+import { TradeEligibilityResultDto } from './dto/evaluate-trade.dto';
+
+export interface EvaluationInput {
+  userId: string;
+  amount: number;
+  asset: string;
+  counterAsset?: string;
+  ipAddress?: string;
+}
+
+/**
+ * Central compliance rule engine.
+ *
+ * Responsibilities:
+ *  1. Enrich the evaluation context (load user, resolve geo, check AML flags).
+ *  2. Run every registered rule in sequence.
+ *  3. Persist an immutable audit record of the decision.
+ *  4. Return a structured result — or throw ForbiddenException when rejected.
+ */
+@Injectable()
+export class ComplianceRuleEngineService {
+  private readonly logger = new Logger(ComplianceRuleEngineService.name);
+
+  /** Ordered list of rules evaluated for every trade. */
+  private readonly rules: ITradeEligibilityRule[];
+
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(TradeEligibilityDecision)
+    private readonly decisionRepository: Repository<TradeEligibilityDecision>,
+    private readonly amlMonitoringService: AmlMonitoringService,
+    private readonly geoBlockService: GeoBlockService,
+    // Individual rules injected so they can be unit-tested independently
+    private readonly kycStatusRule: KycStatusRule,
+    private readonly geographicRestrictionRule: GeographicRestrictionRule,
+    private readonly amlStatusRule: AmlStatusRule,
+    private readonly assetClassRestrictionRule: AssetClassRestrictionRule,
+    private readonly transactionLimitRule: TransactionLimitRule,
+  ) {
+    this.rules = [
+      this.kycStatusRule,
+      this.geographicRestrictionRule,
+      this.amlStatusRule,
+      this.assetClassRestrictionRule,
+      this.transactionLimitRule,
+    ];
+  }
+
+  /**
+   * Evaluate trade eligibility and persist the decision.
+   *
+   * @throws BadRequestException  when the user is not found.
+   * @throws ForbiddenException   when one or more rules reject the trade.
+   */
+  async evaluateTrade(
+    input: EvaluationInput,
+  ): Promise<TradeEligibilityResultDto> {
+    const { userId, amount, asset, counterAsset, ipAddress } = input;
+
+    // ── 1. Load user ──────────────────────────────────────────────────────────
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new BadRequestException(`User ${userId} not found.`);
+    }
+
+    // ── 2. Resolve geo location ───────────────────────────────────────────────
+    let countryCode: string | undefined;
+    if (ipAddress) {
+      try {
+        const geo = await this.geoBlockService.getGeoLocation(ipAddress);
+        countryCode = geo.countryCode !== 'XX' ? geo.countryCode : undefined;
+      } catch {
+        // Geo lookup failure is non-fatal; geographic rule will skip.
+        this.logger.warn(`Geo lookup failed for IP ${ipAddress}`);
+      }
+    }
+
+    // ── 3. Check AML flags ────────────────────────────────────────────────────
+    let hasAmlFlags = false;
+    try {
+      const riskScore =
+        await this.amlMonitoringService.getUserRiskScore(userId);
+      hasAmlFlags = riskScore > 0;
+    } catch {
+      // AML service failure is non-fatal; AML rule will rely on amount threshold.
+      this.logger.warn(`AML risk score lookup failed for user ${userId}`);
+    }
+
+    // ── 4. Build context ──────────────────────────────────────────────────────
+    const context: TradeEligibilityContext = {
+      userId,
+      amount,
+      asset,
+      counterAsset,
+      ipAddress,
+      countryCode,
+      kycStatus: user.kycStatus,
+      userTier: user.tier,
+      hasAmlFlags,
+    };
+
+    // ── 5. Run all rules ──────────────────────────────────────────────────────
+    const ruleResults: RuleResult[] = await Promise.all(
+      this.rules.map((rule) =>
+        rule.evaluate(context).catch((err) => {
+          // A rule that throws is treated as a failure to be safe.
+          this.logger.error(
+            `Rule ${rule.ruleId} threw unexpectedly: ${err.message}`,
+          );
+          return {
+            ruleId: rule.ruleId,
+            ruleName: rule.ruleName,
+            passed: false,
+            reason: `Internal rule evaluation error: ${err.message}`,
+          } as RuleResult;
+        }),
+      ),
+    );
+
+    const failedResults = ruleResults.filter((r) => !r.passed);
+    const eligible = failedResults.length === 0;
+    const outcome = eligible
+      ? EligibilityDecisionOutcome.APPROVED
+      : EligibilityDecisionOutcome.REJECTED;
+
+    // ── 6. Persist audit record ───────────────────────────────────────────────
+    const decision = await this.persistDecision({
+      userId,
+      asset,
+      counterAsset,
+      amount,
+      outcome,
+      failedResults,
+      ruleResults,
+      ipAddress,
+      countryCode,
+    });
+
+    this.logger.log(
+      `Trade eligibility [${outcome.toUpperCase()}] for user=${userId} ` +
+        `asset=${asset} amount=${amount} decisionId=${decision.id}`,
+    );
+
+    // ── 7. Build result DTO ───────────────────────────────────────────────────
+    const result: TradeEligibilityResultDto = {
+      eligible,
+      outcome,
+      reasons: failedResults.map((r) => r.reason ?? ''),
+      ruleResults: ruleResults.map((r) => ({
+        ruleId: r.ruleId,
+        ruleName: r.ruleName,
+        passed: r.passed,
+        reason: r.reason,
+      })),
+      decisionId: decision.id,
+    };
+
+    if (!eligible) {
+      throw new ForbiddenException({
+        message: 'Trade rejected by compliance rule engine.',
+        reasons: result.reasons,
+        ruleResults: result.ruleResults,
+        decisionId: result.decisionId,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Non-throwing variant — returns the result without throwing on rejection.
+   * Useful for preview / dry-run endpoints.
+   */
+  async previewTradeEligibility(
+    input: EvaluationInput,
+  ): Promise<TradeEligibilityResultDto> {
+    try {
+      return await this.evaluateTrade(input);
+    } catch (err) {
+      if (err instanceof ForbiddenException) {
+        const body = err.getResponse() as Record<string, unknown>;
+        return {
+          eligible: false,
+          outcome: 'rejected',
+          reasons: (body.reasons as string[]) ?? [],
+          ruleResults:
+            (body.ruleResults as TradeEligibilityResultDto['ruleResults']) ??
+            [],
+          decisionId: (body.decisionId as string) ?? '',
+        };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Retrieve paginated audit decisions for a user.
+   */
+  async getDecisionsForUser(
+    userId: string,
+    limit = 50,
+    offset = 0,
+  ): Promise<TradeEligibilityDecision[]> {
+    return this.decisionRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private async persistDecision(params: {
+    userId: string;
+    asset: string;
+    counterAsset?: string;
+    amount: number;
+    outcome: EligibilityDecisionOutcome;
+    failedResults: RuleResult[];
+    ruleResults: RuleResult[];
+    ipAddress?: string;
+    countryCode?: string;
+  }): Promise<TradeEligibilityDecision> {
+    const entity = this.decisionRepository.create({
+      userId: params.userId,
+      asset: params.asset,
+      counterAsset: params.counterAsset,
+      amount: params.amount.toString(),
+      outcome: params.outcome,
+      failedRules:
+        params.failedResults.map((r) => r.ruleId).join(',') || undefined,
+      rejectionReasons:
+        params.failedResults.map((r) => r.reason ?? '').join('; ') || undefined,
+      ruleResults: params.ruleResults as unknown as Record<string, unknown>[],
+      ipAddress: params.ipAddress,
+      countryCode: params.countryCode,
+    });
+
+    return this.decisionRepository.save(entity);
+  }
+}

--- a/src/compliance/rule-engine/dto/evaluate-trade.dto.ts
+++ b/src/compliance/rule-engine/dto/evaluate-trade.dto.ts
@@ -1,0 +1,45 @@
+import {
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  Length,
+} from 'class-validator';
+
+export class EvaluateTradeDto {
+  @IsString()
+  userId!: string;
+
+  @IsNumber()
+  @IsPositive()
+  amount!: number;
+
+  @IsString()
+  @Length(1, 50)
+  asset!: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 50)
+  counterAsset?: string;
+
+  @IsOptional()
+  @IsString()
+  ipAddress?: string;
+}
+
+export class TradeEligibilityResultDto {
+  eligible!: boolean;
+  outcome!: 'approved' | 'rejected';
+  /** Reasons for rejection (empty array when approved). */
+  reasons!: string[];
+  /** Detailed per-rule breakdown. */
+  ruleResults!: {
+    ruleId: string;
+    ruleName: string;
+    passed: boolean;
+    reason?: string;
+  }[];
+  /** Persisted audit record ID. */
+  decisionId!: string;
+}

--- a/src/compliance/rule-engine/entities/trade-eligibility-decision.entity.ts
+++ b/src/compliance/rule-engine/entities/trade-eligibility-decision.entity.ts
@@ -1,0 +1,75 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum EligibilityDecisionOutcome {
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+/**
+ * Persisted audit record for every trade-eligibility decision made by the
+ * compliance rule engine.  Immutable once written.
+ */
+@Entity('trade_eligibility_decisions')
+@Index('idx_ted_user_id', ['userId'])
+@Index('idx_ted_created_at', ['createdAt'])
+export class TradeEligibilityDecision {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  @Column({ name: 'asset', type: 'varchar', length: 50 })
+  asset!: string;
+
+  @Column({
+    name: 'counter_asset',
+    type: 'varchar',
+    length: 50,
+    nullable: true,
+  })
+  counterAsset?: string;
+
+  @Column({ name: 'amount', type: 'decimal', precision: 18, scale: 8 })
+  amount!: string;
+
+  @Column({
+    name: 'outcome',
+    type: 'enum',
+    enum: EligibilityDecisionOutcome,
+  })
+  outcome!: EligibilityDecisionOutcome;
+
+  /**
+   * Comma-separated list of rule IDs that failed (empty when approved).
+   */
+  @Column({ name: 'failed_rules', type: 'text', nullable: true })
+  failedRules?: string;
+
+  /**
+   * Human-readable rejection reasons joined by "; " (empty when approved).
+   */
+  @Column({ name: 'rejection_reasons', type: 'text', nullable: true })
+  rejectionReasons?: string;
+
+  /**
+   * Full JSON snapshot of every rule result for deep audit inspection.
+   */
+  @Column({ name: 'rule_results', type: 'jsonb' })
+  ruleResults!: Record<string, unknown>[];
+
+  @Column({ name: 'ip_address', type: 'varchar', length: 45, nullable: true })
+  ipAddress?: string;
+
+  @Column({ name: 'country_code', type: 'varchar', length: 2, nullable: true })
+  countryCode?: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/src/compliance/rule-engine/interfaces/trade-eligibility-rule.interface.ts
+++ b/src/compliance/rule-engine/interfaces/trade-eligibility-rule.interface.ts
@@ -1,0 +1,54 @@
+/**
+ * Context passed to every compliance rule when evaluating a trade.
+ */
+export interface TradeEligibilityContext {
+  /** The user attempting the trade */
+  userId: string;
+  /** Trade amount in the base asset */
+  amount: number;
+  /** Base asset symbol (e.g. 'XLM') */
+  asset: string;
+  /** Counter asset symbol (e.g. 'USDC') */
+  counterAsset?: string;
+  /** ISO-3166-1 alpha-2 country code derived from the user's IP */
+  countryCode?: string;
+  /** Raw IP address of the request */
+  ipAddress?: string;
+  /** KYC status of the user */
+  kycStatus?: string;
+  /** User account tier */
+  userTier?: string;
+  /** Whether the user has any open AML flags */
+  hasAmlFlags?: boolean;
+  /** Arbitrary extra metadata rules may inspect */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Result returned by a single compliance rule.
+ */
+export interface RuleResult {
+  /** Unique identifier for the rule (e.g. 'KYC_STATUS_CHECK') */
+  ruleId: string;
+  /** Human-readable rule name */
+  ruleName: string;
+  /** Whether the trade passes this rule */
+  passed: boolean;
+  /** Reason for rejection (only populated when passed === false) */
+  reason?: string;
+}
+
+/**
+ * Contract that every compliance rule must implement.
+ */
+export interface ITradeEligibilityRule {
+  /** Unique identifier for this rule */
+  readonly ruleId: string;
+  /** Human-readable name */
+  readonly ruleName: string;
+  /**
+   * Evaluate the rule against the given context.
+   * Must never throw — return a failed RuleResult instead.
+   */
+  evaluate(context: TradeEligibilityContext): Promise<RuleResult>;
+}

--- a/src/compliance/rule-engine/rules/aml-status.rule.ts
+++ b/src/compliance/rule-engine/rules/aml-status.rule.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ITradeEligibilityRule,
+  RuleResult,
+  TradeEligibilityContext,
+} from '../interfaces/trade-eligibility-rule.interface';
+
+/**
+ * Rejects trades for users who have open AML flags or whose trade amount
+ * exceeds the hard AML threshold (used as a last-resort circuit-breaker when
+ * real-time AML scanning is unavailable).
+ */
+@Injectable()
+export class AmlStatusRule implements ITradeEligibilityRule {
+  readonly ruleId = 'AML_STATUS_CHECK';
+  readonly ruleName = 'AML / Sanctions Status Check';
+
+  /** Hard threshold above which any single trade is flagged for AML review. */
+  private static readonly HARD_AMOUNT_THRESHOLD = 1_000_000;
+
+  async evaluate(context: TradeEligibilityContext): Promise<RuleResult> {
+    if (context.hasAmlFlags) {
+      return {
+        ruleId: this.ruleId,
+        ruleName: this.ruleName,
+        passed: false,
+        reason:
+          'Trade rejected: account has open AML flags. ' +
+          'Our compliance team will review your account.',
+      };
+    }
+
+    if (context.amount > AmlStatusRule.HARD_AMOUNT_THRESHOLD) {
+      return {
+        ruleId: this.ruleId,
+        ruleName: this.ruleName,
+        passed: false,
+        reason:
+          `Trade rejected: single-trade amount of ${context.amount} exceeds ` +
+          `the AML review threshold of ${AmlStatusRule.HARD_AMOUNT_THRESHOLD}. ` +
+          `Please contact support to proceed.`,
+      };
+    }
+
+    return { ruleId: this.ruleId, ruleName: this.ruleName, passed: true };
+  }
+}

--- a/src/compliance/rule-engine/rules/asset-class-restriction.rule.ts
+++ b/src/compliance/rule-engine/rules/asset-class-restriction.rule.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ITradeEligibilityRule,
+  RuleResult,
+  TradeEligibilityContext,
+} from '../interfaces/trade-eligibility-rule.interface';
+
+/**
+ * Rejects trades involving assets that are restricted on this platform.
+ * The restricted asset list is loaded from the RESTRICTED_ASSETS environment
+ * variable (comma-separated symbols) and falls back to a sensible default.
+ */
+@Injectable()
+export class AssetClassRestrictionRule implements ITradeEligibilityRule {
+  readonly ruleId = 'ASSET_CLASS_RESTRICTION';
+  readonly ruleName = 'Asset Class Restriction Check';
+
+  private readonly restrictedAssets: Set<string>;
+
+  constructor(private readonly configService: ConfigService) {
+    const raw = this.configService.get<string>('RESTRICTED_ASSETS', '');
+    this.restrictedAssets = new Set(
+      raw
+        .split(',')
+        .map((a) => a.trim().toUpperCase())
+        .filter(Boolean),
+    );
+  }
+
+  async evaluate(context: TradeEligibilityContext): Promise<RuleResult> {
+    const assetsToCheck = [
+      context.asset?.toUpperCase(),
+      context.counterAsset?.toUpperCase(),
+    ].filter(Boolean) as string[];
+
+    const restricted = assetsToCheck.filter((a) =>
+      this.restrictedAssets.has(a),
+    );
+
+    const passed = restricted.length === 0;
+
+    return {
+      ruleId: this.ruleId,
+      ruleName: this.ruleName,
+      passed,
+      reason: passed
+        ? undefined
+        : `Trade rejected: asset(s) [${restricted.join(', ')}] are restricted ` +
+          `on this platform.`,
+    };
+  }
+
+  /** Expose the current restricted list for admin endpoints. */
+  getRestrictedAssets(): string[] {
+    return Array.from(this.restrictedAssets);
+  }
+}

--- a/src/compliance/rule-engine/rules/geographic-restriction.rule.ts
+++ b/src/compliance/rule-engine/rules/geographic-restriction.rule.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ITradeEligibilityRule,
+  RuleResult,
+  TradeEligibilityContext,
+} from '../interfaces/trade-eligibility-rule.interface';
+
+/**
+ * Rejects trades originating from OFAC-sanctioned or otherwise restricted
+ * jurisdictions.  The blocked country list is loaded from the
+ * BLOCKED_COUNTRIES environment variable (comma-separated ISO-3166-1 alpha-2
+ * codes) and falls back to a sensible default.
+ */
+@Injectable()
+export class GeographicRestrictionRule implements ITradeEligibilityRule {
+  readonly ruleId = 'GEOGRAPHIC_RESTRICTION';
+  readonly ruleName = 'Geographic Restriction Check';
+
+  private readonly blockedCountries: Set<string>;
+
+  constructor(private readonly configService: ConfigService) {
+    const raw = this.configService.get<string>(
+      'BLOCKED_COUNTRIES',
+      'CU,IR,KP,SY,RU,BY,VE,MM,ZW,SD,LY,SO,YE,IQ,LB,AF',
+    );
+    this.blockedCountries = new Set(
+      raw.split(',').map((c) => c.trim().toUpperCase()),
+    );
+  }
+
+  async evaluate(context: TradeEligibilityContext): Promise<RuleResult> {
+    // If no country code is available we allow the trade (fail-open for geo).
+    if (!context.countryCode) {
+      return { ruleId: this.ruleId, ruleName: this.ruleName, passed: true };
+    }
+
+    const code = context.countryCode.toUpperCase();
+    const passed = !this.blockedCountries.has(code);
+
+    return {
+      ruleId: this.ruleId,
+      ruleName: this.ruleName,
+      passed,
+      reason: passed
+        ? undefined
+        : `Trade rejected: trading is not permitted from jurisdiction "${code}" ` +
+          `due to regulatory restrictions.`,
+    };
+  }
+
+  /** Expose the current blocked list for admin endpoints. */
+  getBlockedCountries(): string[] {
+    return Array.from(this.blockedCountries);
+  }
+}

--- a/src/compliance/rule-engine/rules/kyc-status.rule.ts
+++ b/src/compliance/rule-engine/rules/kyc-status.rule.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ITradeEligibilityRule,
+  RuleResult,
+  TradeEligibilityContext,
+} from '../interfaces/trade-eligibility-rule.interface';
+import { KycStatus } from '../../../users/entities/user.entity';
+
+/**
+ * Rejects trades from users whose KYC verification is not in VERIFIED state.
+ */
+@Injectable()
+export class KycStatusRule implements ITradeEligibilityRule {
+  readonly ruleId = 'KYC_STATUS_CHECK';
+  readonly ruleName = 'KYC Status Verification';
+
+  async evaluate(context: TradeEligibilityContext): Promise<RuleResult> {
+    const passed = context.kycStatus === KycStatus.VERIFIED;
+
+    return {
+      ruleId: this.ruleId,
+      ruleName: this.ruleName,
+      passed,
+      reason: passed
+        ? undefined
+        : `Trade rejected: KYC status is "${context.kycStatus ?? 'unknown'}". ` +
+          `Please complete identity verification before trading.`,
+    };
+  }
+}

--- a/src/compliance/rule-engine/rules/transaction-limit.rule.ts
+++ b/src/compliance/rule-engine/rules/transaction-limit.rule.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ITradeEligibilityRule,
+  RuleResult,
+  TradeEligibilityContext,
+} from '../interfaces/trade-eligibility-rule.interface';
+import { UserTier } from '../../../users/entities/user.entity';
+
+/** Per-tier single-trade limits (in base asset units). */
+const TIER_LIMITS: Record<string, number> = {
+  [UserTier.BASIC]: 1_000,
+  [UserTier.SILVER]: 5_000,
+  [UserTier.GOLD]: 20_000,
+  [UserTier.PLATINUM]: 100_000,
+};
+
+/** Default limit applied when the tier is unknown. */
+const DEFAULT_LIMIT = 0;
+
+/**
+ * Rejects trades whose amount exceeds the per-tier transaction limit.
+ */
+@Injectable()
+export class TransactionLimitRule implements ITradeEligibilityRule {
+  readonly ruleId = 'TRANSACTION_LIMIT_CHECK';
+  readonly ruleName = 'Transaction Limit Check';
+
+  async evaluate(context: TradeEligibilityContext): Promise<RuleResult> {
+    const tier = context.userTier ?? '';
+    const limit = TIER_LIMITS[tier] ?? DEFAULT_LIMIT;
+
+    const passed = context.amount <= limit;
+
+    return {
+      ruleId: this.ruleId,
+      ruleName: this.ruleName,
+      passed,
+      reason: passed
+        ? undefined
+        : `Trade rejected: amount ${context.amount} exceeds the ` +
+          `${tier || 'unknown'}-tier limit of ${limit}. ` +
+          `Upgrade your account tier to trade larger amounts.`,
+    };
+  }
+
+  /** Expose limits for informational endpoints. */
+  getTierLimits(): Record<string, number> {
+    return { ...TIER_LIMITS };
+  }
+}

--- a/src/trades/trades.service.ts
+++ b/src/trades/trades.service.ts
@@ -1,8 +1,17 @@
-import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Trade, TradeStatus, TradeSide } from './entities/trade.entity';
-import { ExecuteTradeDto, CloseTradeDto, GetUserTradesDto } from './dto/execute-trade.dto';
+import {
+  ExecuteTradeDto,
+  CloseTradeDto,
+  GetUserTradesDto,
+} from './dto/execute-trade.dto';
 import {
   TradeResultDto,
   TradeDetailsDto,
@@ -10,11 +19,17 @@ import {
   UserTradesSummaryDto,
   CloseTradeResultDto,
 } from './dto/trade-result.dto';
-import { RiskManagerService, UserBalance } from './services/risk-manager.service';
+import {
+  RiskManagerService,
+  UserBalance,
+} from './services/risk-manager.service';
 import { TradeExecutorService } from './services/trade-executor.service';
 import { RiskManagerService as VelocityRiskManager } from '../risk/risk-manager.service';
-import { ComplianceService } from '../compliance/compliance.service';
-import { TradeLatencyService, TradeStage } from './services/trade-latency.service';
+import { ComplianceRuleEngineService } from '../compliance/rule-engine/compliance-rule-engine.service';
+import {
+  TradeLatencyService,
+  TradeStage,
+} from './services/trade-latency.service';
 
 interface SignalData {
   id: string;
@@ -37,12 +52,14 @@ export class TradesService {
     private readonly riskManager: RiskManagerService,
     private readonly tradeExecutor: TradeExecutorService,
     private readonly velocityRiskManager: VelocityRiskManager,
-    private readonly complianceService: ComplianceService,
+    private readonly complianceRuleEngine: ComplianceRuleEngineService,
     private readonly tradeLatency: TradeLatencyService,
   ) {}
 
   async executeTrade(dto: ExecuteTradeDto): Promise<TradeResultDto> {
-    this.logger.log(`Executing trade for user ${dto.userId}, signal ${dto.signalId}`);
+    this.logger.log(
+      `Executing trade for user ${dto.userId}, signal ${dto.signalId}`,
+    );
 
     // Use a temporary flow ID until the persisted trade ID is available
     const tempFlowId = `${dto.userId}-${dto.signalId}-${Date.now()}`;
@@ -54,17 +71,31 @@ export class TradesService {
         tempFlowId,
         TradeStage.VALIDATION,
         async () => {
-          const isDuplicate = await this.riskManager.checkDuplicateTrade(dto.userId, dto.signalId);
+          const isDuplicate = await this.riskManager.checkDuplicateTrade(
+            dto.userId,
+            dto.signalId,
+          );
           if (isDuplicate) {
-            throw new BadRequestException('A pending trade already exists for this signal');
+            throw new BadRequestException(
+              'A pending trade already exists for this signal',
+            );
           }
 
           const signal = await this.getSignalData(dto.signalId);
           const userBalance = await this.getUserBalance(dto.userId);
 
-          await this.complianceService.validateTransaction(dto.userId, dto.amount, signal.baseAsset);
+          await this.complianceRuleEngine.evaluateTrade({
+            userId: dto.userId,
+            amount: dto.amount,
+            asset: signal.baseAsset,
+            counterAsset: signal.counterAsset,
+          });
 
-          const validation = await this.riskManager.validateTrade(dto, signal, userBalance);
+          const validation = await this.riskManager.validateTrade(
+            dto,
+            signal,
+            userBalance,
+          );
           if (!validation.isValid) {
             throw new BadRequestException({
               message: 'Trade validation failed',
@@ -104,9 +135,13 @@ export class TradesService {
             counterAsset: signalData_.counterAsset,
             entryPrice: signalData_.entryPrice,
             amount: dto.amount.toString(),
-            totalValue: (dto.amount * parseFloat(signalData_.entryPrice)).toFixed(8),
-            stopLossPrice: dto.stopLossPrice?.toString() || signalData_.stopLossPrice,
-            takeProfitPrice: dto.takeProfitPrice?.toString() || signalData_.targetPrice,
+            totalValue: (
+              dto.amount * parseFloat(signalData_.entryPrice)
+            ).toFixed(8),
+            stopLossPrice:
+              dto.stopLossPrice?.toString() || signalData_.stopLossPrice,
+            takeProfitPrice:
+              dto.takeProfitPrice?.toString() || signalData_.targetPrice,
             status: TradeStatus.PENDING,
           });
           await this.tradeRepository.save(newTrade);
@@ -125,32 +160,39 @@ export class TradesService {
 
       if (executionResult.success) {
         // ── Stage: CONFIRMATION ──────────────────────────────────────────────
-        await this.tradeLatency.measureStage(trade.id, TradeStage.CONFIRMATION, async () => {
-          trade.status = TradeStatus.COMPLETED;
-          trade.transactionHash = executionResult.transactionHash;
-          trade.sorobanContractId = executionResult.contractId;
-          trade.feeAmount = executionResult.feeAmount || '0';
-          trade.executedAt = new Date();
+        await this.tradeLatency.measureStage(
+          trade.id,
+          TradeStage.CONFIRMATION,
+          async () => {
+            trade.status = TradeStatus.COMPLETED;
+            trade.transactionHash = executionResult.transactionHash;
+            trade.sorobanContractId = executionResult.contractId;
+            trade.feeAmount = executionResult.feeAmount || '0';
+            trade.executedAt = new Date();
 
-          if (executionResult.executedPrice) {
-            trade.entryPrice = executionResult.executedPrice;
-            trade.totalValue = (
-              parseFloat(trade.amount) * parseFloat(executionResult.executedPrice)
-            ).toFixed(8);
-          }
+            if (executionResult.executedPrice) {
+              trade.entryPrice = executionResult.executedPrice;
+              trade.totalValue = (
+                parseFloat(trade.amount) *
+                parseFloat(executionResult.executedPrice)
+              ).toFixed(8);
+            }
 
-          await this.tradeRepository.save(trade);
+            await this.tradeRepository.save(trade);
 
-          await this.velocityRiskManager.recordTradeExecution({
-            userId: trade.userId,
-            asset: `${trade.baseAsset}/${trade.counterAsset}`,
-            amount: parseFloat(trade.amount),
-            entryPrice: parseFloat(trade.entryPrice),
-          });
-        });
+            await this.velocityRiskManager.recordTradeExecution({
+              userId: trade.userId,
+              asset: `${trade.baseAsset}/${trade.counterAsset}`,
+              amount: parseFloat(trade.amount),
+              entryPrice: parseFloat(trade.entryPrice),
+            });
+          },
+        );
 
         this.tradeLatency.endFlow(trade.id, 'success');
-        this.logger.log(`Trade ${trade.id} executed successfully. Hash: ${trade.transactionHash}`);
+        this.logger.log(
+          `Trade ${trade.id} executed successfully. Hash: ${trade.transactionHash}`,
+        );
 
         return {
           id: trade.id,
@@ -199,22 +241,27 @@ export class TradesService {
     }
 
     if (trade.status !== TradeStatus.COMPLETED || trade.closedAt) {
-      throw new BadRequestException('Trade cannot be closed. It must be in completed status and not already closed.');
+      throw new BadRequestException(
+        'Trade cannot be closed. It must be in completed status and not already closed.',
+      );
     }
 
     // Get current market price or use provided exit price
-    const exitPrice = dto.exitPrice?.toString() || await this.getCurrentPrice(trade.baseAsset, trade.counterAsset);
+    const exitPrice =
+      dto.exitPrice?.toString() ||
+      (await this.getCurrentPrice(trade.baseAsset, trade.counterAsset));
 
     // Execute close on Soroban
     const closeResult = await this.tradeExecutor.closeTrade(trade, exitPrice);
 
     if (closeResult.success) {
-      const { profitLoss, profitLossPercentage } = this.riskManager.calculateProfitLoss(
-        trade.entryPrice,
-        exitPrice,
-        trade.amount,
-        trade.side === TradeSide.BUY ? 'buy' : 'sell',
-      );
+      const { profitLoss, profitLossPercentage } =
+        this.riskManager.calculateProfitLoss(
+          trade.entryPrice,
+          exitPrice,
+          trade.amount,
+          trade.side === TradeSide.BUY ? 'buy' : 'sell',
+        );
 
       trade.exitPrice = exitPrice;
       trade.profitLoss = profitLoss;
@@ -224,11 +271,17 @@ export class TradesService {
       await this.tradeRepository.save(trade);
 
       // Handle large loss for velocity tracking
-      if (parseFloat(profitLoss) < -1000) { // Loss threshold
-        await this.velocityRiskManager.handleTradeLoss(trade.userId, Math.abs(parseFloat(profitLoss)));
+      if (parseFloat(profitLoss) < -1000) {
+        // Loss threshold
+        await this.velocityRiskManager.handleTradeLoss(
+          trade.userId,
+          Math.abs(parseFloat(profitLoss)),
+        );
       }
 
-      this.logger.log(`Trade ${trade.id} closed. P&L: ${profitLoss} (${profitLossPercentage}%)`);
+      this.logger.log(
+        `Trade ${trade.id} closed. P&L: ${profitLoss} (${profitLossPercentage}%)`,
+      );
 
       return {
         id: trade.id,
@@ -248,7 +301,10 @@ export class TradesService {
     }
   }
 
-  async getTradeById(tradeId: string, userId: string): Promise<TradeDetailsDto> {
+  async getTradeById(
+    tradeId: string,
+    userId: string,
+  ): Promise<TradeDetailsDto> {
     const trade = await this.tradeRepository.findOne({
       where: { id: tradeId, userId },
     });
@@ -279,7 +335,7 @@ export class TradesService {
     }
 
     const trades = await query.getMany();
-    return trades.map(trade => this.mapToTradeDetails(trade));
+    return trades.map((trade) => this.mapToTradeDetails(trade));
   }
 
   async getUserTradesSummary(userId: string): Promise<UserTradesSummaryDto> {
@@ -288,15 +344,26 @@ export class TradesService {
     });
 
     const totalTrades = trades.length;
-    const openTrades = trades.filter(t => t.status === TradeStatus.COMPLETED && !t.closedAt).length;
-    const completedTrades = trades.filter(t => t.closedAt).length;
-    const failedTrades = trades.filter(t => t.status === TradeStatus.FAILED).length;
+    const openTrades = trades.filter(
+      (t) => t.status === TradeStatus.COMPLETED && !t.closedAt,
+    ).length;
+    const completedTrades = trades.filter((t) => t.closedAt).length;
+    const failedTrades = trades.filter(
+      (t) => t.status === TradeStatus.FAILED,
+    ).length;
 
-    const closedTrades = trades.filter(t => t.closedAt && t.profitLoss);
-    const totalProfitLoss = closedTrades.reduce((sum, t) => sum + parseFloat(t.profitLoss || '0'), 0);
-    const winningTrades = closedTrades.filter(t => parseFloat(t.profitLoss || '0') > 0).length;
-    const winRate = closedTrades.length > 0 ? (winningTrades / closedTrades.length) * 100 : 0;
-    const averageProfitLoss = closedTrades.length > 0 ? totalProfitLoss / closedTrades.length : 0;
+    const closedTrades = trades.filter((t) => t.closedAt && t.profitLoss);
+    const totalProfitLoss = closedTrades.reduce(
+      (sum, t) => sum + parseFloat(t.profitLoss || '0'),
+      0,
+    );
+    const winningTrades = closedTrades.filter(
+      (t) => parseFloat(t.profitLoss || '0') > 0,
+    ).length;
+    const winRate =
+      closedTrades.length > 0 ? (winningTrades / closedTrades.length) * 100 : 0;
+    const averageProfitLoss =
+      closedTrades.length > 0 ? totalProfitLoss / closedTrades.length : 0;
 
     return {
       totalTrades,
@@ -309,7 +376,9 @@ export class TradesService {
     };
   }
 
-  async validateTradePreview(dto: ExecuteTradeDto): Promise<TradeValidationResultDto> {
+  async validateTradePreview(
+    dto: ExecuteTradeDto,
+  ): Promise<TradeValidationResultDto> {
     const signalData = await this.getSignalData(dto.signalId);
     const userBalance = await this.getUserBalance(dto.userId);
     return this.riskManager.validateTrade(dto, signalData, userBalance);
@@ -323,7 +392,9 @@ export class TradesService {
       },
     });
 
-    return trades.filter(t => !t.closedAt).map(trade => this.mapToTradeDetails(trade));
+    return trades
+      .filter((t) => !t.closedAt)
+      .map((trade) => this.mapToTradeDetails(trade));
   }
 
   async getTradesBySignal(signalId: string): Promise<TradeDetailsDto[]> {
@@ -332,7 +403,7 @@ export class TradesService {
       order: { createdAt: 'DESC' },
     });
 
-    return trades.map(trade => this.mapToTradeDetails(trade));
+    return trades.map((trade) => this.mapToTradeDetails(trade));
   }
 
   private mapToTradeDetails(trade: Trade): TradeDetailsDto {
@@ -387,7 +458,10 @@ export class TradesService {
     };
   }
 
-  private async getCurrentPrice(_baseAsset: string, _counterAsset: string): Promise<string> {
+  private async getCurrentPrice(
+    _baseAsset: string,
+    _counterAsset: string,
+  ): Promise<string> {
     // In production, call price feed service
     return '0.16000000';
   }


### PR DESCRIPTION
- Add ITradeEligibilityRule interface and TradeEligibilityContext types
- Implement KycStatusRule, GeographicRestrictionRule, AmlStatusRule, AssetClassRestrictionRule, and TransactionLimitRule
- Add ComplianceRuleEngineService that orchestrates all rules, enriches context (geo lookup, AML flags), and persists immutable audit decisions
- Add TradeEligibilityDecision entity for compliance audit trail
- Expose POST /compliance/rule-engine/evaluate (dry-run) and GET /compliance/rule-engine/decisions/:userId endpoints
- Wire rule engine into TradesService replacing validateTransaction
- Register all providers and new entity in ComplianceModule
- Add 30+ unit tests covering compliant and non-compliant scenarios
closes #540 