### PR TITLE
[codex] Add secure webhook signature verification

### DIFF
--- a/src/integrations/webhooks/utils/signature-validator.ts
+++ b/src/integrations/webhooks/utils/signature-validator.ts
@@ -1,0 +1,49 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export type WebhookSignatureAlgorithm = 'sha256' | 'sha512';
+
+interface VerifyWebhookSignatureInput {
+  payload: Buffer | string;
+  secret?: string;
+  signature?: string | string[];
+  algorithm?: WebhookSignatureAlgorithm;
+}
+
+export function createWebhookSignature(
+  payload: Buffer | string,
+  secret: string,
+  algorithm: WebhookSignatureAlgorithm = 'sha256',
+): string {
+  return createHmac(algorithm, secret).update(payload).digest('hex');
+}
+
+export function normalizeWebhookSignature(
+  signature?: string | string[],
+): string | null {
+  const candidate = Array.isArray(signature) ? signature[0] : signature;
+  if (!candidate || candidate.trim() === '') return null;
+
+  return candidate.trim().replace(/^sha(?:256|512)=/i, '');
+}
+
+export function verifyWebhookSignature({
+  payload,
+  secret,
+  signature,
+  algorithm = 'sha256',
+}: VerifyWebhookSignatureInput): boolean {
+  if (!secret || secret.trim() === '') return false;
+
+  const normalizedSignature = normalizeWebhookSignature(signature);
+  if (!normalizedSignature || !/^[a-f0-9]+$/i.test(normalizedSignature)) {
+    return false;
+  }
+
+  const expectedSignature = createWebhookSignature(payload, secret, algorithm);
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+  const receivedBuffer = Buffer.from(normalizedSignature, 'hex');
+
+  if (receivedBuffer.length !== expectedBuffer.length) return false;
+
+  return timingSafeEqual(receivedBuffer, expectedBuffer);
+}

