### PR TITLE
feat(notifications,assets): implement notification preferences servic…

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -71,6 +71,7 @@ import { I18nModule } from './i18n/i18n.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { AuditModule } from './audit-log/audit.module';
+import { AssetsModule } from './assets/assets.module';
 import { SocialExportModule } from './social-export/social-export.module';
  main
  main
@@ -206,6 +207,7 @@ import { SocialExportModule } from './social-export/social-export.module';
     PortfolioModule,
     NotificationsModule,
     AuditModule,
+    AssetsModule,
     SocialExportModule,
  main
  main

--- a/src/assets/assets.module.ts
+++ b/src/assets/assets.module.ts
@@ -5,16 +5,19 @@ import { AssetsService } from './assets.service';
 import { AssetsController } from './assets.controller';
 import { Asset } from './entities/asset.entity';
 import { AssetPair } from './entities/asset-pair.entity';
+import { AssetFreeze } from './freeze/entities/asset-freeze.entity';
+import { AssetFreezeService } from './freeze/asset-freeze.service';
+import { AssetController } from './freeze/asset.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Asset, AssetPair]),
+    TypeOrmModule.forFeature([Asset, AssetPair, AssetFreeze]),
     CacheModule.register({
       ttl: 60 * 1000, // 60 seconds default TTL
     }),
   ],
-  providers: [AssetsService],
-  controllers: [AssetsController],
-  exports: [AssetsService],
+  providers: [AssetsService, AssetFreezeService],
+  controllers: [AssetsController, AssetController],
+  exports: [AssetsService, AssetFreezeService],
 })
 export class AssetsModule {}

