### PR TITLE
[codex] Add analytics data drift detection

### DIFF
--- a/src/analytics/drift-detection/drift-detection.module.ts
+++ b/src/analytics/drift-detection/drift-detection.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { DriftDetectorService } from './drift-detector.service';
+import { DetectDataDriftJob } from './jobs/detect-data-drift.job';
+
+@Module({
+  providers: [DriftDetectorService, DetectDataDriftJob],
+  exports: [DriftDetectorService],
+})
+export class DriftDetectionModule {}

--- a/src/analytics/drift-detection/drift-detector.service.spec.ts
+++ b/src/analytics/drift-detection/drift-detector.service.spec.ts
@@ -1,0 +1,97 @@
+import {
+  DriftAlertPublisher,
+  DriftDetectorService,
+  DriftFindingStore,
+} from './drift-detector.service';
+import { DetectDataDriftJob } from './jobs/detect-data-drift.job';
+import { compareDistributions } from './utils/distribution-analyzer';
+
+describe('DriftDetectorService', () => {
+  let findingStore: jest.Mocked<DriftFindingStore>;
+  let alertPublisher: jest.Mocked<DriftAlertPublisher>;
+  let service: DriftDetectorService;
+
+  beforeEach(() => {
+    findingStore = {
+      saveDriftFinding: jest.fn(),
+    };
+    alertPublisher = {
+      publishDriftAlert: jest.fn(),
+    };
+    service = new DriftDetectorService(findingStore, alertPublisher);
+  });
+
+  it('compares distributions and reports no drift below the configured threshold', async () => {
+    const findings = await service.detectFeedDrift({
+      feedName: 'stellar-price-feed',
+      threshold: 0.25,
+      baseline: {
+        price: [100, 101, 99, 100],
+      },
+      current: {
+        price: [102, 101, 100, 102],
+      },
+    });
+
+    expect(findings).toEqual([]);
+    expect(findingStore.saveDriftFinding).not.toHaveBeenCalled();
+    expect(alertPublisher.publishDriftAlert).not.toHaveBeenCalled();
+  });
+
+  it('stores drift findings and publishes alerts when thresholds are exceeded', async () => {
+    const findings = await service.detectFeedDrift({
+      feedName: 'stellar-price-feed',
+      threshold: 0.2,
+      baseline: {
+        price: [100, 101, 99, 100],
+        volume: [1_000, 1_050, 950, 1_000],
+      },
+      current: {
+        price: [150, 151, 149, 152],
+        volume: [1_020, 1_070, 970, 1_020],
+      },
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      feedName: 'stellar-price-feed',
+      metric: 'price',
+      severity: 'critical',
+    });
+    expect(findingStore.saveDriftFinding).toHaveBeenCalledWith(findings[0]);
+    expect(alertPublisher.publishDriftAlert).toHaveBeenCalledWith(findings[0]);
+  });
+
+  it('runs the scheduled job against configured feed snapshots', async () => {
+    const feedProvider = {
+      getDriftSnapshots: jest.fn().mockResolvedValue([
+        {
+          feedName: 'trade-signal-feed',
+          threshold: 0.1,
+          baseline: { confidence: [70, 72, 71] },
+          current: { confidence: [40, 41, 39] },
+        },
+      ]),
+    };
+    const job = new DetectDataDriftJob(service, feedProvider);
+
+    const findings = await job.run();
+
+    expect(feedProvider.getDriftSnapshots).toHaveBeenCalled();
+    expect(findings).toHaveLength(1);
+    expect(alertPublisher.publishDriftAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('calculates stable distribution summaries for review', () => {
+    const comparison = compareDistributions(
+      'latency',
+      [10, 12, 14, 16],
+      [20, 22, 24, 26],
+      0.25,
+    );
+
+    expect(comparison.baseline.mean).toBe(13);
+    expect(comparison.current.mean).toBe(23);
+    expect(comparison.drifted).toBe(true);
+  });
+});

--- a/src/analytics/drift-detection/drift-detector.service.ts
+++ b/src/analytics/drift-detection/drift-detector.service.ts
@@ -1,0 +1,98 @@
+import { Inject, Injectable, Optional } from '@nestjs/common';
+
+import {
+  DistributionComparison,
+  compareDistributions,
+} from './utils/distribution-analyzer';
+
+export const DRIFT_ALERT_PUBLISHER = Symbol('DRIFT_ALERT_PUBLISHER');
+export const DRIFT_FINDING_STORE = Symbol('DRIFT_FINDING_STORE');
+
+export type DriftSeverity = 'warning' | 'critical';
+
+export interface DriftDetectionInput {
+  feedName: string;
+  baseline: Record<string, number[]>;
+  current: Record<string, number[]>;
+  threshold?: number;
+}
+
+export interface DriftFindingRecord {
+  feedName: string;
+  metric: string;
+  severity: DriftSeverity;
+  score: number;
+  threshold: number;
+  baselineMean: number;
+  currentMean: number;
+  detectedAt: Date;
+  comparison: DistributionComparison;
+}
+
+export interface DriftAlertPublisher {
+  publishDriftAlert(finding: DriftFindingRecord): Promise<void> | void;
+}
+
+export interface DriftFindingStore {
+  saveDriftFinding(finding: DriftFindingRecord): Promise<void> | void;
+}
+
+@Injectable()
+export class DriftDetectorService {
+  constructor(
+    @Optional()
+    @Inject(DRIFT_FINDING_STORE)
+    private readonly findingStore?: DriftFindingStore,
+    @Optional()
+    @Inject(DRIFT_ALERT_PUBLISHER)
+    private readonly alertPublisher?: DriftAlertPublisher,
+  ) {}
+
+  async detectFeedDrift(
+    input: DriftDetectionInput,
+  ): Promise<DriftFindingRecord[]> {
+    const findings: DriftFindingRecord[] = [];
+
+    for (const metric of Object.keys(input.current)) {
+      const baselineValues = input.baseline[metric] ?? [];
+      const currentValues = input.current[metric] ?? [];
+
+      if (baselineValues.length === 0 || currentValues.length === 0) {
+        continue;
+      }
+
+      const comparison = compareDistributions(
+        metric,
+        baselineValues,
+        currentValues,
+        input.threshold,
+      );
+
+      if (!comparison.drifted) continue;
+
+      const finding: DriftFindingRecord = {
+        feedName: input.feedName,
+        metric,
+        severity: this.getSeverity(comparison),
+        score: comparison.driftScore,
+        threshold: comparison.threshold,
+        baselineMean: comparison.baseline.mean,
+        currentMean: comparison.current.mean,
+        detectedAt: new Date(),
+        comparison,
+      };
+
+      await this.findingStore?.saveDriftFinding(finding);
+      await this.alertPublisher?.publishDriftAlert(finding);
+      findings.push(finding);
+    }
+
+    return findings;
+  }
+
+  private getSeverity(comparison: DistributionComparison): DriftSeverity {
+    return comparison.driftScore >= comparison.threshold * 2
+      ? 'critical'
+      : 'warning';
+  }
+}

--- a/src/analytics/drift-detection/jobs/detect-data-drift.job.ts
+++ b/src/analytics/drift-detection/jobs/detect-data-drift.job.ts
@@ -1,0 +1,36 @@
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import {
+  DriftDetectionInput,
+  DriftDetectorService,
+  DriftFindingRecord,
+} from '../drift-detector.service';
+
+export const DRIFT_FEED_PROVIDER = Symbol('DRIFT_FEED_PROVIDER');
+
+export interface DriftFeedSnapshotProvider {
+  getDriftSnapshots(): Promise<DriftDetectionInput[]>;
+}
+
+@Injectable()
+export class DetectDataDriftJob {
+  constructor(
+    private readonly driftDetector: DriftDetectorService,
+    @Optional()
+    @Inject(DRIFT_FEED_PROVIDER)
+    private readonly feedProvider?: DriftFeedSnapshotProvider,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async run(): Promise<DriftFindingRecord[]> {
+    if (!this.feedProvider) return [];
+
+    const snapshots = await this.feedProvider.getDriftSnapshots();
+    const findings = await Promise.all(
+      snapshots.map((snapshot) => this.driftDetector.detectFeedDrift(snapshot)),
+    );
+
+    return findings.flat();
+  }
+}

--- a/src/analytics/drift-detection/utils/distribution-analyzer.ts
+++ b/src/analytics/drift-detection/utils/distribution-analyzer.ts
@@ -1,0 +1,101 @@
+export interface DistributionSummary {
+  count: number;
+  mean: number;
+  variance: number;
+  stdDev: number;
+  min: number;
+  max: number;
+  p50: number;
+  p95: number;
+}
+
+export interface DistributionComparison {
+  metric: string;
+  baseline: DistributionSummary;
+  current: DistributionSummary;
+  meanDelta: number;
+  relativeMeanDelta: number;
+  stdDevRatio: number;
+  driftScore: number;
+  threshold: number;
+  drifted: boolean;
+}
+
+const DEFAULT_THRESHOLD = 0.25;
+
+export function summarizeDistribution(values: number[]): DistributionSummary {
+  if (values.length === 0) {
+    return {
+      count: 0,
+      mean: 0,
+      variance: 0,
+      stdDev: 0,
+      min: 0,
+      max: 0,
+      p50: 0,
+      p95: 0,
+    };
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const count = sorted.length;
+  const mean = sorted.reduce((sum, value) => sum + value, 0) / count;
+  const variance =
+    sorted.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / count;
+
+  return {
+    count,
+    mean,
+    variance,
+    stdDev: Math.sqrt(variance),
+    min: sorted[0],
+    max: sorted[count - 1],
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+  };
+}
+
+export function compareDistributions(
+  metric: string,
+  baselineValues: number[],
+  currentValues: number[],
+  threshold = DEFAULT_THRESHOLD,
+): DistributionComparison {
+  const baseline = summarizeDistribution(baselineValues);
+  const current = summarizeDistribution(currentValues);
+  const meanDelta = current.mean - baseline.mean;
+  const relativeMeanDelta =
+    baseline.mean === 0
+      ? Math.abs(meanDelta)
+      : Math.abs(meanDelta) / Math.abs(baseline.mean);
+  const stdDevRatio =
+    baseline.stdDev === 0
+      ? current.stdDev === 0
+        ? 1
+        : current.stdDev
+      : current.stdDev / baseline.stdDev;
+  const driftScore = Math.max(relativeMeanDelta, Math.abs(stdDevRatio - 1));
+
+  return {
+    metric,
+    baseline,
+    current,
+    meanDelta,
+    relativeMeanDelta,
+    stdDevRatio,
+    driftScore,
+    threshold,
+    drifted: driftScore >= threshold,
+  };
+}
+
+function percentile(sortedValues: number[], percentileRank: number): number {
+  if (sortedValues.length === 0) return 0;
+
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil(sortedValues.length * percentileRank) - 1),
+  );
+
+  return sortedValues[index];
+}


### PR DESCRIPTION
## Summary
- Adds distribution summary and comparison utilities for feed metrics.
- Adds `DriftDetectorService` that compares current feed samples against baseline distributions, assigns warning/critical severity, persists findings through a store hook, and publishes alerts through an alert publisher hook.
- Adds a scheduled `DetectDataDriftJob` that processes configured feed snapshots every five minutes.
- Adds a mountable drift detection module and focused Jest coverage for no-drift, drift persistence, alerting, job execution, and summary calculations.

Fixes #580

## Validation
- `npm test -- src/analytics/drift-detection/drift-detector.service.spec.ts --runInBand`
- `npx prettier --check src/analytics/drift-detection/drift-detector.service.ts src/analytics/drift-detection/drift-detection.module.ts src/analytics/drift-detection/jobs/detect-data-drift.job.ts src/analytics/drift-detection/utils/distribution-analyzer.ts src/analytics/drift-detection/drift-detector.service.spec.ts`
- `npx tsc --noEmit --pretty false --module commonjs --target ES2020 --experimentalDecorators --emitDecoratorMetadata --esModuleInterop --skipLibCheck --types node,jest src/analytics/drift-detection/drift-detector.service.ts src/analytics/drift-detection/drift-detection.module.ts src/analytics/drift-detection/jobs/detect-data-drift.job.ts src/analytics/drift-detection/utils/distribution-analyzer.ts src/analytics/drift-detection/drift-detector.service.spec.ts`
- `git diff --check`

## Notes
- The repo ESLint config ignores `src/analytics/**`, so I used Prettier plus a focused TypeScript compile for this isolated slice.
- Repo-wide `npm run build` is currently blocked by existing unrelated errors already present on main, including literal branch-name debris in `src/app.module.ts`, unresolved `InjectRedis`, missing modules, and other unrelated type errors.