--- a/src/integrations/webhooks/webhook-verifier.service.spec.ts
+++ b/src/integrations/webhooks/webhook-verifier.service.spec.ts
@@ -1,0 +1,80 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { WebhookController } from './webhook.controller';
+import { WebhookVerifierService } from './webhook-verifier.service';
+import { createWebhookSignature } from './utils/signature-validator';
+
+describe('WebhookVerifierService', () => {
+  const payload = Buffer.from(
+    JSON.stringify({ event: 'trade.executed', id: 'evt_123' }),
+  );
+  const signingKey = 'provider-signing-secret';
+  let service: WebhookVerifierService;
+  let controller: WebhookController;
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'webhooks.signingKeys.stellar') return signingKey;
+        return undefined;
+      }),
+    } as unknown as ConfigService;
+
+    service = new WebhookVerifierService(configService);
+    controller = new WebhookController(service);
+  });
+
+  it('accepts valid provider signatures from configured signing keys', () => {
+    const signature = createWebhookSignature(payload, signingKey);
+
+    expect(service.verifySignature('stellar', payload, signature)).toBe(true);
+    expect(
+      service.verifySignature('stellar', payload, `sha256=${signature}`),
+    ).toBe(true);
+  });
+
+  it('rejects invalid and missing signatures', () => {
+    expect(service.verifySignature('stellar', payload, 'bad-signature')).toBe(
+      false,
+    );
+    expect(service.verifySignature('stellar', payload, undefined)).toBe(false);
+
+    expect(() =>
+      service.assertValidSignature('stellar', payload, 'bad-signature'),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('rejects signatures when no provider signing key is configured', () => {
+    const signature = createWebhookSignature(payload, signingKey);
+
+    expect(service.verifySignature('unknown', payload, signature)).toBe(false);
+  });
+
+  it('returns 401 through the controller for invalid incoming webhook requests', async () => {
+    await expect(
+      controller.receiveWebhook(
+        'stellar',
+        { 'x-webhook-signature': 'bad-signature' },
+        { rawBody: payload } as never,
+        { event: 'trade.executed', id: 'evt_123' },
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('accepts valid incoming webhook requests through the controller', async () => {
+    const signature = createWebhookSignature(payload, signingKey);
+
+    await expect(
+      controller.receiveWebhook(
+        'stellar',
+        { 'x-webhook-signature': signature },
+        { rawBody: payload } as never,
+        { event: 'trade.executed', id: 'evt_123' },
+      ),
+    ).resolves.toEqual({
+      received: true,
+      provider: 'stellar',
+    });
+  });
+});

--- a/src/integrations/webhooks/webhook-verifier.service.ts
+++ b/src/integrations/webhooks/webhook-verifier.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import {
+  WebhookSignatureAlgorithm,
+  verifyWebhookSignature,
+} from './utils/signature-validator';
+
+@Injectable()
+export class WebhookVerifierService {
+  constructor(private readonly configService: ConfigService) {}
+
+  verifySignature(
+    provider: string,
+    payload: Buffer | string,
+    signature?: string | string[],
+    algorithm: WebhookSignatureAlgorithm = 'sha256',
+  ): boolean {
+    const signingKey = this.getSigningKey(provider);
+
+    return verifyWebhookSignature({
+      payload,
+      secret: signingKey,
+      signature,
+      algorithm,
+    });
+  }
+
+  assertValidSignature(
+    provider: string,
+    payload: Buffer | string,
+    signature?: string | string[],
+    algorithm: WebhookSignatureAlgorithm = 'sha256',
+  ): void {
+    if (!this.verifySignature(provider, payload, signature, algorithm)) {
+      throw new UnauthorizedException('Invalid webhook signature');
+    }
+  }
+
+  private getSigningKey(provider: string): string | undefined {
+    const normalizedProvider = provider.trim();
+    const envProvider = normalizedProvider
+      .replace(/[^a-zA-Z0-9]/g, '_')
+      .toUpperCase();
+
+    return (
+      this.configService.get<string>(
+        `webhooks.signingKeys.${normalizedProvider}`,
+      ) ??
+      this.configService.get<string>(`WEBHOOK_${envProvider}_SIGNING_KEY`) ??
+      this.configService.get<string>('WEBHOOK_SIGNING_KEY')
+    );
+  }
+}

--- a/src/integrations/webhooks/webhook.controller.ts
+++ b/src/integrations/webhooks/webhook.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Body,
+  Controller,
+  Headers,
+  Param,
+  Post,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { WebhookVerifierService } from './webhook-verifier.service';
+
+@Controller('integrations/webhooks')
+export class WebhookController {
+  constructor(private readonly verifier: WebhookVerifierService) {}
+
+  @Post(':provider')
+  async receiveWebhook(
+    @Param('provider') provider: string,
+    @Headers() headers: Record<string, string | string[] | undefined>,
+    @Req() req: RawBodyRequest<Request>,
+    @Body() body: unknown,
+  ) {
+    const signature = this.getSignatureHeader(headers);
+    const payload = req.rawBody ?? Buffer.from(JSON.stringify(body ?? {}));
+
+    this.verifier.assertValidSignature(provider, payload, signature);
+
+    return {
+      received: true,
+      provider,
+    };
+  }
+
+  private getSignatureHeader(
+    headers: Record<string, string | string[] | undefined>,
+  ): string | string[] | undefined {
+    return (
+      headers['x-webhook-signature'] ??
+      headers['x-signature'] ??
+      headers['x-hub-signature-256'] ??
+      headers['stripe-signature']
+    );
+  }
+}

--- a/src/integrations/webhooks/webhook.module.ts
+++ b/src/integrations/webhooks/webhook.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { WebhookController } from './webhook.controller';
+import { WebhookVerifierService } from './webhook-verifier.service';
+
+@Module({
+  controllers: [WebhookController],
+  providers: [WebhookVerifierService],
+  exports: [WebhookVerifierService],
+})
+export class IncomingWebhooksModule {}


### PR DESCRIPTION
## Summary
- Adds a reusable HMAC webhook signature validator with timing-safe comparisons and `sha256=`/`sha512=` prefix normalization.
- Adds `WebhookVerifierService` that resolves provider signing keys from Nest config/env and rejects invalid signatures with `UnauthorizedException`.
- Adds an incoming webhook controller plus mountable module under `src/integrations/webhooks`.
- Adds Jest coverage for valid signatures, invalid/missing signatures, missing provider configuration, and controller 401 behavior.

Fixes #582

## Validation
- `npm test -- src/integrations/webhooks/webhook-verifier.service.spec.ts --runInBand`
- `npx eslint src/integrations/webhooks/webhook.controller.ts src/integrations/webhooks/webhook.module.ts src/integrations/webhooks/webhook-verifier.service.ts src/integrations/webhooks/utils/signature-validator.ts`
- `npx tsc --noEmit --pretty false --module commonjs --target ES2020 --experimentalDecorators --emitDecoratorMetadata --esModuleInterop --skipLibCheck --types node,jest src/integrations/webhooks/webhook.controller.ts src/integrations/webhooks/webhook.module.ts src/integrations/webhooks/webhook-verifier.service.ts src/integrations/webhooks/utils/signature-validator.ts src/integrations/webhooks/webhook-verifier.service.spec.ts`
- `git diff --check`

## Notes
- `npm run build` is currently blocked by existing repository errors outside this change. The first failures include unresolved `InjectRedis`, TypeORM `Repository.reload`, literal branch-name debris in `src/app.module.ts` (`feature/...`, `main`), missing `EmailModule`, missing compliance/event modules, and other unrelated type errors.
- ESLint source checks pass for the new integration files; the repo config excludes `*.spec.ts` from its TypeScript project, so the spec is validated by Jest instead.