--- a/src/assets/freeze/asset-freeze.service.spec.ts
+++ b/src/assets/freeze/asset-freeze.service.spec.ts
@@ -1,0 +1,238 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { AssetFreezeService } from './asset-freeze.service';
+import { AssetFreeze, FreezeReason, FreezeStatus } from './entities/asset-freeze.entity';
+import { FreezeAssetDto, UnfreezeAssetDto } from './dto/freeze-asset.dto';
+
+const ADMIN_ID = 'admin-uuid-1';
+const ASSET_ID = 'asset-uuid-1';
+
+const mockFreezeRecord = (): AssetFreeze => ({
+  id: 'freeze-uuid-1',
+  assetId: ASSET_ID,
+  status: FreezeStatus.FROZEN,
+  reason: FreezeReason.SECURITY,
+  description: 'Suspicious activity',
+  initiatedBy: ADMIN_ID,
+  frozenAt: new Date('2024-01-01T10:00:00Z'),
+  unfrozenAt: null,
+  createdAt: new Date('2024-01-01T10:00:00Z'),
+  updatedAt: new Date('2024-01-01T10:00:00Z'),
+});
+
+describe('AssetFreezeService', () => {
+  let service: AssetFreezeService;
+  let repo: jest.Mocked<Repository<AssetFreeze>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssetFreezeService,
+        {
+          provide: getRepositoryToken(AssetFreeze),
+          useValue: {
+            findOne: jest.fn(),
+            find: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AssetFreezeService>(AssetFreezeService);
+    repo = module.get(getRepositoryToken(AssetFreeze));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ─── freezeAsset ──────────────────────────────────────────────────────────
+
+  describe('freezeAsset', () => {
+    it('creates a freeze record for an unfrozen asset', async () => {
+      repo.findOne.mockResolvedValue(null); // not currently frozen
+      const freeze = mockFreezeRecord();
+      repo.create.mockReturnValue(freeze);
+      repo.save.mockResolvedValue(freeze);
+
+      const dto: FreezeAssetDto = {
+        assetId: ASSET_ID,
+        reason: FreezeReason.SECURITY,
+        description: 'Suspicious activity',
+      };
+
+      const result = await service.freezeAsset(dto, ADMIN_ID);
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetId: ASSET_ID,
+          status: FreezeStatus.FROZEN,
+          reason: FreezeReason.SECURITY,
+          initiatedBy: ADMIN_ID,
+        }),
+      );
+      expect(result.status).toBe(FreezeStatus.FROZEN);
+      expect(result.assetId).toBe(ASSET_ID);
+    });
+
+    it('throws BadRequestException if asset is already frozen', async () => {
+      repo.findOne.mockResolvedValue(mockFreezeRecord());
+
+      const dto: FreezeAssetDto = {
+        assetId: ASSET_ID,
+        reason: FreezeReason.REGULATORY,
+      };
+
+      await expect(service.freezeAsset(dto, ADMIN_ID)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('sets frozenAt timestamp on freeze', async () => {
+      repo.findOne.mockResolvedValue(null);
+      const freeze = mockFreezeRecord();
+      repo.create.mockReturnValue(freeze);
+      repo.save.mockResolvedValue(freeze);
+
+      const dto: FreezeAssetDto = { assetId: ASSET_ID, reason: FreezeReason.COMPLIANCE };
+      const result = await service.freezeAsset(dto, ADMIN_ID);
+
+      expect(result.frozenAt).toBeInstanceOf(Date);
+    });
+  });
+
+  // ─── unfreezeAsset ────────────────────────────────────────────────────────
+
+  describe('unfreezeAsset', () => {
+    it('unfreezes a currently frozen asset', async () => {
+      const freeze = mockFreezeRecord();
+      repo.findOne.mockResolvedValue(freeze);
+      repo.save.mockImplementation(async (f) => f as AssetFreeze);
+
+      const dto: UnfreezeAssetDto = {
+        assetId: ASSET_ID,
+        description: 'Investigation complete',
+      };
+
+      const result = await service.unfreezeAsset(dto, ADMIN_ID);
+
+      expect(result.status).toBe(FreezeStatus.UNFROZEN);
+      expect(result.unfrozenAt).toBeInstanceOf(Date);
+    });
+
+    it('throws NotFoundException if asset is not frozen', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const dto: UnfreezeAssetDto = { assetId: ASSET_ID };
+
+      await expect(service.unfreezeAsset(dto, ADMIN_ID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('records the admin who performed the unfreeze', async () => {
+      const freeze = mockFreezeRecord();
+      repo.findOne.mockResolvedValue(freeze);
+      repo.save.mockImplementation(async (f) => f as AssetFreeze);
+
+      const dto: UnfreezeAssetDto = { assetId: ASSET_ID };
+      const result = await service.unfreezeAsset(dto, 'admin-uuid-2');
+
+      expect(result.initiatedBy).toBe('admin-uuid-2');
+    });
+  });
+
+  // ─── checkFreezeStatus ────────────────────────────────────────────────────
+
+  describe('checkFreezeStatus', () => {
+    it('returns isFrozen=true with active freeze record when frozen', async () => {
+      repo.findOne.mockResolvedValue(mockFreezeRecord());
+
+      const result = await service.checkFreezeStatus(ASSET_ID);
+
+      expect(result.isFrozen).toBe(true);
+      expect(result.activeFreeze).not.toBeNull();
+      expect(result.activeFreeze?.assetId).toBe(ASSET_ID);
+    });
+
+    it('returns isFrozen=false with null activeFreeze when not frozen', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.checkFreezeStatus(ASSET_ID);
+
+      expect(result.isFrozen).toBe(false);
+      expect(result.activeFreeze).toBeNull();
+    });
+  });
+
+  // ─── isFrozen ─────────────────────────────────────────────────────────────
+
+  describe('isFrozen', () => {
+    it('returns true when an active freeze record exists', async () => {
+      repo.findOne.mockResolvedValue(mockFreezeRecord());
+
+      expect(await service.isFrozen(ASSET_ID)).toBe(true);
+    });
+
+    it('returns false when no active freeze record exists', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      expect(await service.isFrozen(ASSET_ID)).toBe(false);
+    });
+  });
+
+  // ─── getFreezeHistory ─────────────────────────────────────────────────────
+
+  describe('getFreezeHistory', () => {
+    it('returns all freeze records for an asset ordered by createdAt DESC', async () => {
+      const records = [
+        { ...mockFreezeRecord(), id: 'freeze-2', status: FreezeStatus.UNFROZEN },
+        mockFreezeRecord(),
+      ];
+      repo.find.mockResolvedValue(records as AssetFreeze[]);
+
+      const result = await service.getFreezeHistory(ASSET_ID);
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { assetId: ASSET_ID },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns an empty array when no history exists', async () => {
+      repo.find.mockResolvedValue([]);
+
+      const result = await service.getFreezeHistory(ASSET_ID);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── Freeze state enforcement ─────────────────────────────────────────────
+
+  describe('freeze state enforcement', () => {
+    it('prevents double-freeze on the same asset', async () => {
+      repo.findOne.mockResolvedValue(mockFreezeRecord());
+
+      const dto: FreezeAssetDto = { assetId: ASSET_ID, reason: FreezeReason.ADMIN };
+
+      await expect(service.freezeAsset(dto, ADMIN_ID)).rejects.toThrow(BadRequestException);
+    });
+
+    it('allows re-freeze after unfreeze', async () => {
+      // First call: no active freeze (asset was unfrozen)
+      repo.findOne.mockResolvedValue(null);
+      const freeze = mockFreezeRecord();
+      repo.create.mockReturnValue(freeze);
+      repo.save.mockResolvedValue(freeze);
+
+      const dto: FreezeAssetDto = { assetId: ASSET_ID, reason: FreezeReason.SECURITY };
+      const result = await service.freezeAsset(dto, ADMIN_ID);
+
+      expect(result.status).toBe(FreezeStatus.FROZEN);
+    });
+  });
+});

--- a/src/assets/freeze/asset-freeze.service.ts
+++ b/src/assets/freeze/asset-freeze.service.ts
@@ -1,0 +1,135 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AssetFreeze, FreezeStatus } from './entities/asset-freeze.entity';
+import { FreezeAssetDto, UnfreezeAssetDto } from './dto/freeze-asset.dto';
+import { AssetFreezeCheckDto, AssetFreezeStatusDto } from './dto/asset-freeze-status.dto';
+
+@Injectable()
+export class AssetFreezeService {
+  private readonly logger = new Logger(AssetFreezeService.name);
+
+  constructor(
+    @InjectRepository(AssetFreeze)
+    private readonly freezeRepository: Repository<AssetFreeze>,
+  ) {}
+
+  /**
+   * Freeze an asset, preventing it from being transferred or traded.
+   * Throws if the asset is already frozen.
+   */
+  async freezeAsset(dto: FreezeAssetDto, adminId: string): Promise<AssetFreezeStatusDto> {
+    const existing = await this.getActiveFreezeRecord(dto.assetId);
+
+    if (existing) {
+      throw new BadRequestException(
+        `Asset ${dto.assetId} is already frozen. Unfreeze it before applying a new freeze.`,
+      );
+    }
+
+    const freeze = this.freezeRepository.create({
+      assetId: dto.assetId,
+      status: FreezeStatus.FROZEN,
+      reason: dto.reason,
+      description: dto.description ?? null,
+      initiatedBy: adminId,
+      frozenAt: new Date(),
+      unfrozenAt: null,
+    });
+
+    const saved = await this.freezeRepository.save(freeze);
+    this.logger.log(`Asset ${dto.assetId} frozen by admin ${adminId} — reason: ${dto.reason}`);
+
+    return this.toStatusDto(saved);
+  }
+
+  /**
+   * Unfreeze a previously frozen asset, restoring transfer and trading capability.
+   * Throws if the asset is not currently frozen.
+   */
+  async unfreezeAsset(dto: UnfreezeAssetDto, adminId: string): Promise<AssetFreezeStatusDto> {
+    const freeze = await this.getActiveFreezeRecord(dto.assetId);
+
+    if (!freeze) {
+      throw new NotFoundException(
+        `Asset ${dto.assetId} is not currently frozen.`,
+      );
+    }
+
+    freeze.status = FreezeStatus.UNFROZEN;
+    freeze.unfrozenAt = new Date();
+    freeze.initiatedBy = adminId;
+
+    if (dto.description) {
+      freeze.description = dto.description;
+    }
+
+    const saved = await this.freezeRepository.save(freeze);
+    this.logger.log(`Asset ${dto.assetId} unfrozen by admin ${adminId}`);
+
+    return this.toStatusDto(saved);
+  }
+
+  /**
+   * Check whether a specific asset is currently frozen.
+   * Returns the active freeze record if one exists.
+   */
+  async checkFreezeStatus(assetId: string): Promise<AssetFreezeCheckDto> {
+    const activeFreeze = await this.getActiveFreezeRecord(assetId);
+
+    return {
+      assetId,
+      isFrozen: activeFreeze !== null,
+      activeFreeze: activeFreeze ? this.toStatusDto(activeFreeze) : null,
+    };
+  }
+
+  /**
+   * Returns true if the asset is currently frozen.
+   * Use this in trade/transfer pipelines to gate operations.
+   */
+  async isFrozen(assetId: string): Promise<boolean> {
+    const record = await this.getActiveFreezeRecord(assetId);
+    return record !== null;
+  }
+
+  /**
+   * Retrieve the full audit history of freeze/unfreeze actions for an asset.
+   */
+  async getFreezeHistory(assetId: string): Promise<AssetFreezeStatusDto[]> {
+    const records = await this.freezeRepository.find({
+      where: { assetId },
+      order: { createdAt: 'DESC' },
+    });
+
+    return records.map((r) => this.toStatusDto(r));
+  }
+
+  // ─── Private Helpers ──────────────────────────────────────────────────────
+
+  private async getActiveFreezeRecord(assetId: string): Promise<AssetFreeze | null> {
+    return this.freezeRepository.findOne({
+      where: { assetId, status: FreezeStatus.FROZEN },
+    });
+  }
+
+  private toStatusDto(freeze: AssetFreeze): AssetFreezeStatusDto {
+    return {
+      id: freeze.id,
+      assetId: freeze.assetId,
+      status: freeze.status,
+      reason: freeze.reason,
+      description: freeze.description,
+      initiatedBy: freeze.initiatedBy,
+      frozenAt: freeze.frozenAt,
+      unfrozenAt: freeze.unfrozenAt,
+      createdAt: freeze.createdAt,
+      updatedAt: freeze.updatedAt,
+    };
+  }
+}

--- a/src/assets/freeze/asset.controller.ts
+++ b/src/assets/freeze/asset.controller.ts
@@ -1,0 +1,97 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from '../../admin/guards/admin-role.guard';
+import { AssetFreezeService } from './asset-freeze.service';
+import { FreezeAssetDto, UnfreezeAssetDto } from './dto/freeze-asset.dto';
+import { AssetFreezeCheckDto, AssetFreezeStatusDto } from './dto/asset-freeze-status.dto';
+
+@ApiTags('asset-freeze')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+@Controller('assets/freeze')
+export class AssetController {
+  constructor(private readonly assetFreezeService: AssetFreezeService) {}
+
+  /**
+   * POST /assets/freeze
+   * Freeze an asset to prevent transfers and trading.
+   * Requires admin privileges.
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Freeze an asset (admin only)' })
+  @ApiResponse({ status: 201, description: 'Asset frozen successfully', type: AssetFreezeStatusDto })
+  @ApiResponse({ status: 400, description: 'Asset is already frozen' })
+  @ApiResponse({ status: 403, description: 'Admin privileges required' })
+  async freezeAsset(
+    @Body() dto: FreezeAssetDto,
+    @Request() req: any,
+  ): Promise<AssetFreezeStatusDto> {
+    return this.assetFreezeService.freezeAsset(dto, req.user.id);
+  }
+
+  /**
+   * POST /assets/freeze/unfreeze
+   * Lift a freeze on an asset, restoring transfer and trading capability.
+   * Requires admin privileges.
+   */
+  @Post('unfreeze')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Unfreeze an asset (admin only)' })
+  @ApiResponse({ status: 200, description: 'Asset unfrozen successfully', type: AssetFreezeStatusDto })
+  @ApiResponse({ status: 404, description: 'Asset is not currently frozen' })
+  @ApiResponse({ status: 403, description: 'Admin privileges required' })
+  async unfreezeAsset(
+    @Body() dto: UnfreezeAssetDto,
+    @Request() req: any,
+  ): Promise<AssetFreezeStatusDto> {
+    return this.assetFreezeService.unfreezeAsset(dto, req.user.id);
+  }
+
+  /**
+   * GET /assets/freeze/:assetId/status
+   * Check the current freeze status of an asset.
+   * Requires admin privileges.
+   */
+  @Get(':assetId/status')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check freeze status of an asset (admin only)' })
+  @ApiResponse({ status: 200, description: 'Freeze status', type: AssetFreezeCheckDto })
+  async checkFreezeStatus(
+    @Param('assetId', ParseUUIDPipe) assetId: string,
+  ): Promise<AssetFreezeCheckDto> {
+    return this.assetFreezeService.checkFreezeStatus(assetId);
+  }
+
+  /**
+   * GET /assets/freeze/:assetId/history
+   * Retrieve the full audit history of freeze/unfreeze actions for an asset.
+   * Requires admin privileges.
+   */
+  @Get(':assetId/history')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get freeze/unfreeze audit history for an asset (admin only)' })
+  @ApiResponse({ status: 200, description: 'Freeze history', type: [AssetFreezeStatusDto] })
+  async getFreezeHistory(
+    @Param('assetId', ParseUUIDPipe) assetId: string,
+  ): Promise<AssetFreezeStatusDto[]> {
+    return this.assetFreezeService.getFreezeHistory(assetId);
+  }
+}

--- a/src/assets/freeze/dto/asset-freeze-status.dto.ts
+++ b/src/assets/freeze/dto/asset-freeze-status.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { FreezeReason, FreezeStatus } from '../entities/asset-freeze.entity';
+
+export class AssetFreezeStatusDto {
+  @ApiProperty({ description: 'Freeze record UUID' })
+  id: string;
+
+  @ApiProperty({ description: 'Asset UUID' })
+  assetId: string;
+
+  @ApiProperty({ enum: FreezeStatus, description: 'Current freeze status' })
+  status: FreezeStatus;
+
+  @ApiProperty({ enum: FreezeReason, description: 'Reason for the freeze' })
+  reason: FreezeReason;
+
+  @ApiPropertyOptional({ description: 'Description of the freeze action' })
+  description: string | null;
+
+  @ApiProperty({ description: 'Admin user who initiated the action' })
+  initiatedBy: string;
+
+  @ApiPropertyOptional({ description: 'Timestamp when the asset was frozen' })
+  frozenAt: Date | null;
+
+  @ApiPropertyOptional({ description: 'Timestamp when the freeze was lifted' })
+  unfrozenAt: Date | null;
+
+  @ApiProperty({ description: 'Record creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Record last updated timestamp' })
+  updatedAt: Date;
+}
+
+export class AssetFreezeCheckDto {
+  @ApiProperty({ description: 'Asset UUID' })
+  assetId: string;
+
+  @ApiProperty({ description: 'Whether the asset is currently frozen' })
+  isFrozen: boolean;
+
+  @ApiPropertyOptional({ type: AssetFreezeStatusDto, description: 'Active freeze record, if any' })
+  activeFreeze: AssetFreezeStatusDto | null;
+}

--- a/src/assets/freeze/dto/freeze-asset.dto.ts
+++ b/src/assets/freeze/dto/freeze-asset.dto.ts
@@ -1,0 +1,41 @@
+import { IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { FreezeReason } from '../entities/asset-freeze.entity';
+
+export class FreezeAssetDto {
+  @ApiProperty({ description: 'UUID of the asset to freeze' })
+  @IsUUID()
+  assetId: string;
+
+  @ApiProperty({
+    enum: FreezeReason,
+    description: 'Reason category for the freeze action',
+    example: FreezeReason.SECURITY,
+  })
+  @IsEnum(FreezeReason)
+  reason: FreezeReason;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable description of why the asset is being frozen',
+    example: 'Suspicious trading activity detected on this asset',
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string;
+}
+
+export class UnfreezeAssetDto {
+  @ApiProperty({ description: 'UUID of the asset to unfreeze' })
+  @IsUUID()
+  assetId: string;
+
+  @ApiPropertyOptional({
+    description: 'Reason for lifting the freeze',
+    example: 'Investigation completed — no violation found',
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string;
+}

--- a/src/assets/freeze/entities/asset-freeze.entity.ts
+++ b/src/assets/freeze/entities/asset-freeze.entity.ts
@@ -1,0 +1,68 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum FreezeStatus {
+  FROZEN = 'FROZEN',
+  UNFROZEN = 'UNFROZEN',
+}
+
+export enum FreezeReason {
+  SECURITY = 'SECURITY',
+  REGULATORY = 'REGULATORY',
+  COMPLIANCE = 'COMPLIANCE',
+  ADMIN = 'ADMIN',
+}
+
+@Entity('asset_freezes')
+@Index(['assetId', 'status'])
+export class AssetFreeze {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The asset being frozen/unfrozen */
+  @Column({ name: 'asset_id' })
+  @Index()
+  assetId: string;
+
+  @Column({
+    type: 'enum',
+    enum: FreezeStatus,
+    default: FreezeStatus.FROZEN,
+  })
+  status: FreezeStatus;
+
+  @Column({
+    type: 'enum',
+    enum: FreezeReason,
+    default: FreezeReason.ADMIN,
+  })
+  reason: FreezeReason;
+
+  /** Human-readable description of why the asset was frozen */
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  /** Admin user who initiated the freeze/unfreeze action */
+  @Column({ name: 'initiated_by' })
+  initiatedBy: string;
+
+  /** Timestamp when the freeze was applied */
+  @Column({ name: 'frozen_at', nullable: true })
+  frozenAt: Date | null;
+
+  /** Timestamp when the freeze was lifted */
+  @Column({ name: 'unfrozen_at', nullable: true })
+  unfrozenAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -5,6 +5,8 @@ import { Notification } from './entities/notification.entity';
 import { NotificationPreference } from './preferences/entities/notification-preference.entity';
 import { PreferencesService } from './preferences/preferences.service';
 import { PreferencesController } from './preferences/preferences.controller';
+import { NotificationPreferencesService } from './preferences/notification-preferences.service';
+import { PreferenceController } from './preferences/preference.controller';
 import { NotificationService, NOTIFICATION_QUEUE } from './notification.service';
 import { NotificationController } from './notification.controller';
 import { NotificationProcessor } from './notification.processor';
@@ -14,8 +16,8 @@ import { NotificationProcessor } from './notification.processor';
     TypeOrmModule.forFeature([Notification, NotificationPreference]),
     BullModule.registerQueue({ name: NOTIFICATION_QUEUE }),
   ],
-  controllers: [NotificationController, PreferencesController],
-  providers: [NotificationService, PreferencesService, NotificationProcessor],
-  exports: [NotificationService, PreferencesService],
+  controllers: [NotificationController, PreferencesController, PreferenceController],
+  providers: [NotificationService, PreferencesService, NotificationPreferencesService, NotificationProcessor],
+  exports: [NotificationService, PreferencesService, NotificationPreferencesService],
 })
 export class NotificationsModule {}

--- a/src/notifications/preferences/dto/preference.dto.ts
+++ b/src/notifications/preferences/dto/preference.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ChannelPreferenceDto {
+  @ApiProperty({ description: 'Email notifications enabled', example: true })
+  email: boolean;
+
+  @ApiProperty({ description: 'Push notifications enabled', example: true })
+  push: boolean;
+}
+
+export class PreferenceDto {
+  @ApiProperty({ description: 'User ID' })
+  userId: string;
+
+  @ApiProperty({ type: ChannelPreferenceDto })
+  tradeUpdates: ChannelPreferenceDto;
+
+  @ApiProperty({ type: ChannelPreferenceDto })
+  signalPerformance: ChannelPreferenceDto;
+
+  @ApiProperty({ type: ChannelPreferenceDto })
+  systemAlerts: ChannelPreferenceDto;
+
+  @ApiProperty({ type: ChannelPreferenceDto })
+  marketing: ChannelPreferenceDto;
+
+  @ApiProperty({ description: 'Last updated timestamp' })
+  updatedAt: Date;
+}

--- a/src/notifications/preferences/dto/update-preferences.dto.ts
+++ b/src/notifications/preferences/dto/update-preferences.dto.ts
@@ -1,0 +1,41 @@
+import { IsBoolean, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ChannelUpdateDto {
+  @ApiPropertyOptional({ description: 'Enable or disable email notifications' })
+  @IsOptional()
+  @IsBoolean()
+  email?: boolean;
+
+  @ApiPropertyOptional({ description: 'Enable or disable push notifications' })
+  @IsOptional()
+  @IsBoolean()
+  push?: boolean;
+}
+
+export class UpdatePreferencesDto {
+  @ApiPropertyOptional({ type: ChannelUpdateDto, description: 'Trade update notification settings' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelUpdateDto)
+  tradeUpdates?: ChannelUpdateDto;
+
+  @ApiPropertyOptional({ type: ChannelUpdateDto, description: 'Signal performance notification settings' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelUpdateDto)
+  signalPerformance?: ChannelUpdateDto;
+
+  @ApiPropertyOptional({ type: ChannelUpdateDto, description: 'System alert notification settings' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelUpdateDto)
+  systemAlerts?: ChannelUpdateDto;
+
+  @ApiPropertyOptional({ type: ChannelUpdateDto, description: 'Marketing notification settings' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChannelUpdateDto)
+  marketing?: ChannelUpdateDto;
+}

--- a/src/notifications/preferences/notification-preferences.service.spec.ts
+++ b/src/notifications/preferences/notification-preferences.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationPreferencesService } from './notification-preferences.service';
+import { NotificationPreference } from './entities/notification-preference.entity';
+import { UpdatePreferencesDto } from './dto/update-preferences.dto';
+
+const mockPreference = (): NotificationPreference => ({
+  id: 'pref-uuid-1',
+  userId: 'user-uuid-1',
+  tradeUpdatesEmail: true,
+  tradeUpdatesPush: true,
+  signalPerformanceEmail: true,
+  signalPerformancePush: true,
+  systemAlertsEmail: true,
+  systemAlertsPush: true,
+  marketingEmail: false,
+  marketingPush: false,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+});
+
+describe('NotificationPreferencesService', () => {
+  let service: NotificationPreferencesService;
+  let repo: jest.Mocked<Repository<NotificationPreference>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationPreferencesService,
+        {
+          provide: getRepositoryToken(NotificationPreference),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationPreferencesService>(NotificationPreferencesService);
+    repo = module.get(getRepositoryToken(NotificationPreference));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ─── getPreferences ───────────────────────────────────────────────────────
+
+  describe('getPreferences', () => {
+    it('returns existing preferences for a user', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+
+      const result = await service.getPreferences('user-uuid-1');
+
+      expect(repo.findOne).toHaveBeenCalledWith({ where: { userId: 'user-uuid-1' } });
+      expect(result.userId).toBe('user-uuid-1');
+      expect(result.tradeUpdates).toEqual({ email: true, push: true });
+      expect(result.marketing).toEqual({ email: false, push: false });
+    });
+
+    it('creates default preferences when none exist', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(null);
+      repo.create.mockReturnValue(pref);
+      repo.save.mockResolvedValue(pref);
+
+      const result = await service.getPreferences('user-uuid-1');
+
+      expect(repo.create).toHaveBeenCalledWith({ userId: 'user-uuid-1' });
+      expect(repo.save).toHaveBeenCalled();
+      expect(result.userId).toBe('user-uuid-1');
+    });
+  });
+
+  // ─── updatePreferences ────────────────────────────────────────────────────
+
+  describe('updatePreferences', () => {
+    it('updates only the provided fields', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+      repo.save.mockImplementation(async (p) => p as NotificationPreference);
+
+      const dto: UpdatePreferencesDto = {
+        marketing: { email: true, push: true },
+      };
+
+      const result = await service.updatePreferences('user-uuid-1', dto);
+
+      expect(result.marketing).toEqual({ email: true, push: true });
+      // Other fields should remain unchanged
+      expect(result.tradeUpdates).toEqual({ email: true, push: true });
+    });
+
+    it('updates email-only channel preference', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+      repo.save.mockImplementation(async (p) => p as NotificationPreference);
+
+      const dto: UpdatePreferencesDto = {
+        tradeUpdates: { email: false },
+      };
+
+      const result = await service.updatePreferences('user-uuid-1', dto);
+
+      expect(result.tradeUpdates.email).toBe(false);
+      expect(result.tradeUpdates.push).toBe(true); // unchanged
+    });
+
+    it('updates multiple notification types at once', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+      repo.save.mockImplementation(async (p) => p as NotificationPreference);
+
+      const dto: UpdatePreferencesDto = {
+        signalPerformance: { email: false, push: false },
+        systemAlerts: { push: false },
+      };
+
+      const result = await service.updatePreferences('user-uuid-1', dto);
+
+      expect(result.signalPerformance).toEqual({ email: false, push: false });
+      expect(result.systemAlerts.push).toBe(false);
+      expect(result.systemAlerts.email).toBe(true); // unchanged
+    });
+  });
+
+  // ─── isEnabled ────────────────────────────────────────────────────────────
+
+  describe('isEnabled', () => {
+    it('returns true when the channel is enabled', async () => {
+      repo.findOne.mockResolvedValue(mockPreference());
+
+      const result = await service.isEnabled('user-uuid-1', 'tradeUpdates', 'email');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the channel is disabled', async () => {
+      repo.findOne.mockResolvedValue(mockPreference());
+
+      const result = await service.isEnabled('user-uuid-1', 'marketing', 'email');
+
+      expect(result).toBe(false);
+    });
+
+    it('creates default preferences and returns default value when user has no record', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(null);
+      repo.create.mockReturnValue(pref);
+      repo.save.mockResolvedValue(pref);
+
+      const result = await service.isEnabled('new-user', 'systemAlerts', 'push');
+
+      expect(result).toBe(true); // default is true for systemAlerts
+    });
+  });
+
+  // ─── unsubscribe ──────────────────────────────────────────────────────────
+
+  describe('unsubscribe', () => {
+    it('disables the specified channel for the given type', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+      repo.save.mockImplementation(async (p) => p as NotificationPreference);
+
+      const result = await service.unsubscribe('user-uuid-1', 'marketing', 'push');
+
+      expect(result.marketing.push).toBe(false);
+    });
+
+    it('only disables the targeted channel, leaving others intact', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+      repo.save.mockImplementation(async (p) => p as NotificationPreference);
+
+      const result = await service.unsubscribe('user-uuid-1', 'tradeUpdates', 'email');
+
+      expect(result.tradeUpdates.email).toBe(false);
+      expect(result.tradeUpdates.push).toBe(true); // push remains enabled
+    });
+  });
+
+  // ─── Preference persistence ───────────────────────────────────────────────
+
+  describe('preference persistence', () => {
+    it('persists updated preferences to the repository', async () => {
+      const pref = mockPreference();
+      repo.findOne.mockResolvedValue(pref);
+      repo.save.mockImplementation(async (p) => p as NotificationPreference);
+
+      await service.updatePreferences('user-uuid-1', {
+        marketing: { email: true },
+      });
+
+      expect(repo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a well-formed PreferenceDto with all channels', async () => {
+      repo.findOne.mockResolvedValue(mockPreference());
+
+      const result = await service.getPreferences('user-uuid-1');
+
+      expect(result).toMatchObject({
+        userId: 'user-uuid-1',
+        tradeUpdates: expect.objectContaining({ email: expect.any(Boolean), push: expect.any(Boolean) }),
+        signalPerformance: expect.objectContaining({ email: expect.any(Boolean), push: expect.any(Boolean) }),
+        systemAlerts: expect.objectContaining({ email: expect.any(Boolean), push: expect.any(Boolean) }),
+        marketing: expect.objectContaining({ email: expect.any(Boolean), push: expect.any(Boolean) }),
+        updatedAt: expect.any(Date),
+      });
+    });
+  });
+});

--- a/src/notifications/preferences/notification-preferences.service.ts
+++ b/src/notifications/preferences/notification-preferences.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationPreference } from './entities/notification-preference.entity';
+import { UpdatePreferencesDto } from './dto/update-preferences.dto';
+import { PreferenceDto } from './dto/preference.dto';
+
+export type NotificationType =
+  | 'tradeUpdates'
+  | 'signalPerformance'
+  | 'systemAlerts'
+  | 'marketing';
+
+export type NotificationChannelType = 'email' | 'push';
+
+@Injectable()
+export class NotificationPreferencesService {
+  constructor(
+    @InjectRepository(NotificationPreference)
+    private readonly preferenceRepository: Repository<NotificationPreference>,
+  ) {}
+
+  /**
+   * Retrieve current notification preferences for a user.
+   * Creates default preferences if none exist.
+   */
+  async getPreferences(userId: string): Promise<PreferenceDto> {
+    const preference = await this.findOrCreate(userId);
+    return this.toDto(preference);
+  }
+
+  /**
+   * Update notification preferences for a user.
+   * Only provided fields are updated; others remain unchanged.
+   */
+  async updatePreferences(
+    userId: string,
+    dto: UpdatePreferencesDto,
+  ): Promise<PreferenceDto> {
+    const preference = await this.findOrCreate(userId);
+
+    if (dto.tradeUpdates !== undefined) {
+      if (dto.tradeUpdates.email !== undefined) {
+        preference.tradeUpdatesEmail = dto.tradeUpdates.email;
+      }
+      if (dto.tradeUpdates.push !== undefined) {
+        preference.tradeUpdatesPush = dto.tradeUpdates.push;
+      }
+    }
+
+    if (dto.signalPerformance !== undefined) {
+      if (dto.signalPerformance.email !== undefined) {
+        preference.signalPerformanceEmail = dto.signalPerformance.email;
+      }
+      if (dto.signalPerformance.push !== undefined) {
+        preference.signalPerformancePush = dto.signalPerformance.push;
+      }
+    }
+
+    if (dto.systemAlerts !== undefined) {
+      if (dto.systemAlerts.email !== undefined) {
+        preference.systemAlertsEmail = dto.systemAlerts.email;
+      }
+      if (dto.systemAlerts.push !== undefined) {
+        preference.systemAlertsPush = dto.systemAlerts.push;
+      }
+    }
+
+    if (dto.marketing !== undefined) {
+      if (dto.marketing.email !== undefined) {
+        preference.marketingEmail = dto.marketing.email;
+      }
+      if (dto.marketing.push !== undefined) {
+        preference.marketingPush = dto.marketing.push;
+      }
+    }
+
+    const saved = await this.preferenceRepository.save(preference);
+    return this.toDto(saved);
+  }
+
+  /**
+   * Check whether a specific notification type/channel is enabled for a user.
+   * Used by the notification delivery pipeline before dispatching.
+   */
+  async isEnabled(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannelType,
+  ): Promise<boolean> {
+    const preference = await this.findOrCreate(userId);
+
+    const map: Record<NotificationType, Record<NotificationChannelType, boolean>> = {
+      tradeUpdates: {
+        email: preference.tradeUpdatesEmail,
+        push: preference.tradeUpdatesPush,
+      },
+      signalPerformance: {
+        email: preference.signalPerformanceEmail,
+        push: preference.signalPerformancePush,
+      },
+      systemAlerts: {
+        email: preference.systemAlertsEmail,
+        push: preference.systemAlertsPush,
+      },
+      marketing: {
+        email: preference.marketingEmail,
+        push: preference.marketingPush,
+      },
+    };
+
+    return map[type][channel];
+  }
+
+  /**
+   * Unsubscribe a user from a specific notification type and channel.
+   * Intended for use by email unsubscribe links.
+   */
+  async unsubscribe(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannelType,
+  ): Promise<PreferenceDto> {
+    const dto: UpdatePreferencesDto = {
+      [type]: { [channel]: false },
+    };
+    return this.updatePreferences(userId, dto);
+  }
+
+  // ─── Private Helpers ──────────────────────────────────────────────────────
+
+  private async findOrCreate(userId: string): Promise<NotificationPreference> {
+    const existing = await this.preferenceRepository.findOne({
+      where: { userId },
+    });
+
+    if (existing) return existing;
+
+    const preference = this.preferenceRepository.create({ userId });
+    return this.preferenceRepository.save(preference);
+  }
+
+  private toDto(preference: NotificationPreference): PreferenceDto {
+    return {
+      userId: preference.userId,
+      tradeUpdates: {
+        email: preference.tradeUpdatesEmail,
+        push: preference.tradeUpdatesPush,
+      },
+      signalPerformance: {
+        email: preference.signalPerformanceEmail,
+        push: preference.signalPerformancePush,
+      },
+      systemAlerts: {
+        email: preference.systemAlertsEmail,
+        push: preference.systemAlertsPush,
+      },
+      marketing: {
+        email: preference.marketingEmail,
+        push: preference.marketingPush,
+      },
+      updatedAt: preference.updatedAt,
+    };
+  }
+}

--- a/src/notifications/preferences/preference.controller.ts
+++ b/src/notifications/preferences/preference.controller.ts
@@ -1,0 +1,88 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Put,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import {
+  NotificationPreferencesService,
+  NotificationType,
+  NotificationChannelType,
+} from './notification-preferences.service';
+import { UpdatePreferencesDto } from './dto/update-preferences.dto';
+import { PreferenceDto } from './dto/preference.dto';
+
+@ApiTags('notification-preferences')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('notifications/preferences')
+export class PreferenceController {
+  constructor(
+    private readonly notificationPreferencesService: NotificationPreferencesService,
+  ) {}
+
+  /**
+   * GET /notifications/preferences
+   * Returns the current notification preferences for the authenticated user.
+   */
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get notification preferences for the current user' })
+  @ApiResponse({ status: 200, description: 'Current preferences', type: PreferenceDto })
+  async getPreferences(@Request() req: any): Promise<PreferenceDto> {
+    return this.notificationPreferencesService.getPreferences(req.user.id);
+  }
+
+  /**
+   * PUT /notifications/preferences
+   * Updates notification preferences for the authenticated user.
+   * Only provided fields are changed; omitted fields remain unchanged.
+   */
+  @Put()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update notification preferences for the current user' })
+  @ApiResponse({ status: 200, description: 'Updated preferences', type: PreferenceDto })
+  async updatePreferences(
+    @Request() req: any,
+    @Body() dto: UpdatePreferencesDto,
+  ): Promise<PreferenceDto> {
+    return this.notificationPreferencesService.updatePreferences(req.user.id, dto);
+  }
+
+  /**
+   * GET /notifications/preferences/unsubscribe
+   * One-click unsubscribe endpoint for email links.
+   * e.g. /notifications/preferences/unsubscribe?type=marketing&channel=email
+   */
+  @Get('unsubscribe')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Unsubscribe from a specific notification type and channel' })
+  @ApiQuery({ name: 'type', enum: ['tradeUpdates', 'signalPerformance', 'systemAlerts', 'marketing'] })
+  @ApiQuery({ name: 'channel', enum: ['email', 'push'] })
+  @ApiResponse({ status: 200, description: 'Unsubscribed successfully' })
+  async unsubscribe(
+    @Request() req: any,
+    @Query('type') type: NotificationType,
+    @Query('channel') channel: NotificationChannelType,
+  ): Promise<{ message: string }> {
+    await this.notificationPreferencesService.unsubscribe(req.user.id, type, channel);
+    return {
+      message: `Successfully unsubscribed from ${type} ${channel} notifications.`,
+    };
+  }
+}


### PR DESCRIPTION

Issue #594 - Notification Preference Service:


- Add NotificationPreferencesService with getPreferences, updatePreferences, isEnabled, and unsubscribe methods; preferences are created with sensible defaults on first access (upsert pattern)
- Add PreferenceController (preference.controller.ts) with JWT-guarded endpoints.
- Add PreferenceDto and UpdatePreferencesDto (with ChannelUpdateDto) under preferences/dto/ with full class-validator and Swagger decorations
- Add notification-preferences.service.spec.ts covering getPreferences, updatePreferences, isEnabled, unsubscribe, and persistence scenarios


Issue #601 - Asset Freeze/Unfreeze Support:
- Add AssetFreeze entity (asset_freezes table) with FreezeStatus and FreezeReason enums, indexed on assetId+status for efficient lookup
- Add FreezeAssetDto / UnfreezeAssetDto with UUID and enum validation
- Add AssetFreezeStatusDto and AssetFreezeCheckDto for structured API responses
- Add AssetFreezeService with freezeAsset, unfreezeAsset, checkFreezeStatus, isFrozen, and getFreezeHistory; enforces single-active-freeze invariant and guards against double-freeze / unfreeze-when-not-frozen edge cases
- Add AssetController (asset.controller.ts) with JwtAuthGuard + AdminRoleGuard: POST /assets/freeze, POST /assets/freeze/unfreeze, GET /assets/freeze/:assetId/status, GET /assets/freeze/:assetId/history
- Register AssetFreeze entity, AssetFreezeService, and AssetController in AssetsModule; register AssetsModule in AppModule

Closes #594
Closes #601