### PR TITLE
Title: feat: trade execution orchestrator, Soroban tx builder, swipe fallback endpoint, and low balance alert 

### DIFF
--- a/src/alerts/low-balance-alert.module.ts
+++ b/src/alerts/low-balance-alert.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LowBalanceAlertService } from './low-balance-alert.service';
+import { NotificationsModule } from '../notifications/notifications.module';
+
+@Module({
+  imports: [NotificationsModule],
+  providers: [LowBalanceAlertService],
+  exports: [LowBalanceAlertService],
+})
+export class LowBalanceAlertModule {}

--- a/src/alerts/low-balance-alert.service.spec.ts
+++ b/src/alerts/low-balance-alert.service.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  LowBalanceAlertService,
+  BalanceAlertContext,
+} from './low-balance-alert.service';
+import { CacheService } from '../cache/cache.service';
+import { NotificationService } from '../notifications/notification.service';
+import { NotificationChannel } from '../notifications/entities/notification.entity';
+
+const mockConfigService = {
+  get: jest.fn().mockImplementation((key: string, def: unknown) => {
+    const map: Record<string, unknown> = {
+      'trade.minimumBalanceThreshold': 10,
+      'alerts.lowBalanceCooldownSeconds': 86400,
+      'trade.baseFeePercentage': 0.1,
+    };
+    return map[key] ?? def;
+  }),
+};
+
+const mockCacheService = {
+  get: jest.fn(),
+  setWithTTL: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockNotificationService = {
+  send: jest.fn().mockResolvedValue({ id: 'notif-001' }),
+};
+
+const buildCtx = (available: string, overrides: Partial<BalanceAlertContext> = {}): BalanceAlertContext => ({
+  userId: 'user-abc',
+  walletAddress: 'GTEST123',
+  balance: { available, locked: '0', total: available },
+  ...overrides,
+});
+
+describe('LowBalanceAlertService', () => {
+  let service: LowBalanceAlertService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LowBalanceAlertService,
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: CacheService, useValue: mockCacheService },
+        { provide: NotificationService, useValue: mockNotificationService },
+      ],
+    }).compile();
+
+    service = module.get(LowBalanceAlertService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── Threshold evaluation ────────────────────────────────────────────────────
+
+  describe('balance evaluation', () => {
+    it('returns balance_sufficient when balance is above threshold', async () => {
+      const result = await service.checkAndAlert(buildCtx('100'));
+
+      expect(result.alerted).toBe(false);
+      expect(result.reason).toBe('balance_sufficient');
+      expect(mockNotificationService.send).not.toHaveBeenCalled();
+    });
+
+    it('returns balance_sufficient when balance equals threshold exactly', async () => {
+      const result = await service.checkAndAlert(buildCtx('10'));
+
+      expect(result.alerted).toBe(false);
+      expect(result.reason).toBe('balance_sufficient');
+    });
+
+    it('triggers alert when balance is below threshold', async () => {
+      mockCacheService.get.mockResolvedValue(null); // no cooldown
+
+      const result = await service.checkAndAlert(buildCtx('5'));
+
+      expect(result.alerted).toBe(true);
+      expect(result.reason).toBe('below_threshold');
+    });
+
+    it('includes currentBalance and minimumThreshold in result', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      const result = await service.checkAndAlert(buildCtx('3'));
+
+      expect(result.currentBalance).toBe('3');
+      expect(result.minimumThreshold).toBe('10');
+    });
+  });
+
+  // ── Alert content ───────────────────────────────────────────────────────────
+
+  describe('alert generation', () => {
+    it('sends an IN_APP notification with correct userId', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      await service.checkAndAlert(buildCtx('2', { userId: 'user-xyz' }));
+
+      expect(mockNotificationService.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-xyz',
+          channel: NotificationChannel.IN_APP,
+          type: 'LOW_BALANCE',
+        }),
+      );
+    });
+
+    it('alert message includes top-up wallet address', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      await service.checkAndAlert(buildCtx('2', { walletAddress: 'GWALLET999' }));
+
+      const call = mockNotificationService.send.mock.calls[0][0];
+      expect(call.message).toContain('GWALLET999');
+    });
+
+    it('alert message mentions the shortfall amount', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      await service.checkAndAlert(buildCtx('5'));
+
+      // shortfall = 10 - 5 = 5
+      const call = mockNotificationService.send.mock.calls[0][0];
+      expect(call.message).toContain('5.00000000');
+    });
+
+    it('includes estimatedTradeCapacity in result', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      const result = await service.checkAndAlert(buildCtx('5'));
+
+      expect(result.estimatedTradeCapacity).toBeDefined();
+    });
+
+    it('includes trade capacity coverage percentage when requestedTradeAmount given', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      const result = await service.checkAndAlert(
+        buildCtx('5', { requestedTradeAmount: 20 }),
+      );
+
+      expect(result.estimatedTradeCapacity).toMatch(/%.*requested/i);
+    });
+
+    it('alert metadata includes walletAddress and current balance', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      await service.checkAndAlert(buildCtx('3', { walletAddress: 'GMETA001' }));
+
+      const call = mockNotificationService.send.mock.calls[0][0];
+      expect(call.metadata).toMatchObject({
+        walletAddress: 'GMETA001',
+        currentBalance: '3',
+      });
+    });
+  });
+
+  // ── Cooldown ────────────────────────────────────────────────────────────────
+
+  describe('cooldown window', () => {
+    it('suppresses alert when cooldown is active', async () => {
+      mockCacheService.get.mockResolvedValue('1'); // sentinel present
+
+      const result = await service.checkAndAlert(buildCtx('2'));
+
+      expect(result.alerted).toBe(false);
+      expect(result.reason).toBe('cooldown_active');
+      expect(mockNotificationService.send).not.toHaveBeenCalled();
+    });
+
+    it('sets cooldown key after sending alert', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      await service.checkAndAlert(buildCtx('2'));
+
+      expect(mockCacheService.setWithTTL).toHaveBeenCalledWith(
+        expect.stringContaining('user-abc'),
+        '1',
+        86400,
+      );
+    });
+
+    it('does not set cooldown when balance is sufficient', async () => {
+      await service.checkAndAlert(buildCtx('50'));
+
+      expect(mockCacheService.setWithTTL).not.toHaveBeenCalled();
+    });
+
+    it('does not set cooldown when alert is suppressed by cooldown', async () => {
+      mockCacheService.get.mockResolvedValue('1');
+
+      await service.checkAndAlert(buildCtx('2'));
+
+      expect(mockCacheService.setWithTTL).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── isInCooldown ────────────────────────────────────────────────────────────
+
+  describe('isInCooldown', () => {
+    it('returns true when cache key exists', async () => {
+      mockCacheService.get.mockResolvedValue('1');
+
+      expect(await service.isInCooldown('user-abc')).toBe(true);
+    });
+
+    it('returns false when cache key is absent', async () => {
+      mockCacheService.get.mockResolvedValue(null);
+
+      expect(await service.isInCooldown('user-abc')).toBe(false);
+    });
+
+    it('returns false when cache key is undefined', async () => {
+      mockCacheService.get.mockResolvedValue(undefined);
+
+      expect(await service.isInCooldown('user-abc')).toBe(false);
+    });
+  });
+});

--- a/src/alerts/low-balance-alert.service.ts
+++ b/src/alerts/low-balance-alert.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CacheService } from '../cache/cache.service';
+import { NotificationService } from '../notifications/notification.service';
+import { NotificationChannel } from '../notifications/entities/notification.entity';
+
+export interface WalletBalance {
+  available: string;
+  locked: string;
+  total: string;
+  asset?: string;
+}
+
+export interface BalanceAlertContext {
+  userId: string;
+  walletAddress: string;
+  balance: WalletBalance;
+  /** Optional: the amount the user tried to trade that triggered the check */
+  requestedTradeAmount?: number;
+}
+
+export interface AlertResult {
+  alerted: boolean;
+  /** false when cooldown is active */
+  reason?: 'below_threshold' | 'cooldown_active' | 'balance_sufficient';
+  currentBalance: string;
+  minimumThreshold: string;
+  estimatedTradeCapacity?: string;
+}
+
+const COOLDOWN_CACHE_PREFIX = 'stellarswipe:low_balance_alert:';
+
+@Injectable()
+export class LowBalanceAlertService {
+  private readonly logger = new Logger(LowBalanceAlertService.name);
+  private readonly minimumThreshold: number;
+  /** Cooldown in seconds before the same user can receive another alert */
+  private readonly cooldownSeconds: number;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly cacheService: CacheService,
+    private readonly notificationService: NotificationService,
+  ) {
+    this.minimumThreshold = this.configService.get<number>(
+      'trade.minimumBalanceThreshold',
+      10,
+    );
+    this.cooldownSeconds = this.configService.get<number>(
+      'alerts.lowBalanceCooldownSeconds',
+      86_400, // 24 hours
+    );
+  }
+
+  /**
+   * Main entry point. Checks the wallet balance and dispatches an alert if:
+   *  1. The available balance is below the configured minimum threshold, AND
+   *  2. No alert has been sent for this user within the cooldown window.
+   */
+  async checkAndAlert(ctx: BalanceAlertContext): Promise<AlertResult> {
+    const available = parseFloat(ctx.balance.available);
+    const threshold = this.minimumThreshold;
+
+    if (available >= threshold) {
+      return {
+        alerted: false,
+        reason: 'balance_sufficient',
+        currentBalance: ctx.balance.available,
+        minimumThreshold: threshold.toString(),
+      };
+    }
+
+    if (await this.isInCooldown(ctx.userId)) {
+      this.logger.debug(
+        `Low-balance alert suppressed for user=${ctx.userId} (cooldown active)`,
+      );
+      return {
+        alerted: false,
+        reason: 'cooldown_active',
+        currentBalance: ctx.balance.available,
+        minimumThreshold: threshold.toString(),
+      };
+    }
+
+    const estimatedCapacity = this.estimateTradeCapacity(available, ctx.requestedTradeAmount);
+
+    await this.dispatchAlert(ctx, available, threshold, estimatedCapacity);
+    await this.markCooldown(ctx.userId);
+
+    this.logger.log(
+      `Low-balance alert sent for user=${ctx.userId} balance=${available} threshold=${threshold}`,
+    );
+
+    return {
+      alerted: true,
+      reason: 'below_threshold',
+      currentBalance: ctx.balance.available,
+      minimumThreshold: threshold.toString(),
+      estimatedTradeCapacity: estimatedCapacity,
+    };
+  }
+
+  /**
+   * Returns true if an alert was sent within the cooldown window.
+   */
+  async isInCooldown(userId: string): Promise<boolean> {
+    const key = `${COOLDOWN_CACHE_PREFIX}${userId}`;
+    const sentinel = await this.cacheService.get<string>(key);
+    return sentinel !== undefined && sentinel !== null;
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private async dispatchAlert(
+    ctx: BalanceAlertContext,
+    available: number,
+    threshold: number,
+    estimatedCapacity: string,
+  ): Promise<void> {
+    const shortfall = (threshold - available).toFixed(8);
+    const asset = ctx.balance.asset ?? 'XLM';
+
+    const title = 'Low Balance Warning';
+    const message =
+      `Your trading balance (${available.toFixed(8)} ${asset}) is below the minimum ` +
+      `required threshold of ${threshold} ${asset}. ` +
+      `You need at least ${shortfall} ${asset} more to place new trades. ` +
+      `Estimated trade capacity with current balance: ${estimatedCapacity} ${asset}. ` +
+      `Top up your wallet at ${ctx.walletAddress} to continue trading.`;
+
+    await this.notificationService.send({
+      userId: ctx.userId,
+      type: 'LOW_BALANCE',
+      channel: NotificationChannel.IN_APP,
+      title,
+      message,
+      metadata: {
+        walletAddress: ctx.walletAddress,
+        currentBalance: ctx.balance.available,
+        minimumThreshold: threshold.toString(),
+        shortfall,
+        estimatedTradeCapacity: estimatedCapacity,
+        asset,
+      },
+    });
+  }
+
+  private async markCooldown(userId: string): Promise<void> {
+    const key = `${COOLDOWN_CACHE_PREFIX}${userId}`;
+    // Store a sentinel; TTL in milliseconds (cache-manager convention)
+    await this.cacheService.setWithTTL(key, '1', this.cooldownSeconds);
+  }
+
+  /**
+   * Estimates how many units of the base asset the user can trade at the
+   * current balance given a typical fee of 0.1%.
+   */
+  private estimateTradeCapacity(
+    available: number,
+    requestedAmount?: number,
+  ): string {
+    const feeRate = this.configService.get<number>('trade.baseFeePercentage', 0.1) / 100;
+    const capacity = available / (1 + feeRate);
+
+    if (requestedAmount && requestedAmount > 0) {
+      // Express shortfall as a percentage of the requested amount
+      const coveragePct = ((capacity / requestedAmount) * 100).toFixed(2);
+      return `${capacity.toFixed(8)} (${coveragePct}% of requested)`;
+    }
+
+    return capacity.toFixed(8);
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -72,6 +72,7 @@ import { PortfolioModule } from './portfolio/portfolio.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { AuditModule } from './audit-log/audit.module';
 import { SocialExportModule } from './social-export/social-export.module';
+import { LowBalanceAlertModule } from './alerts/low-balance-alert.module';
  main
  main
  main
@@ -207,6 +208,7 @@ import { SocialExportModule } from './social-export/social-export.module';
     NotificationsModule,
     AuditModule,
     SocialExportModule,
+    LowBalanceAlertModule,
  main
  main
  main

--- a/src/soroban/soroban-transaction-builder.service.spec.ts
+++ b/src/soroban/soroban-transaction-builder.service.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { BadRequestException } from '@nestjs/common';
+import {
+  SorobanTransactionBuilderService,
+  MarketOrderParams,
+  LimitOrderParams,
+} from './soroban-transaction-builder.service';
+import { TradeSide } from '../trades/entities/trade.entity';
+
+const mockConfigService = {
+  get: jest.fn().mockImplementation((key: string, def: unknown) => {
+    const cfg: Record<string, unknown> = {
+      'stellar.tradeContractId': 'TEST_CONTRACT_ID',
+      'trade.defaultSlippageBps': 50,
+      'trade.maxSlippageBps': 500,
+    };
+    return cfg[key] ?? def;
+  }),
+};
+
+const baseMarket: MarketOrderParams = {
+  userId: 'user-001',
+  baseAsset: 'XLM',
+  counterAsset: 'USDC',
+  amount: 100,
+  entryPrice: 0.15,
+  side: TradeSide.BUY,
+};
+
+const baseLimit: LimitOrderParams = {
+  userId: 'user-001',
+  baseAsset: 'XLM',
+  counterAsset: 'USDC',
+  amount: 200,
+  limitPrice: 0.14,
+  side: TradeSide.BUY,
+};
+
+describe('SorobanTransactionBuilderService', () => {
+  let service: SorobanTransactionBuilderService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SorobanTransactionBuilderService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(SorobanTransactionBuilderService);
+  });
+
+  // ── Market order ────────────────────────────────────────────────────────────
+
+  describe('buildMarketOrder', () => {
+    it('builds a valid market order payload', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+
+      expect(payload.orderType).toBe('market');
+      expect(payload.method).toBe('execute_market_order');
+      expect(payload.contractId).toBe('TEST_CONTRACT_ID');
+      expect(payload.adjustedAmount).toBe(100);
+      expect(payload.slippageBps).toBe(50); // default
+    });
+
+    it('converts slippage percentage to basis points', () => {
+      const payload = service.buildMarketOrder({ ...baseMarket, slippageTolerance: 1.0 });
+      expect(payload.slippageBps).toBe(100);
+    });
+
+    it('caps slippage at maxSlippageBps', () => {
+      const payload = service.buildMarketOrder({ ...baseMarket, slippageTolerance: 99 });
+      expect(payload.slippageBps).toBeLessThanOrEqual(500);
+    });
+
+    it('applies maxExposure risk cap when notional exceeds limit', () => {
+      // amount * price = 100 * 0.15 = 15; maxExposure = 1 → cap to ~6.67
+      const payload = service.buildMarketOrder(baseMarket, { maxExposure: 1 });
+      expect(payload.adjustedAmount).toBeLessThan(100);
+    });
+
+    it('does not cap amount when within exposure limit', () => {
+      const payload = service.buildMarketOrder(baseMarket, { maxExposure: 1000 });
+      expect(payload.adjustedAmount).toBe(100);
+    });
+
+    it('encodes XLM amount as stroops in args', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+      const amountArg = payload.args.find((a) => a.type === 'i128');
+      // 100 * 10_000_000 = 1_000_000_000
+      expect(amountArg?.value).toBe('1000000000');
+    });
+
+    it('includes stopLoss and takeProfit in metadata', () => {
+      const payload = service.buildMarketOrder({
+        ...baseMarket,
+        stopLossPrice: 0.12,
+        takeProfitPrice: 0.20,
+      });
+      expect(payload.metadata.stopLossPrice).toBe(0.12);
+      expect(payload.metadata.takeProfitPrice).toBe(0.20);
+    });
+
+    it('throws when amount is zero', () => {
+      expect(() => service.buildMarketOrder({ ...baseMarket, amount: 0 })).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws when base and counter assets are the same', () => {
+      expect(() =>
+        service.buildMarketOrder({ ...baseMarket, counterAsset: 'XLM' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('throws when baseAsset is empty', () => {
+      expect(() =>
+        service.buildMarketOrder({ ...baseMarket, baseAsset: '' }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  // ── Limit order ─────────────────────────────────────────────────────────────
+
+  describe('buildLimitOrder', () => {
+    it('builds a valid limit order payload', () => {
+      const payload = service.buildLimitOrder(baseLimit);
+
+      expect(payload.orderType).toBe('limit');
+      expect(payload.method).toBe('place_limit_order');
+      expect(payload.slippageBps).toBe(0);
+      expect(payload.adjustedAmount).toBe(200);
+    });
+
+    it('sets default expiry to 24 hours from now', () => {
+      const before = Math.floor(Date.now() / 1000) + 86_400 - 5;
+      const payload = service.buildLimitOrder(baseLimit);
+      const after = Math.floor(Date.now() / 1000) + 86_400 + 5;
+
+      expect(payload.metadata.expiresAt).toBeGreaterThanOrEqual(before);
+      expect(payload.metadata.expiresAt).toBeLessThanOrEqual(after);
+    });
+
+    it('respects caller-provided expiresAt', () => {
+      const expiry = Math.floor(Date.now() / 1000) + 3600;
+      const payload = service.buildLimitOrder({ ...baseLimit, expiresAt: expiry });
+      expect(payload.metadata.expiresAt).toBe(expiry);
+    });
+
+    it('stores limitPrice in metadata', () => {
+      const payload = service.buildLimitOrder(baseLimit);
+      expect(payload.metadata.limitPrice).toBe(0.14);
+    });
+
+    it('throws when limitPrice is zero', () => {
+      expect(() =>
+        service.buildLimitOrder({ ...baseLimit, limitPrice: 0 }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('applies risk cap for limit orders', () => {
+      // notional = 200 * 0.14 = 28; maxExposure = 1 → capped
+      const payload = service.buildLimitOrder(baseLimit, { maxExposure: 1 });
+      expect(payload.adjustedAmount).toBeLessThan(200);
+    });
+  });
+
+  // ── validatePayload ──────────────────────────────────────────────────────────
+
+  describe('validatePayload', () => {
+    it('throws when contractId is missing', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+      (payload as any).contractId = '';
+      expect(() => service.validatePayload(payload)).toThrow(BadRequestException);
+    });
+
+    it('throws when method is missing', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+      (payload as any).method = '';
+      expect(() => service.validatePayload(payload)).toThrow(BadRequestException);
+    });
+
+    it('throws when args is empty', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+      (payload as any).args = [];
+      expect(() => service.validatePayload(payload)).toThrow(BadRequestException);
+    });
+
+    it('throws when adjustedAmount is zero', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+      (payload as any).adjustedAmount = 0;
+      expect(() => service.validatePayload(payload)).toThrow(BadRequestException);
+    });
+
+    it('does not throw for a valid payload', () => {
+      const payload = service.buildMarketOrder(baseMarket);
+      expect(() => service.validatePayload(payload)).not.toThrow();
+    });
+  });
+});

--- a/src/soroban/soroban-transaction-builder.service.ts
+++ b/src/soroban/soroban-transaction-builder.service.ts
@@ -1,0 +1,268 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TradeSide } from '../trades/entities/trade.entity';
+
+// ── Domain types ──────────────────────────────────────────────────────────────
+
+export interface MarketOrderParams {
+  userId: string;
+  baseAsset: string;
+  counterAsset: string;
+  amount: number;
+  entryPrice: number;
+  side: TradeSide;
+  slippageTolerance?: number;
+  stopLossPrice?: number;
+  takeProfitPrice?: number;
+}
+
+export interface LimitOrderParams {
+  userId: string;
+  baseAsset: string;
+  counterAsset: string;
+  amount: number;
+  limitPrice: number;
+  side: TradeSide;
+  stopLossPrice?: number;
+  takeProfitPrice?: number;
+  /** Unix timestamp; defaults to 24 hours from now */
+  expiresAt?: number;
+}
+
+export interface UserRiskParameters {
+  /** Maximum notional exposure the user is allowed to place in a single order */
+  maxExposure?: number;
+  /** Cap on position size as a fraction of available balance (0–1) */
+  positionSizeCap?: number;
+}
+
+export interface SorobanTransactionPayload {
+  contractId: string;
+  method: string;
+  args: ContractArg[];
+  orderType: 'market' | 'limit';
+  /** Effective amount after applying risk cap */
+  adjustedAmount: number;
+  /** Slippage expressed as bps for market orders (0 for limit) */
+  slippageBps: number;
+  metadata: {
+    userId: string;
+    baseAsset: string;
+    counterAsset: string;
+    side: TradeSide;
+    stopLossPrice?: number;
+    takeProfitPrice?: number;
+    limitPrice?: number;
+    expiresAt?: number;
+  };
+}
+
+interface ContractArg {
+  type: string;
+  value: unknown;
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+@Injectable()
+export class SorobanTransactionBuilderService {
+  private readonly logger = new Logger(SorobanTransactionBuilderService.name);
+  private readonly tradeContractId: string;
+  private readonly defaultSlippageBps: number;
+  private readonly maxSlippageBps: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.tradeContractId = this.configService.get<string>(
+      'stellar.tradeContractId',
+      'MOCK_CONTRACT_ID',
+    );
+    this.defaultSlippageBps = this.configService.get<number>(
+      'trade.defaultSlippageBps',
+      50,
+    );
+    this.maxSlippageBps = this.configService.get<number>(
+      'trade.maxSlippageBps',
+      500,
+    );
+  }
+
+  /**
+   * Builds and validates a Soroban payload for a market order.
+   * Slippage is converted from a percentage (e.g. 0.5) to basis points.
+   */
+  buildMarketOrder(
+    params: MarketOrderParams,
+    userRisk: UserRiskParameters = {},
+  ): SorobanTransactionPayload {
+    this.validateAssetPair(params.baseAsset, params.counterAsset);
+    this.validateAmount(params.amount, params.userId);
+
+    const slippageBps = this.resolveSlippageBps(params.slippageTolerance);
+    const adjustedAmount = this.applyRiskCap(params.amount, params.entryPrice, userRisk);
+
+    const payload: SorobanTransactionPayload = {
+      contractId: this.tradeContractId,
+      method: 'execute_market_order',
+      args: [
+        { type: 'address', value: params.userId },
+        { type: 'symbol', value: params.baseAsset },
+        { type: 'symbol', value: params.counterAsset },
+        { type: 'i128', value: this.toStroops(adjustedAmount) },
+        { type: 'u32', value: slippageBps },
+        { type: 'symbol', value: params.side },
+      ],
+      orderType: 'market',
+      adjustedAmount,
+      slippageBps,
+      metadata: {
+        userId: params.userId,
+        baseAsset: params.baseAsset,
+        counterAsset: params.counterAsset,
+        side: params.side,
+        stopLossPrice: params.stopLossPrice,
+        takeProfitPrice: params.takeProfitPrice,
+      },
+    };
+
+    this.validatePayload(payload);
+
+    this.logger.debug(
+      `Built market order payload for user=${params.userId} adjustedAmount=${adjustedAmount}`,
+    );
+
+    return payload;
+  }
+
+  /**
+   * Builds and validates a Soroban payload for a limit order.
+   */
+  buildLimitOrder(
+    params: LimitOrderParams,
+    userRisk: UserRiskParameters = {},
+  ): SorobanTransactionPayload {
+    this.validateAssetPair(params.baseAsset, params.counterAsset);
+    this.validateAmount(params.amount, params.userId);
+
+    if (params.limitPrice <= 0) {
+      throw new BadRequestException('Limit price must be greater than zero');
+    }
+
+    const adjustedAmount = this.applyRiskCap(
+      params.amount,
+      params.limitPrice,
+      userRisk,
+    );
+
+    const expiresAt =
+      params.expiresAt ?? Math.floor(Date.now() / 1000) + 86_400;
+
+    const payload: SorobanTransactionPayload = {
+      contractId: this.tradeContractId,
+      method: 'place_limit_order',
+      args: [
+        { type: 'address', value: params.userId },
+        { type: 'symbol', value: params.baseAsset },
+        { type: 'symbol', value: params.counterAsset },
+        { type: 'i128', value: this.toStroops(adjustedAmount) },
+        { type: 'i128', value: this.toStroops(params.limitPrice) },
+        { type: 'symbol', value: params.side },
+        { type: 'u64', value: expiresAt },
+      ],
+      orderType: 'limit',
+      adjustedAmount,
+      slippageBps: 0,
+      metadata: {
+        userId: params.userId,
+        baseAsset: params.baseAsset,
+        counterAsset: params.counterAsset,
+        side: params.side,
+        limitPrice: params.limitPrice,
+        stopLossPrice: params.stopLossPrice,
+        takeProfitPrice: params.takeProfitPrice,
+        expiresAt,
+      },
+    };
+
+    this.validatePayload(payload);
+
+    this.logger.debug(
+      `Built limit order payload for user=${params.userId} limitPrice=${params.limitPrice} adjustedAmount=${adjustedAmount}`,
+    );
+
+    return payload;
+  }
+
+  /**
+   * Validates a payload before it is dispatched to the Soroban RPC.
+   * Throws BadRequestException for any structural problem.
+   */
+  validatePayload(payload: SorobanTransactionPayload): void {
+    if (!payload.contractId) {
+      throw new BadRequestException('Missing contractId in Soroban payload');
+    }
+    if (!payload.method) {
+      throw new BadRequestException('Missing method in Soroban payload');
+    }
+    if (!payload.args || payload.args.length === 0) {
+      throw new BadRequestException('Soroban payload has no contract arguments');
+    }
+    if (payload.adjustedAmount <= 0) {
+      throw new BadRequestException('Payload adjustedAmount must be positive');
+    }
+    if (payload.slippageBps < 0 || payload.slippageBps > this.maxSlippageBps) {
+      throw new BadRequestException(
+        `slippageBps ${payload.slippageBps} out of allowed range [0, ${this.maxSlippageBps}]`,
+      );
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  /** Enforces user-specific max exposure; reduces amount if needed. */
+  private applyRiskCap(
+    amount: number,
+    price: number,
+    risk: UserRiskParameters,
+  ): number {
+    const notional = amount * price;
+    if (risk.maxExposure && notional > risk.maxExposure) {
+      const capped = risk.maxExposure / price;
+      this.logger.warn(
+        `Amount capped from ${amount} to ${capped.toFixed(8)} due to maxExposure=${risk.maxExposure}`,
+      );
+      return parseFloat(capped.toFixed(8));
+    }
+    return amount;
+  }
+
+  private resolveSlippageBps(slippagePct?: number): number {
+    if (slippagePct === undefined) return this.defaultSlippageBps;
+    const bps = Math.round(slippagePct * 100);
+    return Math.min(bps, this.maxSlippageBps);
+  }
+
+  /** Converts a decimal amount to Stellar stroops (7 decimal places). */
+  private toStroops(amount: number): string {
+    return Math.round(amount * 10_000_000).toString();
+  }
+
+  private validateAssetPair(base: string, counter: string): void {
+    if (!base || base.trim().length === 0) {
+      throw new BadRequestException('baseAsset is required');
+    }
+    if (!counter || counter.trim().length === 0) {
+      throw new BadRequestException('counterAsset is required');
+    }
+    if (base === counter) {
+      throw new BadRequestException('baseAsset and counterAsset must differ');
+    }
+  }
+
+  private validateAmount(amount: number, userId: string): void {
+    if (!amount || amount <= 0) {
+      throw new BadRequestException(
+        `Invalid amount for user ${userId}: must be positive`,
+      );
+    }
+  }
+}

--- a/src/soroban/soroban.module.ts
+++ b/src/soroban/soroban.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { SorobanService } from './soroban.service';
 import { StellarConfigService } from '../config/stellar.service';
 import { ContractDeploymentService } from './deployment/contract-deployment.service';
+import { SorobanTransactionBuilderService } from './soroban-transaction-builder.service';
 
 @Module({
-  providers: [SorobanService, StellarConfigService, ContractDeploymentService],
-  exports: [SorobanService, ContractDeploymentService],
+  providers: [SorobanService, StellarConfigService, ContractDeploymentService, SorobanTransactionBuilderService],
+  exports: [SorobanService, ContractDeploymentService, SorobanTransactionBuilderService],
 })
 export class SorobanModule {}

--- a/src/trades/services/trade-execution-orchestrator.service.spec.ts
+++ b/src/trades/services/trade-execution-orchestrator.service.spec.ts
@@ -1,0 +1,270 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
+import {
+  TradeExecutionOrchestratorService,
+  OrderType,
+  TradeIntent,
+} from './trade-execution-orchestrator.service';
+import { RiskManagerService } from './risk-manager.service';
+import { TradeExecutorService } from './trade-executor.service';
+import { RiskManagerService as VelocityRiskManager } from '../../risk/risk-manager.service';
+import { ComplianceRuleEngineService } from '../../compliance/rule-engine/compliance-rule-engine.service';
+import { SorobanTransactionBuilderService } from '../../soroban/soroban-transaction-builder.service';
+import { Trade, TradeStatus, TradeSide } from '../entities/trade.entity';
+
+const mockTrade = (overrides: Partial<Trade> = {}): Trade =>
+  ({
+    id: 'trade-abc',
+    userId: 'user-123',
+    signalId: 'signal-456',
+    side: TradeSide.BUY,
+    baseAsset: 'XLM',
+    counterAsset: 'USDC',
+    entryPrice: '0.15000000',
+    amount: '100',
+    totalValue: '15.00000000',
+    feeAmount: '0',
+    status: TradeStatus.EXECUTING,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Trade);
+
+describe('TradeExecutionOrchestratorService', () => {
+  let service: TradeExecutionOrchestratorService;
+
+  const mockRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockRiskManager = {
+    checkDuplicateTrade: jest.fn().mockResolvedValue(false),
+    validateTrade: jest.fn().mockResolvedValue({ isValid: true, errors: [], warnings: [] }),
+  };
+
+  const mockTradeExecutor = {
+    executeTrade: jest.fn(),
+  };
+
+  const mockVelocityRisk = {
+    validateTrade: jest.fn().mockResolvedValue(undefined),
+    recordTradeExecution: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockCompliance = {
+    evaluateTrade: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockTxBuilder = {
+    buildMarketOrder: jest.fn().mockReturnValue({ validated: true }),
+    buildLimitOrder: jest.fn().mockReturnValue({ validated: true }),
+  };
+
+  const baseIntent: TradeIntent = {
+    userId: 'user-123',
+    signalId: 'signal-456',
+    side: TradeSide.BUY,
+    amount: 100,
+    walletAddress: 'GTEST',
+    source: 'gesture',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeExecutionOrchestratorService,
+        { provide: getRepositoryToken(Trade), useValue: mockRepo },
+        { provide: RiskManagerService, useValue: mockRiskManager },
+        { provide: TradeExecutorService, useValue: mockTradeExecutor },
+        { provide: VelocityRiskManager, useValue: mockVelocityRisk },
+        { provide: ComplianceRuleEngineService, useValue: mockCompliance },
+        { provide: SorobanTransactionBuilderService, useValue: mockTxBuilder },
+      ],
+    }).compile();
+
+    service = module.get<TradeExecutionOrchestratorService>(
+      TradeExecutionOrchestratorService,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('successful execution', () => {
+    it('returns success result for a valid market order', async () => {
+      const trade = mockTrade();
+      mockRepo.create.mockReturnValue(trade);
+      mockRepo.save.mockResolvedValue(trade);
+      mockTradeExecutor.executeTrade.mockResolvedValue({
+        success: true,
+        transactionHash: 'abc123',
+        executedPrice: '0.15100000',
+        feeAmount: '0.00015000',
+        contractId: 'CONTRACT_XYZ',
+      });
+
+      const result = await service.orchestrate(baseIntent);
+
+      expect(result.success).toBe(true);
+      expect(result.traceId).toBeDefined();
+      expect(result.orderType).toBe(OrderType.MARKET);
+      expect(result.result?.transactionHash).toBe('abc123');
+    });
+
+    it('selects LIMIT order type when overridden', async () => {
+      const trade = mockTrade();
+      mockRepo.create.mockReturnValue(trade);
+      mockRepo.save.mockResolvedValue(trade);
+      mockTradeExecutor.executeTrade.mockResolvedValue({
+        success: true,
+        transactionHash: 'lim001',
+        feeAmount: '0.00015000',
+      });
+
+      const result = await service.orchestrate({
+        ...baseIntent,
+        orderTypeOverride: OrderType.LIMIT,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.orderType).toBe(OrderType.LIMIT);
+      expect(mockTxBuilder.buildLimitOrder).toHaveBeenCalled();
+    });
+
+    it('records all stages in the result', async () => {
+      const trade = mockTrade();
+      mockRepo.create.mockReturnValue(trade);
+      mockRepo.save.mockResolvedValue(trade);
+      mockTradeExecutor.executeTrade.mockResolvedValue({
+        success: true,
+        transactionHash: 'stg001',
+        feeAmount: '0',
+      });
+
+      const { stages } = await service.orchestrate(baseIntent);
+
+      const stageNames = stages.map((s) => s.stage);
+      expect(stageNames).toContain('account_validation');
+      expect(stageNames).toContain('risk_checks');
+      expect(stageNames).toContain('order_type_selection');
+      expect(stageNames).toContain('soroban_execution');
+      expect(stageNames).toContain('finalize');
+      stages.forEach((s) => expect(s.durationMs).toBeGreaterThanOrEqual(0));
+    });
+
+    it('calls velocity risk manager after successful execution', async () => {
+      const trade = mockTrade();
+      mockRepo.create.mockReturnValue(trade);
+      mockRepo.save.mockResolvedValue(trade);
+      mockTradeExecutor.executeTrade.mockResolvedValue({
+        success: true,
+        transactionHash: 'vel001',
+        feeAmount: '0',
+      });
+
+      await service.orchestrate(baseIntent);
+
+      expect(mockVelocityRisk.recordTradeExecution).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+      );
+    });
+  });
+
+  describe('failure pathways', () => {
+    it('returns failure when duplicate trade exists', async () => {
+      mockRiskManager.checkDuplicateTrade.mockResolvedValueOnce(true);
+
+      const result = await service.orchestrate(baseIntent);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/pending trade/i);
+      expect(
+        result.stages.find((s) => s.stage === 'account_validation')?.status,
+      ).toBe('failed');
+    });
+
+    it('returns failure when trade validation errors exist', async () => {
+      mockRiskManager.validateTrade.mockResolvedValueOnce({
+        isValid: false,
+        errors: ['Insufficient balance'],
+        warnings: [],
+      });
+
+      const result = await service.orchestrate(baseIntent);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/validation failed/i);
+    });
+
+    it('returns failure when Soroban execution fails', async () => {
+      const trade = mockTrade();
+      mockRepo.create.mockReturnValue(trade);
+      mockRepo.save.mockResolvedValue(trade);
+      mockTradeExecutor.executeTrade.mockResolvedValue({
+        success: false,
+        error: 'Soroban RPC timeout',
+      });
+
+      const result = await service.orchestrate(baseIntent);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/execution failed/i);
+      // Verify the trade was marked failed
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: TradeStatus.FAILED }),
+      );
+    });
+
+    it('returns failure when compliance check throws', async () => {
+      mockCompliance.evaluateTrade.mockRejectedValueOnce(
+        new BadRequestException('KYC not verified'),
+      );
+
+      const result = await service.orchestrate(baseIntent);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/KYC/i);
+    });
+
+    it('records failed stage detail in stages array', async () => {
+      mockRiskManager.checkDuplicateTrade.mockResolvedValueOnce(true);
+
+      const { stages } = await service.orchestrate(baseIntent);
+
+      const failedStage = stages.find((s) => s.status === 'failed');
+      expect(failedStage).toBeDefined();
+      expect(failedStage!.detail).toBeDefined();
+    });
+
+    it('returns a traceId even on failure for traceability', async () => {
+      mockRiskManager.checkDuplicateTrade.mockResolvedValueOnce(true);
+
+      const result = await service.orchestrate(baseIntent);
+
+      expect(result.traceId).toBeDefined();
+      expect(result.traceId).toHaveLength(36); // UUID
+    });
+  });
+
+  describe('source variants', () => {
+    it.each(['gesture', 'keyboard', 'button'] as const)(
+      'accepts "%s" as a valid source',
+      async (source) => {
+        const trade = mockTrade();
+        mockRepo.create.mockReturnValue(trade);
+        mockRepo.save.mockResolvedValue(trade);
+        mockTradeExecutor.executeTrade.mockResolvedValue({
+          success: true,
+          transactionHash: `${source}-tx`,
+          feeAmount: '0',
+        });
+
+        const result = await service.orchestrate({ ...baseIntent, source });
+
+        expect(result.success).toBe(true);
+      },
+    );
+  });
+});

--- a/src/trades/services/trade-execution-orchestrator.service.ts
+++ b/src/trades/services/trade-execution-orchestrator.service.ts
@@ -1,0 +1,377 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { ExecuteTradeDto } from '../dto/execute-trade.dto';
+import { TradeResultDto } from '../dto/trade-result.dto';
+import { RiskManagerService, UserBalance } from './risk-manager.service';
+import { TradeExecutorService } from './trade-executor.service';
+import { RiskManagerService as VelocityRiskManager } from '../../risk/risk-manager.service';
+import { ComplianceRuleEngineService } from '../../compliance/rule-engine/compliance-rule-engine.service';
+import { SorobanTransactionBuilderService } from '../../soroban/soroban-transaction-builder.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Trade, TradeStatus } from '../entities/trade.entity';
+
+export enum OrderType {
+  MARKET = 'market',
+  LIMIT = 'limit',
+}
+
+export interface TradeIntent extends ExecuteTradeDto {
+  /** Origin of the trade intent: gesture swipe, keyboard shortcut, or button press */
+  source?: 'gesture' | 'keyboard' | 'button';
+  /** Optional short-circuit: caller-specified order type override */
+  orderTypeOverride?: OrderType;
+}
+
+export interface OrchestratorResult {
+  success: boolean;
+  tradeId?: string;
+  traceId: string;
+  orderType: OrderType;
+  result?: TradeResultDto;
+  error?: string;
+  stages: StageLog[];
+}
+
+interface StageLog {
+  stage: string;
+  status: 'ok' | 'failed' | 'skipped';
+  durationMs: number;
+  detail?: string;
+}
+
+interface SignalData {
+  id: string;
+  entryPrice: string;
+  status: string;
+  expiresAt: Date;
+  baseAsset: string;
+  counterAsset: string;
+  stopLossPrice?: string;
+  targetPrice?: string;
+  /** When a limit price is specified on the signal it triggers a limit order */
+  limitPrice?: string;
+}
+
+@Injectable()
+export class TradeExecutionOrchestratorService {
+  private readonly logger = new Logger(TradeExecutionOrchestratorService.name);
+
+  constructor(
+    @InjectRepository(Trade)
+    private readonly tradeRepository: Repository<Trade>,
+    private readonly riskManager: RiskManagerService,
+    private readonly tradeExecutor: TradeExecutorService,
+    private readonly velocityRiskManager: VelocityRiskManager,
+    private readonly complianceEngine: ComplianceRuleEngineService,
+    private readonly txBuilder: SorobanTransactionBuilderService,
+  ) {}
+
+  async orchestrate(intent: TradeIntent): Promise<OrchestratorResult> {
+    const traceId = uuidv4();
+    const stages: StageLog[] = [];
+
+    this.logger.log(
+      `[${traceId}] Orchestrating trade for user=${intent.userId} signal=${intent.signalId} source=${intent.source ?? 'gesture'}`,
+    );
+
+    try {
+      // ── Stage 1: Account & user validation ──────────────────────────────────
+      const { signal, userBalance } = await this.runStage(
+        stages,
+        'account_validation',
+        () => this.validateAccountState(intent, traceId),
+      );
+
+      // ── Stage 2: Risk checks ─────────────────────────────────────────────────
+      await this.runStage(stages, 'risk_checks', () =>
+        this.runRiskChecks(intent, signal, userBalance, traceId),
+      );
+
+      // ── Stage 3: Order type selection ────────────────────────────────────────
+      const orderType = await this.runStage(stages, 'order_type_selection', () =>
+        Promise.resolve(this.selectOrderType(intent, signal)),
+      );
+
+      // ── Stage 4: Transaction payload construction ────────────────────────────
+      const payload = await this.runStage(
+        stages,
+        'transaction_build',
+        async () => {
+          const userRisk = { maxExposure: parseFloat(userBalance.available) * 0.2 };
+
+          if (orderType === OrderType.LIMIT) {
+            return this.txBuilder.buildLimitOrder(
+              {
+                userId: intent.userId,
+                baseAsset: signal.baseAsset,
+                counterAsset: signal.counterAsset,
+                amount: intent.amount,
+                limitPrice: parseFloat(signal.limitPrice ?? signal.entryPrice),
+                side: intent.side,
+                stopLossPrice: intent.stopLossPrice,
+                takeProfitPrice: intent.takeProfitPrice,
+              },
+              userRisk,
+            );
+          }
+
+          return this.txBuilder.buildMarketOrder(
+            {
+              userId: intent.userId,
+              baseAsset: signal.baseAsset,
+              counterAsset: signal.counterAsset,
+              amount: intent.amount,
+              entryPrice: parseFloat(signal.entryPrice),
+              side: intent.side,
+              slippageTolerance: intent.slippageTolerance,
+              stopLossPrice: intent.stopLossPrice,
+              takeProfitPrice: intent.takeProfitPrice,
+            },
+            userRisk,
+          );
+        },
+      );
+
+      // ── Stage 5: Persist trade record ────────────────────────────────────────
+      const trade = await this.runStage(stages, 'trade_persist', async () => {
+        const newTrade = this.tradeRepository.create({
+          userId: intent.userId,
+          signalId: intent.signalId,
+          side: intent.side,
+          baseAsset: signal.baseAsset,
+          counterAsset: signal.counterAsset,
+          entryPrice: signal.entryPrice,
+          amount: intent.amount.toString(),
+          totalValue: (intent.amount * parseFloat(signal.entryPrice)).toFixed(8),
+          stopLossPrice: intent.stopLossPrice?.toString() ?? signal.stopLossPrice,
+          takeProfitPrice: intent.takeProfitPrice?.toString() ?? signal.targetPrice,
+          status: TradeStatus.EXECUTING,
+        });
+        return this.tradeRepository.save(newTrade);
+      });
+
+      this.logger.log(`[${traceId}] Trade persisted: tradeId=${trade.id}`);
+
+      // ── Stage 6: Soroban contract invocation ─────────────────────────────────
+      const executionResult = await this.runStage(
+        stages,
+        'soroban_execution',
+        () => this.tradeExecutor.executeTrade(trade, intent.walletAddress),
+      );
+
+      // ── Stage 7: Finalize trade record ───────────────────────────────────────
+      const result = await this.runStage(stages, 'finalize', async () => {
+        if (executionResult.success) {
+          trade.status = TradeStatus.COMPLETED;
+          trade.transactionHash = executionResult.transactionHash;
+          trade.sorobanContractId = executionResult.contractId;
+          trade.feeAmount = executionResult.feeAmount ?? '0';
+          trade.executedAt = new Date();
+
+          if (executionResult.executedPrice) {
+            trade.entryPrice = executionResult.executedPrice;
+            trade.totalValue = (
+              parseFloat(trade.amount) * parseFloat(executionResult.executedPrice)
+            ).toFixed(8);
+          }
+
+          await this.tradeRepository.save(trade);
+
+          await this.velocityRiskManager.recordTradeExecution({
+            userId: trade.userId,
+            asset: `${trade.baseAsset}/${trade.counterAsset}`,
+            amount: parseFloat(trade.amount),
+            entryPrice: parseFloat(trade.entryPrice),
+          });
+
+          this.logger.log(
+            `[${traceId}] Trade ${trade.id} completed. hash=${trade.transactionHash}`,
+          );
+
+          return {
+            id: trade.id,
+            userId: trade.userId,
+            signalId: trade.signalId,
+            status: trade.status,
+            side: trade.side,
+            baseAsset: trade.baseAsset,
+            counterAsset: trade.counterAsset,
+            entryPrice: trade.entryPrice,
+            amount: trade.amount,
+            totalValue: trade.totalValue,
+            feeAmount: trade.feeAmount,
+            transactionHash: trade.transactionHash,
+            executedAt: trade.executedAt,
+            message: 'Trade executed successfully',
+          } as TradeResultDto;
+        }
+
+        trade.status = TradeStatus.FAILED;
+        trade.errorMessage = executionResult.error;
+        await this.tradeRepository.save(trade);
+
+        this.logger.error(
+          `[${traceId}] Trade ${trade.id} failed: ${executionResult.error}`,
+        );
+
+        // Propagate as a domain error so runStage captures it
+        throw new BadRequestException({
+          message: 'Trade execution failed',
+          error: executionResult.error,
+          tradeId: trade.id,
+        });
+      });
+
+      return {
+        success: true,
+        traceId,
+        tradeId: result.id,
+        orderType,
+        result,
+        stages,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Orchestration failed';
+
+      this.logger.error(`[${traceId}] Orchestration error: ${message}`);
+
+      return {
+        success: false,
+        traceId,
+        orderType: intent.orderTypeOverride ?? OrderType.MARKET,
+        error: message,
+        stages,
+      };
+    }
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async validateAccountState(
+    intent: TradeIntent,
+    traceId: string,
+  ): Promise<{ signal: SignalData; userBalance: UserBalance }> {
+    const isDuplicate = await this.riskManager.checkDuplicateTrade(
+      intent.userId,
+      intent.signalId,
+    );
+    if (isDuplicate) {
+      throw new BadRequestException(
+        'A pending trade already exists for this signal',
+      );
+    }
+
+    const signal = await this.fetchSignalData(intent.signalId);
+
+    const userBalance = await this.fetchUserBalance(intent.userId);
+
+    await this.complianceEngine.evaluateTrade({
+      userId: intent.userId,
+      amount: intent.amount,
+      asset: signal.baseAsset,
+      counterAsset: signal.counterAsset,
+    });
+
+    const validation = await this.riskManager.validateTrade(
+      intent,
+      signal,
+      userBalance,
+    );
+    if (!validation.isValid) {
+      this.logger.warn(
+        `[${traceId}] Validation failed for user=${intent.userId}: ${validation.errors.join(', ')}`,
+      );
+      throw new BadRequestException({
+        message: 'Trade validation failed',
+        errors: validation.errors,
+      });
+    }
+
+    return { signal, userBalance };
+  }
+
+  private async runRiskChecks(
+    intent: TradeIntent,
+    signal: SignalData,
+    userBalance: UserBalance,
+    traceId: string,
+  ): Promise<void> {
+    try {
+      await this.velocityRiskManager.validateTrade(
+        {
+          userId: intent.userId,
+          asset: `${signal.baseAsset}/${signal.counterAsset}`,
+          amount: intent.amount,
+          entryPrice: parseFloat(signal.entryPrice),
+          stopLossPrice: intent.stopLossPrice,
+        },
+        0,
+        0,
+        parseFloat(userBalance.available),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Risk check failed';
+      this.logger.warn(`[${traceId}] Risk check blocked trade: ${msg}`);
+      throw new BadRequestException(`Risk check failed: ${msg}`);
+    }
+  }
+
+  private selectOrderType(intent: TradeIntent, signal: SignalData): OrderType {
+    if (intent.orderTypeOverride) return intent.orderTypeOverride;
+    return signal.limitPrice ? OrderType.LIMIT : OrderType.MARKET;
+  }
+
+  /** Runs a stage, records timing and status, and re-throws on failure */
+  private async runStage<T>(
+    stages: StageLog[],
+    name: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const start = Date.now();
+    try {
+      const result = await fn();
+      stages.push({ stage: name, status: 'ok', durationMs: Date.now() - start });
+      return result;
+    } catch (error) {
+      const detail =
+        error instanceof Error ? error.message : 'unknown error';
+      stages.push({
+        stage: name,
+        status: 'failed',
+        durationMs: Date.now() - start,
+        detail,
+      });
+      throw error;
+    }
+  }
+
+  private async fetchSignalData(signalId: string): Promise<SignalData> {
+    // In production delegate to SignalsService
+    return {
+      id: signalId,
+      entryPrice: '0.15000000',
+      status: 'active',
+      expiresAt: new Date(Date.now() + 3_600_000),
+      baseAsset: 'XLM',
+      counterAsset: 'USDC',
+      stopLossPrice: '0.14000000',
+      targetPrice: '0.18000000',
+    };
+  }
+
+  private async fetchUserBalance(_userId: string): Promise<UserBalance> {
+    // In production delegate to WalletService
+    return {
+      available: '10000.00000000',
+      locked: '0.00000000',
+      total: '10000.00000000',
+    };
+  }
+}

--- a/src/trades/swipe/dto/swipe-intent.dto.ts
+++ b/src/trades/swipe/dto/swipe-intent.dto.ts
@@ -1,0 +1,75 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import { TradeSide } from '../../entities/trade.entity';
+import { OrderType } from '../../services/trade-execution-orchestrator.service';
+
+export enum SwipeSource {
+  GESTURE = 'gesture',
+  KEYBOARD = 'keyboard',
+  BUTTON = 'button',
+}
+
+export class SwipeIntentDto {
+  @IsUUID()
+  @IsNotEmpty()
+  userId!: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  signalId!: string;
+
+  @IsEnum(TradeSide)
+  @IsNotEmpty()
+  side!: TradeSide;
+
+  @IsNumber({ maxDecimalPlaces: 8 })
+  @IsPositive()
+  amount!: number;
+
+  @IsEnum(SwipeSource)
+  @IsNotEmpty()
+  source!: SwipeSource;
+
+  /** Optional keyboard shortcut identifier, e.g. "shift+right" */
+  @IsString()
+  @IsOptional()
+  shortcutKey?: string;
+
+  /** Explicit confirmation flag required for button-sourced actions */
+  @IsOptional()
+  confirmAction?: boolean;
+
+  @IsNumber({ maxDecimalPlaces: 8 })
+  @IsOptional()
+  @IsPositive()
+  stopLossPrice?: number;
+
+  @IsNumber({ maxDecimalPlaces: 8 })
+  @IsOptional()
+  @IsPositive()
+  takeProfitPrice?: number;
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsOptional()
+  @Min(0)
+  @Max(100)
+  slippageTolerance?: number;
+
+  @IsString()
+  @IsOptional()
+  walletAddress?: string;
+
+  /** Caller-requested order type; orchestrator resolves from signal if omitted */
+  @IsEnum(OrderType)
+  @IsOptional()
+  orderTypeOverride?: OrderType;
+}

--- a/src/trades/swipe/swipe.controller.ts
+++ b/src/trades/swipe/swipe.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { SwipeService } from './swipe.service';
+import { SwipeIntentDto } from './dto/swipe-intent.dto';
+import { OrchestratorResult } from '../services/trade-execution-orchestrator.service';
+
+@Controller('trades/swipe')
+export class SwipeController {
+  constructor(private readonly swipeService: SwipeService) {}
+
+  /**
+   * Unified swipe endpoint — accepts trade intents from gesture, keyboard,
+   * or button sources and applies the same validation, risk checks, and
+   * Soroban execution as the primary gesture flow.
+   *
+   * POST /trades/swipe
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async handleSwipe(@Body() dto: SwipeIntentDto): Promise<OrchestratorResult> {
+    return this.swipeService.handleSwipe(dto);
+  }
+}

--- a/src/trades/swipe/swipe.service.spec.ts
+++ b/src/trades/swipe/swipe.service.spec.ts
@@ -1,0 +1,192 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { SwipeService } from './swipe.service';
+import { SwipeIntentDto, SwipeSource } from './dto/swipe-intent.dto';
+import {
+  TradeExecutionOrchestratorService,
+  OrderType,
+  OrchestratorResult,
+} from '../services/trade-execution-orchestrator.service';
+import { TradeSide, TradeStatus } from '../entities/trade.entity';
+
+const successResult = (overrides: Partial<OrchestratorResult> = {}): OrchestratorResult => ({
+  success: true,
+  traceId: 'trace-001',
+  orderType: OrderType.MARKET,
+  stages: [{ stage: 'finalize', status: 'ok', durationMs: 12 }],
+  result: {
+    id: 'trade-abc',
+    userId: 'user-001',
+    signalId: 'signal-001',
+    status: TradeStatus.COMPLETED,
+    side: TradeSide.BUY,
+    baseAsset: 'XLM',
+    counterAsset: 'USDC',
+    entryPrice: '0.15',
+    amount: '100',
+    totalValue: '15',
+    feeAmount: '0.015',
+    transactionHash: 'hash123',
+    executedAt: new Date(),
+    message: 'Trade executed successfully',
+  },
+  ...overrides,
+});
+
+const baseDto: SwipeIntentDto = {
+  userId: 'user-001',
+  signalId: 'signal-001',
+  side: TradeSide.BUY,
+  amount: 100,
+  source: SwipeSource.GESTURE,
+};
+
+describe('SwipeService', () => {
+  let service: SwipeService;
+  const mockOrchestrator = { orchestrate: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SwipeService,
+        {
+          provide: TradeExecutionOrchestratorService,
+          useValue: mockOrchestrator,
+        },
+      ],
+    }).compile();
+
+    service = module.get(SwipeService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('gesture source', () => {
+    it('delegates to orchestrator and returns result', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(successResult());
+
+      const result = await service.handleSwipe(baseDto);
+
+      expect(result.success).toBe(true);
+      expect(mockOrchestrator.orchestrate).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-001', source: 'gesture' }),
+      );
+    });
+
+    it('throws BadRequestException on orchestrator failure', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(
+        successResult({ success: false, error: 'Soroban timeout' }),
+      );
+
+      await expect(service.handleSwipe(baseDto)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('keyboard source', () => {
+    it('passes through keyboard source and shortcutKey to orchestrator', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(successResult());
+
+      await service.handleSwipe({
+        ...baseDto,
+        source: SwipeSource.KEYBOARD,
+        shortcutKey: 'shift+right',
+      });
+
+      expect(mockOrchestrator.orchestrate).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'keyboard' }),
+      );
+    });
+
+    it('produces identical result shape as gesture', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(successResult());
+
+      const gestureResult = await service.handleSwipe(baseDto);
+      const keyboardResult = await service.handleSwipe({
+        ...baseDto,
+        source: SwipeSource.KEYBOARD,
+        shortcutKey: 'shift+right',
+      });
+
+      // Same shape — only source differs internally
+      expect(Object.keys(gestureResult)).toEqual(Object.keys(keyboardResult));
+    });
+  });
+
+  describe('button source', () => {
+    it('throws when confirmAction is missing', async () => {
+      await expect(
+        service.handleSwipe({ ...baseDto, source: SwipeSource.BUTTON }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws when confirmAction is false', async () => {
+      await expect(
+        service.handleSwipe({
+          ...baseDto,
+          source: SwipeSource.BUTTON,
+          confirmAction: false,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('proceeds when confirmAction is true', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(successResult());
+
+      const result = await service.handleSwipe({
+        ...baseDto,
+        source: SwipeSource.BUTTON,
+        confirmAction: true,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('applies same validation and risk checks as gesture', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(
+        successResult({ success: false, error: 'Insufficient balance' }),
+      );
+
+      await expect(
+        service.handleSwipe({
+          ...baseDto,
+          source: SwipeSource.BUTTON,
+          confirmAction: true,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('traceability', () => {
+    it('includes traceId in error response when orchestration fails', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(
+        successResult({ success: false, error: 'risk blocked', traceId: 'trace-xyz' }),
+      );
+
+      try {
+        await service.handleSwipe(baseDto);
+        fail('should have thrown');
+      } catch (err: unknown) {
+        const ex = err as BadRequestException;
+        const body = ex.getResponse() as Record<string, unknown>;
+        expect(body.traceId).toBe('trace-xyz');
+      }
+    });
+  });
+
+  describe('order type override', () => {
+    it('forwards orderTypeOverride to the orchestrator', async () => {
+      mockOrchestrator.orchestrate.mockResolvedValue(
+        successResult({ orderType: OrderType.LIMIT }),
+      );
+
+      await service.handleSwipe({
+        ...baseDto,
+        orderTypeOverride: OrderType.LIMIT,
+      });
+
+      expect(mockOrchestrator.orchestrate).toHaveBeenCalledWith(
+        expect.objectContaining({ orderTypeOverride: OrderType.LIMIT }),
+      );
+    });
+  });
+});

--- a/src/trades/swipe/swipe.service.ts
+++ b/src/trades/swipe/swipe.service.ts
@@ -1,0 +1,68 @@
+import {
+  Injectable,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { SwipeIntentDto, SwipeSource } from './dto/swipe-intent.dto';
+import {
+  TradeExecutionOrchestratorService,
+  OrchestratorResult,
+} from '../services/trade-execution-orchestrator.service';
+
+@Injectable()
+export class SwipeService {
+  private readonly logger = new Logger(SwipeService.name);
+
+  constructor(
+    private readonly orchestrator: TradeExecutionOrchestratorService,
+  ) {}
+
+  /**
+   * Accepts a swipe intent from any input source (gesture, keyboard, button)
+   * and delegates to the trade execution orchestrator.
+   * Response semantics are identical regardless of source.
+   */
+  async handleSwipe(dto: SwipeIntentDto): Promise<OrchestratorResult> {
+    this.guardButtonConfirmation(dto);
+
+    this.logger.log(
+      `Swipe received: user=${dto.userId} signal=${dto.signalId} source=${dto.source}` +
+        (dto.shortcutKey ? ` shortcut=${dto.shortcutKey}` : ''),
+    );
+
+    const result = await this.orchestrator.orchestrate({
+      userId: dto.userId,
+      signalId: dto.signalId,
+      side: dto.side,
+      amount: dto.amount,
+      stopLossPrice: dto.stopLossPrice,
+      takeProfitPrice: dto.takeProfitPrice,
+      slippageTolerance: dto.slippageTolerance,
+      walletAddress: dto.walletAddress,
+      orderTypeOverride: dto.orderTypeOverride,
+      source: dto.source,
+    });
+
+    if (!result.success) {
+      throw new BadRequestException({
+        message: result.error ?? 'Swipe trade execution failed',
+        traceId: result.traceId,
+        stages: result.stages,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Button-sourced actions require explicit confirmation to prevent accidental
+   * execution from UI mis-clicks.
+   */
+  private guardButtonConfirmation(dto: SwipeIntentDto): void {
+    if (dto.source === SwipeSource.BUTTON && !dto.confirmAction) {
+      throw new BadRequestException(
+        'Button-sourced swipe requires confirmAction=true',
+      );
+    }
+  }
+}

--- a/src/trades/trades.module.ts
+++ b/src/trades/trades.module.ts
@@ -29,6 +29,9 @@ import { TradeAuditController } from './trade-audit.controller';
 import { ConfirmationPollingService } from './services/confirmation-polling.service';
 import { AuditModule } from '../audit-log/audit.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { TradeExecutionOrchestratorService } from './services/trade-execution-orchestrator.service';
+import { SwipeController } from './swipe/swipe.controller';
+import { SwipeService } from './swipe/swipe.service';
 
 @Module({
   imports: [
@@ -44,7 +47,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     AuditModule,
     NotificationsModule,
   ],
-  controllers: [TradesController, AdvancedOrdersController, LimitOrderController],
+  controllers: [TradesController, AdvancedOrdersController, LimitOrderController, SwipeController],
   providers: [
     TradesService,
     RiskManagerService,
@@ -58,8 +61,10 @@ import { NotificationsModule } from '../notifications/notifications.module';
     TradeHistoryService,
     TradeOutcomeService,
     LimitOrderService,
+    TradeExecutionOrchestratorService,
+    SwipeService,
   ],
-  exports: [TradesService, RiskManagerService, OcoOrderService, IcebergOrderService, PartialCloseService, TradeHistoryService, TradeOutcomeService, TradeAuditService, ConfirmationPollingService],
+  exports: [TradesService, RiskManagerService, OcoOrderService, IcebergOrderService, PartialCloseService, TradeHistoryService, TradeOutcomeService, TradeAuditService, ConfirmationPollingService, TradeExecutionOrchestratorService],
 })
 export class TradesModule { }
 


### PR DESCRIPTION


Summary
This PR implements four related backend features that complete the swipe-to-trade execution pipeline:

closes #503 — Trade Execution Orchestrator: coordinates the full path from swipe intent to Soroban order placement
closes #504 — Soroban Transaction Builder: constructs and validates signed Soroban payloads for market and limit orders
closes #513 — Fallback Swipe Endpoint: unified POST /trades/swipe that accepts gesture, keyboard, and button inputs with identical semantics
closees #522 — Low Balance Alert Service: detects insufficient wallet balances and queues user alerts with top-up guidance and cooldown deduplication
Changes
#503 — Trade Execution Orchestrator (src/trades/services/)
TradeExecutionOrchestratorService runs 7 named, timed stages: account validation → risk checks → order type selection → transaction build → trade persist → Soroban execution → finalize
Each stage records status and duration; failures propagate with a UUID traceId for end-to-end traceability
Delegates to RiskManagerService, ComplianceRuleEngineService, VelocityRiskManager, TradeExecutorService, and the new SorobanTransactionBuilderService
Integration tests cover: successful market/limit execution, duplicate signal rejection, validation failure, Soroban timeout, compliance block, and all three input sources
#504 — Soroban Transaction Builder (src/soroban/)
SorobanTransactionBuilderService.buildMarketOrder() — constructs execute_market_order payload; converts slippage % → bps, encodes amounts as Stellar stroops
buildLimitOrder() — constructs place_limit_order payload with configurable expiry (default 24h)
applyRiskCap() — reduces order size when notional value exceeds userRisk.maxExposure
validatePayload() — guards contractId, method, args, adjustedAmount, and slippageBps before dispatch
Unit tests cover both order variants, risk capping, stroop encoding, slippage clamping, and all validation error paths
#513 — Fallback Swipe Endpoint (src/trades/swipe/)
POST /trades/swipe accepts SwipeIntentDto with source: 'gesture' | 'keyboard' | 'button', optional shortcutKey, and confirmAction
SwipeService delegates to the orchestrator — identical validation, risk checks, and Soroban execution regardless of source
Button-sourced requests require confirmAction: true to prevent accidental execution
Tests confirm result shape is identical across all three sources; traceId is included in error responses
#522 — Low Balance Alert Service (src/alerts/)
LowBalanceAlertService.checkAndAlert() compares wallet balance against trade.minimumBalanceThreshold (config)
Alert notification includes shortfall amount, top-up wallet address, and estimated trade capacity with fee factored in
Per-user cooldown stored in Redis via CacheService; default 24h (alerts.lowBalanceCooldownSeconds)
Tests verify threshold evaluation, alert content, cooldown suppression, and isInCooldown edge cases
Module wiring
SorobanTransactionBuilderService added to SorobanModule providers/exports
TradeExecutionOrchestratorService, SwipeService, SwipeController registered in TradesModule
LowBalanceAlertModule imported in AppModule
Test plan
 Run jest --testPathPattern="trade-execution-orchestrator" — all integration tests pass
 Run jest --testPathPattern="soroban-transaction-builder" — all unit tests pass
 Run jest --testPathPattern="swipe.service" — all swipe source/confirmation tests pass
 Run jest --testPathPattern="low-balance-alert" — all alert/cooldown tests pass
 POST /trades/swipe with each of gesture, keyboard, button (with confirmAction: true) returns HTTP 201 with matching result shape
 POST /trades/swipe with source: "button" and no confirmAction returns HTTP 400
 Low balance alert is sent once for a sub-threshold wallet; a second call within 24h is suppressed