### PR TITLE
feat/tenant-quota-price-abi-managment-payload-storage

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,13 +53,8 @@ import { CompetitionsModule } from './competitions/competitions.module';
 import { NftModule } from './nft/nft.module';
 import { HealthModule } from './health/health.module';
 import { RateLimitModule } from './common/rate-limit.module';
- feature/295-discord-community-integration
 import { DiscordBotModule } from './integrations/discord/discord-bot.module';
-
- feature/294-telegram-bot-integration
 import { TelegramBotModule } from './integrations/telegram/telegram-bot.module';
-
- feature/293-mobile-api-optimizations
 import { MobileModule } from './mobile/mobile.module';
 
 import { AutomationModule } from './integrations/automation-platforms/automation.module';
@@ -72,9 +67,7 @@ import { PortfolioModule } from './portfolio/portfolio.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { AuditModule } from './audit-log/audit.module';
 import { SocialExportModule } from './social-export/social-export.module';
- main
- main
- main
+import { QuotaReportingModule } from './multitenancy/quota-reporting/quota-reporting.module';
 
 @Module({
   imports: [
@@ -175,6 +168,7 @@ import { SocialExportModule } from './social-export/social-export.module';
     SecurityModule,
     SecurityMonitoringModule,
     AccessControlModule,
+    QuotaReportingModule,
     KycModule,
     ProductAnalyticsModule,
     BackupModule,
@@ -188,13 +182,8 @@ import { SocialExportModule } from './social-export/social-export.module';
     NftModule,
     HealthModule,
     RateLimitModule,
- feature/295-discord-community-integration
     DiscordBotModule,
-
- feature/294-telegram-bot-integration
     TelegramBotModule,
-
- feature/293-mobile-api-optimizations
     MobileModule,
 
     AutomationModule,
@@ -207,9 +196,6 @@ import { SocialExportModule } from './social-export/social-export.module';
     NotificationsModule,
     AuditModule,
     SocialExportModule,
- main
- main
- main
   ],
   providers: [StellarConfigService],
   exports: [StellarConfigService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { SecurityModule } from './security/security.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { SecurityMonitoringModule } from './security/security-monitoring.module';
 import { AccessControlModule } from './security/access-control/access-control.module';
+import { EncryptedStorageModule } from './storage/encryption/encrypted-storage.module';
 import { KycModule } from './kyc/kyc.module';
 import { ProductAnalyticsModule } from './analytics/product-analytics.module';
 import { BackupModule } from './backup/backup.module';
@@ -170,6 +171,7 @@ import { ContractsModule } from './contracts/contracts.module';
     SecurityModule,
     SecurityMonitoringModule,
     AccessControlModule,
+    EncryptedStorageModule,
     QuotaReportingModule,
     MarketDataHistoryModule,
     ContractsModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -68,6 +68,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { AuditModule } from './audit-log/audit.module';
 import { SocialExportModule } from './social-export/social-export.module';
 import { QuotaReportingModule } from './multitenancy/quota-reporting/quota-reporting.module';
+import { MarketDataHistoryModule } from './market-data/history/market-data-history.module';
 
 @Module({
   imports: [
@@ -169,6 +170,7 @@ import { QuotaReportingModule } from './multitenancy/quota-reporting/quota-repor
     SecurityMonitoringModule,
     AccessControlModule,
     QuotaReportingModule,
+    MarketDataHistoryModule,
     KycModule,
     ProductAnalyticsModule,
     BackupModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -69,6 +69,7 @@ import { AuditModule } from './audit-log/audit.module';
 import { SocialExportModule } from './social-export/social-export.module';
 import { QuotaReportingModule } from './multitenancy/quota-reporting/quota-reporting.module';
 import { MarketDataHistoryModule } from './market-data/history/market-data-history.module';
+import { ContractsModule } from './contracts/contracts.module';
 
 @Module({
   imports: [
@@ -171,6 +172,7 @@ import { MarketDataHistoryModule } from './market-data/history/market-data-histo
     AccessControlModule,
     QuotaReportingModule,
     MarketDataHistoryModule,
+    ContractsModule,
     KycModule,
     ProductAnalyticsModule,
     BackupModule,

--- a/src/contracts/abi-management/abi-management.controller.ts
+++ b/src/contracts/abi-management/abi-management.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AbiManagementService } from './abi-management.service';
+import { UploadAbiDto } from './dto/upload-abi.dto';
+
+@Controller('contracts/abi-management')
+@UseGuards(JwtAuthGuard)
+export class AbiManagementController {
+  constructor(private readonly abiManagementService: AbiManagementService) {}
+
+  @Post()
+  uploadAbi(@Body() dto: UploadAbiDto, @Req() req: any) {
+    return this.abiManagementService.uploadAbi(dto, {
+      id: req.user?.userId ?? req.user?.id,
+      roles: req.user?.roles ?? [],
+    });
+  }
+
+  @Get(':contractName/:network')
+  getLatestAbi(
+    @Param('contractName') contractName: string,
+    @Param('network') network: string,
+  ) {
+    return this.abiManagementService.getLatestAbi(contractName, network);
+  }
+
+  @Get(':contractName/:network/versions')
+  listAbiVersions(
+    @Param('contractName') contractName: string,
+    @Param('network') network: string,
+  ) {
+    return this.abiManagementService.listAbiVersions(contractName, network);
+  }
+
+  @Get(':contractName/:network/versions/:version')
+  getAbiVersion(
+    @Param('contractName') contractName: string,
+    @Param('network') network: string,
+    @Param('version') version: string,
+  ) {
+    return this.abiManagementService.getAbiVersion(contractName, network, version);
+  }
+}

--- a/src/contracts/abi-management/abi-management.module.ts
+++ b/src/contracts/abi-management/abi-management.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContractAbi } from './entities/contract-abi.entity';
+import { AbiManagementService } from './abi-management.service';
+import { AbiManagementController } from './abi-management.controller';
+import { AuthModule } from '../../auth/auth.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ContractAbi]), AuthModule],
+  controllers: [AbiManagementController],
+  providers: [AbiManagementService],
+  exports: [AbiManagementService],
+})
+export class AbiManagementModule {}

--- a/src/contracts/abi-management/abi-management.service.spec.ts
+++ b/src/contracts/abi-management/abi-management.service.spec.ts
@@ -1,0 +1,96 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AbiManagementService } from './abi-management.service';
+import { ContractAbi } from './entities/contract-abi.entity';
+import { Repository } from 'typeorm';
+
+function makeRepo(records: ContractAbi[] = []): jest.Mocked<Repository<ContractAbi>> {
+  return {
+    create: jest.fn((dto) => dto as ContractAbi),
+    save: jest.fn(async (value) => ({ id: 'saved-id', createdAt: new Date(), updatedAt: new Date(), ...value } as ContractAbi)),
+    findOne: jest.fn().mockImplementation(async (query) => {
+      if ('version' in (query.where ?? {})) {
+        return records.find(
+          (record) =>
+            record.contractName === query.where.contractName &&
+            record.network === query.where.network &&
+            record.version === query.where.version,
+        ) ?? null;
+      }
+
+      return (
+        [...records].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ?? null
+      );
+    }),
+    find: jest.fn().mockResolvedValue(records),
+  } as unknown as jest.Mocked<Repository<ContractAbi>>;
+}
+
+describe('AbiManagementService', () => {
+  it('uploads and versions a valid ABI', async () => {
+    const repo = makeRepo([]);
+    const service = new AbiManagementService(repo);
+
+    const result = await service.uploadAbi({
+      contractName: 'TokenBridge',
+      network: 'mainnet',
+      abi: [{ type: 'function', name: 'mint', inputs: [] }],
+      metadata: { address: 'GABC' },
+    });
+
+    expect(result.contractName).toBe('TokenBridge');
+    expect(result.version).toBe('1.0.0');
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  it('rejects malformed ABI payloads', async () => {
+    const service = new AbiManagementService(makeRepo([]));
+
+    await expect(
+      service.uploadAbi({
+        contractName: 'TokenBridge',
+        network: 'mainnet',
+        abi: { not: 'an array' },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('retrieves ABI versions by contract and network', async () => {
+    const records = [
+      {
+        contractName: 'TokenBridge',
+        network: 'mainnet',
+        version: '1.0.0',
+        abi: [{ type: 'function', name: 'mint' }],
+        abiHash: 'hash-1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      {
+        contractName: 'TokenBridge',
+        network: 'mainnet',
+        version: '1.0.1',
+        abi: [{ type: 'function', name: 'burn' }],
+        abiHash: 'hash-2',
+        createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-01T00:00:00.000Z'),
+      },
+    ] as ContractAbi[];
+    const service = new AbiManagementService(makeRepo(records));
+
+    const latest = await service.getLatestAbi('TokenBridge', 'mainnet');
+    const version = await service.getAbiVersion('TokenBridge', 'mainnet', '1.0.0');
+    const versions = await service.listAbiVersions('TokenBridge', 'mainnet');
+
+    expect(latest.version).toBe('1.0.1');
+    expect(version.version).toBe('1.0.0');
+    expect(versions).toHaveLength(2);
+  });
+
+  it('throws when a version is missing', async () => {
+    const service = new AbiManagementService(makeRepo([]));
+
+    await expect(service.getAbiVersion('Missing', 'mainnet', '1.0.0')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+});

--- a/src/contracts/abi-management/abi-management.service.ts
+++ b/src/contracts/abi-management/abi-management.service.ts
@@ -1,0 +1,126 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { ContractAbi, ContractAbiMetadata } from './entities/contract-abi.entity';
+import { UploadAbiDto } from './dto/upload-abi.dto';
+import { AbiVersionDto } from './dto/abi-version.dto';
+import { canonicalizeAbi, parseAbiPayload, AbiEntry } from './utils/abi-validator';
+
+export interface AbiUploadActor {
+  id: string;
+  roles?: string[];
+}
+
+@Injectable()
+export class AbiManagementService {
+  private readonly logger = new Logger(AbiManagementService.name);
+
+  constructor(
+    @InjectRepository(ContractAbi)
+    private readonly abiRepository: Repository<ContractAbi>,
+  ) {}
+
+  async uploadAbi(
+    dto: UploadAbiDto,
+    actor?: AbiUploadActor,
+  ): Promise<AbiVersionDto> {
+    const abi = this.validateAbi(dto.abi);
+    const version = dto.version ?? (await this.resolveNextVersion(dto.contractName, dto.network));
+    const abiHash = this.hashAbi(abi);
+
+    const entity = this.abiRepository.create({
+      contractName: dto.contractName,
+      network: dto.network,
+      version,
+      abi: abi as Record<string, unknown>[],
+      abiHash,
+      metadata: dto.metadata as ContractAbiMetadata | undefined,
+      uploadedByUserId: actor?.id,
+      isActive: true,
+    });
+
+    const saved = await this.abiRepository.save(entity);
+    this.logger.log(
+      `Stored ABI ${saved.contractName}@${saved.network} version ${saved.version}`,
+    );
+    return this.toDto(saved);
+  }
+
+  async getLatestAbi(contractName: string, network: string): Promise<AbiVersionDto> {
+    const record = await this.abiRepository.findOne({
+      where: { contractName, network },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (!record) {
+      throw new NotFoundException(`No ABI found for ${contractName} on ${network}`);
+    }
+
+    return this.toDto(record);
+  }
+
+  async getAbiVersion(
+    contractName: string,
+    network: string,
+    version: string,
+  ): Promise<AbiVersionDto> {
+    const record = await this.abiRepository.findOne({
+      where: { contractName, network, version },
+    });
+
+    if (!record) {
+      throw new NotFoundException(
+        `ABI version ${version} not found for ${contractName} on ${network}`,
+      );
+    }
+
+    return this.toDto(record);
+  }
+
+  async listAbiVersions(contractName: string, network: string): Promise<AbiVersionDto[]> {
+    const records = await this.abiRepository.find({
+      where: { contractName, network },
+      order: { createdAt: 'DESC' },
+    });
+
+    return records.map((record) => this.toDto(record));
+  }
+
+  private validateAbi(abi: unknown): AbiEntry[] {
+    try {
+      return parseAbiPayload(abi);
+    } catch (error) {
+      throw new BadRequestException((error as Error).message);
+    }
+  }
+
+  private async resolveNextVersion(contractName: string, network: string): Promise<string> {
+    const versions = await this.abiRepository.find({
+      where: { contractName, network },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (versions.length === 0) {
+      return '1.0.0';
+    }
+
+    const [major, minor, patch] = versions[0].version.split('.').map((part) => Number(part) || 0);
+    return `${major}.${minor}.${patch + 1}`;
+  }
+
+  private hashAbi(abi: AbiEntry[]): string {
+    return crypto.createHash('sha256').update(canonicalizeAbi(abi)).digest('hex');
+  }
+
+  private toDto(record: ContractAbi): AbiVersionDto {
+    return {
+      contractName: record.contractName,
+      network: record.network,
+      version: record.version,
+      abiHash: record.abiHash,
+      createdAt: record.createdAt.toISOString(),
+      metadata: record.metadata as Record<string, unknown> | undefined,
+    };
+  }
+}

--- a/src/contracts/abi-management/dto/abi-version.dto.ts
+++ b/src/contracts/abi-management/dto/abi-version.dto.ts
@@ -1,0 +1,8 @@
+export class AbiVersionDto {
+  contractName!: string;
+  network!: string;
+  version!: string;
+  abiHash!: string;
+  createdAt!: string;
+  metadata?: Record<string, unknown>;
+}

--- a/src/contracts/abi-management/dto/upload-abi.dto.ts
+++ b/src/contracts/abi-management/dto/upload-abi.dto.ts
@@ -1,0 +1,22 @@
+import { IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class UploadAbiDto {
+  @IsString()
+  @IsNotEmpty()
+  contractName!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  network!: string;
+
+  @IsOptional()
+  @IsString()
+  version?: string;
+
+  @IsObject()
+  abi!: unknown;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/contracts/abi-management/entities/contract-abi.entity.ts
+++ b/src/contracts/abi-management/entities/contract-abi.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export interface ContractAbiMetadata {
+  address?: string;
+  compilerVersion?: string;
+  deployedBlock?: number;
+  sourceCodeHash?: string;
+  notes?: string;
+}
+
+@Entity('contract_abis')
+@Index(['contractName', 'network', 'version'], { unique: true })
+export class ContractAbi {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 120 })
+  contractName!: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 80 })
+  network!: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  version!: string;
+
+  @Column({ type: 'jsonb' })
+  abi!: Record<string, unknown>[];
+
+  @Column({ type: 'varchar', length: 128 })
+  abiHash!: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: ContractAbiMetadata;
+
+  @Column({ type: 'uuid', nullable: true })
+  uploadedByUserId?: string;
+
+  @Column({ type: 'boolean', default: true })
+  isActive!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/contracts/abi-management/utils/abi-validator.ts
+++ b/src/contracts/abi-management/utils/abi-validator.ts
@@ -1,0 +1,60 @@
+export interface AbiEntry {
+  type: string;
+  name?: string;
+  inputs?: Array<Record<string, unknown>>;
+  outputs?: Array<Record<string, unknown>>;
+  stateMutability?: string;
+  anonymous?: boolean;
+}
+
+export function parseAbiPayload(abi: unknown): AbiEntry[] {
+  const parsed = typeof abi === 'string' ? JSON.parse(abi) : abi;
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('ABI must be a JSON array');
+  }
+
+  parsed.forEach((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error(`ABI entry at index ${index} must be an object`);
+    }
+
+    if (typeof (item as AbiEntry).type !== 'string' || !(item as AbiEntry).type) {
+      throw new Error(`ABI entry at index ${index} is missing required field "type"`);
+    }
+  });
+
+  return parsed as AbiEntry[];
+}
+
+export function canonicalizeAbi(abi: AbiEntry[]): string {
+  return JSON.stringify(
+    abi.map((entry) => {
+      const normalized: Record<string, unknown> = {};
+      for (const key of Object.keys(entry).sort()) {
+        const value = (entry as Record<string, unknown>)[key];
+        normalized[key] = Array.isArray(value)
+          ? value.map((item) =>
+              item && typeof item === 'object' ? sortObject(item as Record<string, unknown>) : item,
+            )
+          : value && typeof value === 'object'
+            ? sortObject(value as Record<string, unknown>)
+            : value;
+      }
+      return normalized;
+    }),
+  );
+}
+
+function sortObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.keys(value)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      const item = value[key];
+      acc[key] =
+        item && typeof item === 'object' && !Array.isArray(item)
+          ? sortObject(item as Record<string, unknown>)
+          : item;
+      return acc;
+    }, {});
+}

--- a/src/contracts/contracts.module.ts
+++ b/src/contracts/contracts.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AbiManagementModule } from './abi-management/abi-management.module';
+
+@Module({
+  imports: [AbiManagementModule],
+  exports: [AbiManagementModule],
+})
+export class ContractsModule {}

--- a/src/market-data/history/jobs/refresh-historical-prices.job.ts
+++ b/src/market-data/history/jobs/refresh-historical-prices.job.ts
@@ -1,0 +1,24 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { JobSchedulerService } from '../../../jobs/job-scheduler.service';
+import { PriceCacheRefreshService } from '../price-cache-refresh.service';
+
+@Injectable()
+export class RefreshHistoricalPricesJob implements OnModuleInit {
+  constructor(
+    private readonly scheduler: JobSchedulerService,
+    private readonly priceCacheRefreshService: PriceCacheRefreshService,
+  ) {}
+
+  onModuleInit(): void {
+    this.scheduler.register({
+      name: 'market-data.refresh-historical-prices',
+      cronEnvKey: 'CRON_REFRESH_HISTORICAL_PRICES',
+      defaultCron: '0 */6 * * *',
+      handler: () => this.run(),
+    });
+  }
+
+  async run(): Promise<void> {
+    await this.priceCacheRefreshService.refreshHistoricalPriceCaches();
+  }
+}

--- a/src/market-data/history/market-data-history.module.ts
+++ b/src/market-data/history/market-data-history.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JobsModule } from '../../jobs/jobs.module';
+import { PriceHistory } from '../../prices/entities/price-history.entity';
+import { PriceCacheRefreshService } from './price-cache-refresh.service';
+import { RefreshHistoricalPricesJob } from './jobs/refresh-historical-prices.job';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PriceHistory]), JobsModule],
+  providers: [PriceCacheRefreshService, RefreshHistoricalPricesJob],
+  exports: [PriceCacheRefreshService],
+})
+export class MarketDataHistoryModule {}

--- a/src/market-data/history/price-cache-refresh.service.spec.ts
+++ b/src/market-data/history/price-cache-refresh.service.spec.ts
@@ -1,0 +1,99 @@
+import { PriceCacheRefreshService } from './price-cache-refresh.service';
+import { PriceHistory } from '../../prices/entities/price-history.entity';
+
+function makeRepo(rows: PriceHistory[] = []) {
+  return {
+    createQueryBuilder: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(
+        rows.length > 0
+          ? Array.from(new Set(rows.map((row) => row.assetPair))).map((assetPair) => ({ assetPair }))
+          : [],
+      ),
+    }),
+    find: jest.fn().mockResolvedValue(rows),
+  };
+}
+
+describe('PriceCacheRefreshService', () => {
+  it('refreshes each asset pair and writes the warm cache', async () => {
+    const rows = [
+      {
+        id: '1',
+        assetPair: 'XLM-USDC',
+        price: 0.123,
+        source: 'aggregated',
+        metadata: { pricesUsed: [0.123] },
+        timestamp: new Date(),
+        createdAt: new Date(),
+      },
+    ] as PriceHistory[];
+    const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+    const service = new PriceCacheRefreshService(
+      makeRepo(rows) as any,
+      cacheManager as any,
+    );
+
+    const result = await service.refreshAssetPair('XLM-USDC');
+
+    expect(result.refreshed).toBe(true);
+    expect(cacheManager.set).toHaveBeenCalled();
+  });
+
+  it('retries partial failures before succeeding', async () => {
+    let attempts = 0;
+    const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+    const repo = {
+      createQueryBuilder: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ assetPair: 'BTC-USDC' }]),
+      }),
+      find: jest.fn().mockImplementation(async () => {
+        attempts++;
+        if (attempts < 2) {
+          throw new Error('transient failure');
+        }
+        return [
+          {
+            id: '2',
+            assetPair: 'BTC-USDC',
+            price: 1,
+            source: 'aggregated',
+            metadata: { pricesUsed: [1] },
+            timestamp: new Date(),
+            createdAt: new Date(),
+          },
+        ] as PriceHistory[];
+      }),
+    };
+    const service = new PriceCacheRefreshService(repo as any, cacheManager as any);
+
+    const result = await service.refreshAssetPair('BTC-USDC');
+
+    expect(result.refreshed).toBe(true);
+    expect(result.attempts).toBeGreaterThan(1);
+  });
+
+  it('summarizes a full refresh across all pairs', async () => {
+    const cacheManager = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+    const repo = makeRepo([
+      {
+        id: '1',
+        assetPair: 'ETH-USDC',
+        price: 1,
+        source: 'aggregated',
+        metadata: { pricesUsed: [1] },
+        timestamp: new Date(),
+        createdAt: new Date(),
+      } as PriceHistory,
+    ]);
+    const service = new PriceCacheRefreshService(repo as any, cacheManager as any);
+
+    const summary = await service.refreshHistoricalPriceCaches();
+
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0].assetPair).toBe('ETH-USDC');
+  });
+});

--- a/src/market-data/history/price-cache-refresh.service.ts
+++ b/src/market-data/history/price-cache-refresh.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+import { Repository } from 'typeorm';
+import { PriceHistory } from '../../prices/entities/price-history.entity';
+import {
+  readHistoricalPriceCache,
+  writeHistoricalPriceCache,
+} from './utils/cache-writer';
+
+export interface HistoricalPriceRefreshResult {
+  assetPair: string;
+  refreshed: boolean;
+  attempts: number;
+  cachedRows: number;
+  error?: string;
+}
+
+export interface HistoricalPriceRefreshSummary {
+  lookbackHours: number;
+  refreshedAt: string;
+  results: HistoricalPriceRefreshResult[];
+}
+
+@Injectable()
+export class PriceCacheRefreshService {
+  private readonly logger = new Logger(PriceCacheRefreshService.name);
+  private readonly defaultLookbackHours = 168;
+  private readonly maxAttempts = 3;
+
+  constructor(
+    @InjectRepository(PriceHistory)
+    private readonly priceHistoryRepository: Repository<PriceHistory>,
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager: Cache,
+  ) {}
+
+  async refreshHistoricalPriceCaches(
+    lookbackHours = this.defaultLookbackHours,
+  ): Promise<HistoricalPriceRefreshSummary> {
+    const assetPairs = await this.resolveAssetPairs();
+    const results: HistoricalPriceRefreshResult[] = [];
+
+    for (const assetPair of assetPairs) {
+      results.push(await this.refreshAssetPair(assetPair, lookbackHours));
+    }
+
+    return {
+      lookbackHours,
+      refreshedAt: new Date().toISOString(),
+      results,
+    };
+  }
+
+  async refreshAssetPair(
+    assetPair: string,
+    lookbackHours = this.defaultLookbackHours,
+  ): Promise<HistoricalPriceRefreshResult> {
+    const cached = await readHistoricalPriceCache(this.cacheManager, assetPair, lookbackHours);
+    if (cached && cached.length > 0) {
+      this.logger.debug(`Historical price cache already warm for ${assetPair} (${lookbackHours}h)`);
+    }
+
+    let lastError: string | undefined;
+    let attempts = 0;
+
+    while (attempts < this.maxAttempts) {
+      attempts++;
+      try {
+        const history = await this.loadHistoricalPrices(assetPair, lookbackHours);
+        await writeHistoricalPriceCache(
+          this.cacheManager,
+          assetPair,
+          lookbackHours,
+          history,
+        );
+
+        return {
+          assetPair,
+          refreshed: true,
+          attempts,
+          cachedRows: history.length,
+        };
+      } catch (error) {
+        lastError = (error as Error).message;
+        this.logger.warn(
+          `Historical price refresh failed for ${assetPair} (attempt ${attempts}/${this.maxAttempts}): ${lastError}`,
+        );
+
+        if (attempts < this.maxAttempts) {
+          await this.backoff(attempts);
+        }
+      }
+    }
+
+    return {
+      assetPair,
+      refreshed: false,
+      attempts,
+      cachedRows: 0,
+      error: lastError,
+    };
+  }
+
+  async primeHistoricalPriceCache(
+    assetPair: string,
+    lookbackHours = this.defaultLookbackHours,
+  ): Promise<PriceHistory[]> {
+    const cached = await readHistoricalPriceCache(this.cacheManager, assetPair, lookbackHours);
+    if (cached) {
+      return cached;
+    }
+
+    const history = await this.loadHistoricalPrices(assetPair, lookbackHours);
+    await writeHistoricalPriceCache(
+      this.cacheManager,
+      assetPair,
+      lookbackHours,
+      history,
+    );
+    return history;
+  }
+
+  private async resolveAssetPairs(): Promise<string[]> {
+    const rows = await this.priceHistoryRepository
+      .createQueryBuilder('price')
+      .select('DISTINCT price.assetPair', 'assetPair')
+      .orderBy('price.assetPair', 'ASC')
+      .getRawMany<{ assetPair: string }>();
+
+    const assetPairs = rows.map((row) => row.assetPair).filter(Boolean);
+    return assetPairs.length > 0 ? assetPairs : ['XLM-USDC', 'BTC-USDC', 'ETH-USDC'];
+  }
+
+  private async loadHistoricalPrices(
+    assetPair: string,
+    lookbackHours: number,
+  ): Promise<PriceHistory[]> {
+    const since = new Date(Date.now() - lookbackHours * 60 * 60 * 1000);
+
+    return this.priceHistoryRepository.find({
+      where: {
+        assetPair,
+      },
+      order: {
+        timestamp: 'DESC',
+      },
+    }).then((rows) =>
+      rows.filter((row) => new Date(row.timestamp).getTime() >= since.getTime()),
+    );
+  }
+
+  private async backoff(attempt: number): Promise<void> {
+    const delayMs = Math.min(1000 * Math.pow(2, attempt - 1), 8000);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}

--- a/src/market-data/history/refresh-historical-prices.job.spec.ts
+++ b/src/market-data/history/refresh-historical-prices.job.spec.ts
@@ -1,0 +1,28 @@
+import { RefreshHistoricalPricesJob } from './jobs/refresh-historical-prices.job';
+
+describe('RefreshHistoricalPricesJob', () => {
+  it('registers the job with the configured scheduler', () => {
+    const scheduler = { register: jest.fn() } as any;
+    const refreshService = { refreshHistoricalPriceCaches: jest.fn() } as any;
+
+    const job = new RefreshHistoricalPricesJob(scheduler, refreshService);
+    job.onModuleInit();
+
+    expect(scheduler.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'market-data.refresh-historical-prices',
+        cronEnvKey: 'CRON_REFRESH_HISTORICAL_PRICES',
+      }),
+    );
+  });
+
+  it('delegates execution to the refresh service', async () => {
+    const scheduler = { register: jest.fn() } as any;
+    const refreshService = { refreshHistoricalPriceCaches: jest.fn().mockResolvedValue(undefined) } as any;
+
+    const job = new RefreshHistoricalPricesJob(scheduler, refreshService);
+    await job.run();
+
+    expect(refreshService.refreshHistoricalPriceCaches).toHaveBeenCalled();
+  });
+});

--- a/src/market-data/history/utils/cache-writer.ts
+++ b/src/market-data/history/utils/cache-writer.ts
@@ -1,0 +1,77 @@
+import { Cache } from 'cache-manager';
+import { PriceHistory } from '../../../prices/entities/price-history.entity';
+
+export const HISTORICAL_PRICE_CACHE_PREFIX = 'historical-price-history';
+export const HISTORICAL_PRICE_CACHE_TTL_MS = 30 * 60 * 1000;
+
+export function historicalPriceCacheKey(assetPair: string, hours: number): string {
+  return `${HISTORICAL_PRICE_CACHE_PREFIX}:${assetPair}:${hours}`;
+}
+
+export interface HistoricalPriceCacheEntry {
+  assetPair: string;
+  hours: number;
+  refreshedAt: string;
+  history: Array<Pick<PriceHistory, 'id' | 'assetPair' | 'price' | 'source' | 'metadata' | 'timestamp' | 'createdAt'>>;
+}
+
+export function toHistoricalPriceCacheEntry(
+  assetPair: string,
+  hours: number,
+  history: PriceHistory[],
+): HistoricalPriceCacheEntry {
+  return {
+    assetPair,
+    hours,
+    refreshedAt: new Date().toISOString(),
+    history: history.map((row) => ({
+      id: row.id,
+      assetPair: row.assetPair,
+      price: Number(row.price),
+      source: row.source,
+      metadata: row.metadata,
+      timestamp: row.timestamp,
+      createdAt: row.createdAt,
+    })),
+  };
+}
+
+export function hydrateHistoricalPriceCacheEntry(
+  entry: HistoricalPriceCacheEntry,
+): PriceHistory[] {
+  return entry.history.map((row) => ({
+    ...row,
+    timestamp: new Date(row.timestamp),
+    createdAt: new Date(row.createdAt),
+  })) as PriceHistory[];
+}
+
+export async function writeHistoricalPriceCache(
+  cache: Cache,
+  assetPair: string,
+  hours: number,
+  history: PriceHistory[],
+): Promise<void> {
+  const key = historicalPriceCacheKey(assetPair, hours);
+  await cache.set(
+    key,
+    toHistoricalPriceCacheEntry(assetPair, hours, history),
+    HISTORICAL_PRICE_CACHE_TTL_MS,
+  );
+}
+
+export async function readHistoricalPriceCache(
+  cache: Cache,
+  assetPair: string,
+  hours: number,
+): Promise<PriceHistory[] | null> {
+  const entry = await cache.get<HistoricalPriceCacheEntry>(
+    historicalPriceCacheKey(assetPair, hours),
+  );
+
+  if (!entry) {
+    return null;
+  }
+
+  return hydrateHistoricalPriceCacheEntry(entry);
+}

--- a/src/multitenancy/quota-reporting/dto/quota-report-request.dto.ts
+++ b/src/multitenancy/quota-reporting/dto/quota-report-request.dto.ts
@@ -1,0 +1,17 @@
+import { IsDateString, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class QuotaReportRequestDto {
+  @IsOptional()
+  @IsDateString()
+  periodStart?: string;
+
+  @IsOptional()
+  @IsDateString()
+  periodEnd?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(365)
+  forecastDays?: number;
+}

--- a/src/multitenancy/quota-reporting/dto/quota-report.dto.ts
+++ b/src/multitenancy/quota-reporting/dto/quota-report.dto.ts
@@ -1,0 +1,20 @@
+export class QuotaMetricReportDto {
+  usageType!: string;
+  unit!: string;
+  used!: number;
+  quota!: number;
+  remaining!: number;
+  forecastedQuota!: number;
+  forecastedUsage!: number;
+  forecastedRemaining!: number;
+  utilizationPercentage!: number;
+  forecastedUtilizationPercentage!: number;
+}
+
+export class QuotaReportDto {
+  tenantId!: string;
+  periodStart!: string;
+  periodEnd!: string;
+  generatedAt!: string;
+  metrics!: QuotaMetricReportDto[];
+}

--- a/src/multitenancy/quota-reporting/entities/tenant-usage.entity.ts
+++ b/src/multitenancy/quota-reporting/entities/tenant-usage.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum TenantUsageType {
+  API_CALLS = 'api_calls',
+  SIGNAL_SUBMISSIONS = 'signal_submissions',
+  STORAGE = 'storage',
+}
+
+@Entity('tenant_usage')
+@Index(['tenantId', 'usageType', 'recordedAt'])
+export class TenantUsage {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  tenantId!: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  usageType!: TenantUsageType;
+
+  @Column({ type: 'double precision', default: 0 })
+  used!: number;
+
+  @Column({ type: 'double precision', default: 0 })
+  quota!: number;
+
+  @Column({ type: 'varchar', length: 32, default: 'count' })
+  unit!: string;
+
+  @Column({ type: 'timestamp' })
+  periodStart!: Date;
+
+  @Column({ type: 'timestamp' })
+  periodEnd!: Date;
+
+  @Index()
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  recordedAt!: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/multitenancy/quota-reporting/quota-reporting.module.ts
+++ b/src/multitenancy/quota-reporting/quota-reporting.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../../auth/auth.module';
+import { TenantUsage } from './entities/tenant-usage.entity';
+import { TenantQuotaService } from './tenant-quota.service';
+import { ReportController } from './report.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TenantUsage]), AuthModule],
+  controllers: [ReportController],
+  providers: [TenantQuotaService],
+  exports: [TenantQuotaService],
+})
+export class QuotaReportingModule {}

--- a/src/multitenancy/quota-reporting/report.controller.spec.ts
+++ b/src/multitenancy/quota-reporting/report.controller.spec.ts
@@ -1,0 +1,35 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ReportController } from './report.controller';
+
+describe('ReportController', () => {
+  it('passes the tenant identity and roles to the quota service', async () => {
+    const service = {
+      generateReport: jest.fn().mockResolvedValue({ ok: true }),
+    } as any;
+    const controller = new ReportController(service);
+
+    await controller.getQuotaReport(
+      { user: { userId: 'u1', tenantId: 'tenant-1', roles: ['tenant-admin'] } },
+      {},
+    );
+
+    expect(service.generateReport).toHaveBeenCalledWith(
+      { id: 'u1', tenantId: 'tenant-1', roles: ['tenant-admin'] },
+      {},
+    );
+  });
+
+  it('surfaces access restriction errors from the service', async () => {
+    const service = {
+      generateReport: jest.fn().mockRejectedValue(new ForbiddenException()),
+    } as any;
+    const controller = new ReportController(service);
+
+    await expect(
+      controller.getQuotaReport(
+        { user: { userId: 'u1', tenantId: 'tenant-1', roles: ['member'] } },
+        {},
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/src/multitenancy/quota-reporting/report.controller.ts
+++ b/src/multitenancy/quota-reporting/report.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { TenantQuotaService } from './tenant-quota.service';
+import { QuotaReportRequestDto } from './dto/quota-report-request.dto';
+import { getCurrentTenantId } from '../../tenancy/tenant-context';
+
+@Controller('multitenancy/quota-report')
+@UseGuards(JwtAuthGuard)
+export class ReportController {
+  constructor(private readonly tenantQuotaService: TenantQuotaService) {}
+
+  @Get()
+  async getQuotaReport(@Req() req: any, @Query() query: QuotaReportRequestDto) {
+    return this.tenantQuotaService.generateReport(
+      {
+        id: req.user?.userId ?? req.user?.id,
+        tenantId: req.user?.tenantId ?? getCurrentTenantId(),
+        roles: req.user?.roles ?? req.user?.tenantRoles ?? [],
+      },
+      query,
+    );
+  }
+}

--- a/src/multitenancy/quota-reporting/tenant-quota.service.spec.ts
+++ b/src/multitenancy/quota-reporting/tenant-quota.service.spec.ts
@@ -1,0 +1,76 @@
+import { ForbiddenException } from '@nestjs/common';
+import { TenantQuotaService } from './tenant-quota.service';
+import { TenantUsage, TenantUsageType } from './entities/tenant-usage.entity';
+import { Repository } from 'typeorm';
+
+function makeRepo(rows: TenantUsage[] = []): jest.Mocked<Repository<TenantUsage>> {
+  return {
+    find: jest.fn().mockResolvedValue(rows),
+  } as unknown as jest.Mocked<Repository<TenantUsage>>;
+}
+
+describe('TenantQuotaService', () => {
+  it('generates a quota report with usage, remaining, and forecast values', async () => {
+    const repo = makeRepo([
+      {
+        usageType: TenantUsageType.API_CALLS,
+        used: 250,
+        quota: 1000,
+        unit: 'calls',
+      } as TenantUsage,
+      {
+        usageType: TenantUsageType.SIGNAL_SUBMISSIONS,
+        used: 12,
+        quota: 100,
+        unit: 'submissions',
+      } as TenantUsage,
+      {
+        usageType: TenantUsageType.STORAGE,
+        used: 128,
+        quota: 512,
+        unit: 'bytes',
+      } as TenantUsage,
+    ]);
+    const service = new TenantQuotaService(repo);
+
+    const report = await service.generateReport(
+      { id: 'tenant-admin-1', tenantId: 'tenant-1', roles: ['tenant-admin'] },
+      {
+        periodStart: '2026-05-01T00:00:00.000Z',
+        periodEnd: '2026-05-31T00:00:00.000Z',
+        forecastDays: 30,
+      },
+    );
+
+    expect(report.tenantId).toBe('tenant-1');
+    expect(report.metrics).toHaveLength(3);
+    expect(report.metrics.find((m) => m.usageType === TenantUsageType.API_CALLS)).toMatchObject({
+      used: 250,
+      remaining: 750,
+      forecastedQuota: expect.any(Number),
+      forecastedUsage: expect.any(Number),
+    });
+  });
+
+  it('falls back to default quotas when there are no usage rows', async () => {
+    const repo = makeRepo([]);
+    const service = new TenantQuotaService(repo);
+
+    const report = await service.generateReport(
+      { id: 'tenant-admin-1', roles: ['tenant-admin'] },
+      {},
+    );
+
+    expect(report.metrics.find((m) => m.usageType === TenantUsageType.API_CALLS)?.quota).toBe(
+      100000,
+    );
+  });
+
+  it('rejects non-admin callers', async () => {
+    const service = new TenantQuotaService(makeRepo([]));
+
+    await expect(
+      service.generateReport({ id: 'user-1', roles: ['member'] }, {}),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/src/multitenancy/quota-reporting/tenant-quota.service.ts
+++ b/src/multitenancy/quota-reporting/tenant-quota.service.ts
@@ -1,0 +1,143 @@
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import { TenantUsage, TenantUsageType } from './entities/tenant-usage.entity';
+import { QuotaReportDto, QuotaMetricReportDto } from './dto/quota-report.dto';
+import { QuotaReportRequestDto } from './dto/quota-report-request.dto';
+
+export interface TenantQuotaRequester {
+  id: string;
+  tenantId?: string;
+  roles?: string[];
+}
+
+const DEFAULT_QUOTAS: Record<TenantUsageType, { quota: number; unit: string }> = {
+  [TenantUsageType.API_CALLS]: { quota: 100000, unit: 'calls' },
+  [TenantUsageType.SIGNAL_SUBMISSIONS]: { quota: 10000, unit: 'submissions' },
+  [TenantUsageType.STORAGE]: { quota: 500 * 1024 * 1024 * 1024, unit: 'bytes' },
+};
+
+@Injectable()
+export class TenantQuotaService {
+  private readonly logger = new Logger(TenantQuotaService.name);
+
+  constructor(
+    @InjectRepository(TenantUsage)
+    private readonly usageRepository: Repository<TenantUsage>,
+  ) {}
+
+  async generateReport(
+    requester: TenantQuotaRequester,
+    request: QuotaReportRequestDto = {},
+  ): Promise<QuotaReportDto> {
+    this.assertTenantAdmin(requester);
+
+    const tenantId = requester.tenantId ?? requester.id;
+    const periodStart = request.periodStart ? new Date(request.periodStart) : this.defaultPeriodStart();
+    const periodEnd = request.periodEnd ? new Date(request.periodEnd) : new Date();
+    const forecastDays = request.forecastDays ?? this.deriveForecastDays(periodStart, periodEnd);
+
+    const usageRows = await this.usageRepository.find({
+      where: {
+        tenantId,
+        recordedAt: Between(periodStart, periodEnd),
+      },
+      order: { recordedAt: 'DESC' },
+    });
+
+    const metrics = this.buildMetrics(usageRows, periodStart, periodEnd, forecastDays);
+
+    this.logger.debug(
+      `Generated quota report for tenant ${tenantId} with ${metrics.length} metrics`,
+    );
+
+    return {
+      tenantId,
+      periodStart: periodStart.toISOString(),
+      periodEnd: periodEnd.toISOString(),
+      generatedAt: new Date().toISOString(),
+      metrics,
+    };
+  }
+
+  private buildMetrics(
+    rows: TenantUsage[],
+    periodStart: Date,
+    periodEnd: Date,
+    forecastDays: number,
+  ): QuotaMetricReportDto[] {
+    const grouped = new Map<TenantUsageType, TenantUsage[]>();
+
+    for (const row of rows) {
+      const bucket = grouped.get(row.usageType as TenantUsageType) ?? [];
+      bucket.push(row);
+      grouped.set(row.usageType as TenantUsageType, bucket);
+    }
+
+    return Object.values(TenantUsageType).map((usageType) => {
+      const defaults = DEFAULT_QUOTAS[usageType];
+      const bucket = grouped.get(usageType) ?? [];
+      const used = bucket.reduce((sum, row) => sum + Number(row.used ?? 0), 0);
+      const quota = this.resolveQuota(bucket, defaults.quota);
+      const unit = bucket[0]?.unit ?? defaults.unit;
+      const remaining = Math.max(quota - used, 0);
+      const utilizationPercentage = this.percent(used, quota);
+      const forecastedUsage = this.forecastUsage(used, periodStart, periodEnd, forecastDays);
+      const forecastedRemaining = Math.max(quota - forecastedUsage, 0);
+
+      return {
+        usageType,
+        unit,
+        used,
+        quota,
+        remaining,
+        forecastedQuota: forecastedUsage,
+        forecastedUsage,
+        forecastedRemaining,
+        utilizationPercentage,
+        forecastedUtilizationPercentage: this.percent(forecastedUsage, quota),
+      };
+    });
+  }
+
+  private resolveQuota(rows: TenantUsage[], fallback: number): number {
+    if (rows.length === 0) return fallback;
+    return rows.reduce((max, row) => Math.max(max, Number(row.quota ?? 0)), fallback);
+  }
+
+  private forecastUsage(
+    used: number,
+    periodStart: Date,
+    periodEnd: Date,
+    forecastDays: number,
+  ): number {
+    const elapsedDays = Math.max((periodEnd.getTime() - periodStart.getTime()) / 86_400_000, 1);
+    const dailyRate = used / elapsedDays;
+    return dailyRate * Math.max(forecastDays, 1);
+  }
+
+  private percent(used: number, quota: number): number {
+    if (!quota) return 0;
+    return Number(((used / quota) * 100).toFixed(2));
+  }
+
+  private deriveForecastDays(periodStart: Date, periodEnd: Date): number {
+    const deltaDays = Math.ceil((periodEnd.getTime() - periodStart.getTime()) / 86_400_000);
+    return Math.max(deltaDays, 1);
+  }
+
+  private defaultPeriodStart(): Date {
+    return new Date(Date.now() - 30 * 86_400_000);
+  }
+
+  private assertTenantAdmin(requester: TenantQuotaRequester): void {
+    const roles = (requester.roles ?? []).map((role) => role.toLowerCase());
+    const isTenantAdmin =
+      roles.includes('tenant-admin') ||
+      roles.includes('tenant_admin');
+
+    if (!isTenantAdmin) {
+      throw new ForbiddenException('Only tenant admins can access quota reports');
+    }
+  }
+}

--- a/src/prices/price-oracle.service.ts
+++ b/src/prices/price-oracle.service.ts
@@ -11,6 +11,11 @@ import { PriceDataDto } from './dto/price-data.dto';
 import { SdexPriceProvider } from './providers/sdex-price.provider';
 import { CoinGeckoPriceProvider } from './providers/coingecko-price.provider';
 import { StellarExpertPriceProvider } from './providers/stellar-expert-price.provider';
+import {
+  historicalPriceCacheKey,
+  hydrateHistoricalPriceCacheEntry,
+  readHistoricalPriceCache,
+} from '../market-data/history/utils/cache-writer';
 
 @Injectable()
 export class PriceOracleService implements OnModuleInit {
@@ -185,11 +190,37 @@ export class PriceOracleService implements OnModuleInit {
     assetPair: string,
     hours: number = 24,
   ): Promise<PriceHistory[]> {
-    const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+    const cached = await readHistoricalPriceCache(this.cacheManager, assetPair, hours);
+    if (cached && cached.length > 0) {
+      this.logger.debug(`Historical price cache hit for ${assetPair} (${hours}h)`);
+      return cached;
+    }
 
-    return this.priceHistoryRepository.find({
+    const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+    const history = await this.priceHistoryRepository.find({
       where: { assetPair },
       order: { timestamp: 'DESC' },
+    });
+
+    const filtered = history.filter(
+      (row) => new Date(row.timestamp).getTime() >= since.getTime(),
+    );
+    await this.cacheManager.set(
+      historicalPriceCacheKey(assetPair, hours),
+      {
+        assetPair,
+        hours,
+        refreshedAt: new Date().toISOString(),
+        history: filtered,
+      },
+      30 * 60 * 1000,
+    );
+
+    return hydrateHistoricalPriceCacheEntry({
+      assetPair,
+      hours,
+      refreshedAt: new Date().toISOString(),
+      history: filtered,
     });
   }
 }

--- a/src/storage/encryption/dto/encrypted-payload.dto.ts
+++ b/src/storage/encryption/dto/encrypted-payload.dto.ts
@@ -1,0 +1,29 @@
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
+import {
+  EncryptedPayloadAccessLevel,
+  EncryptedPayloadSourceType,
+} from '../entities/encrypted-payload.entity';
+
+export class EncryptedPayloadDto {
+  @IsEnum(EncryptedPayloadSourceType)
+  sourceType!: EncryptedPayloadSourceType;
+
+  @IsObject()
+  payload!: Record<string, unknown>;
+
+  @IsOptional()
+  @IsString()
+  tenantId?: string;
+
+  @IsOptional()
+  @IsString()
+  ownerUserId?: string;
+
+  @IsOptional()
+  @IsEnum(EncryptedPayloadAccessLevel)
+  accessLevel?: EncryptedPayloadAccessLevel;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/src/storage/encryption/encrypted-storage.module.ts
+++ b/src/storage/encryption/encrypted-storage.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SecurityModule } from '../../security/security.module';
+import { EncryptedStorageService } from './encrypted-storage.service';
+import { EncryptedPayloadRecord } from './entities/encrypted-payload.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EncryptedPayloadRecord]), SecurityModule],
+  providers: [EncryptedStorageService],
+  exports: [EncryptedStorageService],
+})
+export class EncryptedStorageModule {}

--- a/src/storage/encryption/encrypted-storage.service.spec.ts
+++ b/src/storage/encryption/encrypted-storage.service.spec.ts
@@ -1,0 +1,93 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EncryptionService } from '../../security/encryption.service';
+import { EncryptedStorageService } from './encrypted-storage.service';
+import { EncryptedPayloadAccessLevel, EncryptedPayloadRecord, EncryptedPayloadSourceType } from './entities/encrypted-payload.entity';
+import { Repository } from 'typeorm';
+
+const VALID_KEY = 'a-sufficiently-long-encryption-key-for-tests!!';
+
+function makeEncryptionService(): EncryptionService {
+  const config = { get: jest.fn().mockReturnValue(VALID_KEY) } as unknown as ConfigService;
+  return new EncryptionService(config);
+}
+
+function makeRepo(record?: EncryptedPayloadRecord): jest.Mocked<Repository<EncryptedPayloadRecord>> {
+  return {
+    create: jest.fn((value) => value as EncryptedPayloadRecord),
+    save: jest.fn(async (value) => ({ id: 'payload-1', createdAt: new Date(), updatedAt: new Date(), ...value } as EncryptedPayloadRecord)),
+    findOne: jest.fn().mockResolvedValue(record ?? null),
+    find: jest.fn().mockResolvedValue(record ? [record] : []),
+  } as unknown as jest.Mocked<Repository<EncryptedPayloadRecord>>;
+}
+
+describe('EncryptedStorageService', () => {
+  it('encrypts payloads before persistence and decrypts on read', async () => {
+    const encryptionService = makeEncryptionService();
+    const repo = makeRepo({
+      id: 'payload-1',
+      ownerUserId: 'user-1',
+      sourceType: EncryptedPayloadSourceType.WEBHOOK,
+      accessLevel: EncryptedPayloadAccessLevel.PRIVATE,
+      payloadHash: 'hash',
+      encryptedPayload: encryptionService.encrypt(JSON.stringify({ secret: 'value' })),
+      metadata: { hook: 'webhook-1' },
+      payloadSize: 0,
+      createdAt: new Date('2026-05-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    } as EncryptedPayloadRecord);
+    const service = new EncryptedStorageService(repo, encryptionService);
+
+    const stored = await service.storePayload(
+      {
+        sourceType: EncryptedPayloadSourceType.CALLBACK,
+        payload: { hello: 'world' },
+        metadata: { callbackId: 'cb-1' },
+      },
+      { id: 'user-1', roles: ['tenant-admin'] },
+    );
+
+    expect(stored.payload).toEqual({ hello: 'world' });
+    expect(encryptionService.decrypt((repo.save.mock.calls[0][0] as EncryptedPayloadRecord).encryptedPayload)).toEqual(JSON.stringify({ hello: 'world' }));
+  });
+
+  it('denies retrieval to unauthorized users', async () => {
+    const encryptionService = makeEncryptionService();
+    const repo = makeRepo({
+      id: 'payload-1',
+      ownerUserId: 'owner-1',
+      sourceType: EncryptedPayloadSourceType.WEBHOOK,
+      accessLevel: EncryptedPayloadAccessLevel.PRIVATE,
+      payloadHash: 'hash',
+      encryptedPayload: encryptionService.encrypt(JSON.stringify({ secret: 'value' })),
+      payloadSize: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as EncryptedPayloadRecord);
+    const service = new EncryptedStorageService(repo, encryptionService);
+
+    await expect(
+      service.getPayload('payload-1', { id: 'intruder', roles: ['member'] }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows admins to retrieve any decrypted payload', async () => {
+    const encryptionService = makeEncryptionService();
+    const repo = makeRepo({
+      id: 'payload-1',
+      ownerUserId: 'owner-1',
+      sourceType: EncryptedPayloadSourceType.WEBHOOK,
+      accessLevel: EncryptedPayloadAccessLevel.PRIVATE,
+      payloadHash: 'hash',
+      encryptedPayload: encryptionService.encrypt(JSON.stringify({ secret: 'value' })),
+      payloadSize: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as EncryptedPayloadRecord);
+    const service = new EncryptedStorageService(repo, encryptionService);
+
+    const result = await service.getPayload('payload-1', { id: 'admin-1', roles: ['admin'] });
+
+    expect(result.payload).toEqual({ secret: 'value' });
+  });
+});

--- a/src/storage/encryption/encrypted-storage.service.ts
+++ b/src/storage/encryption/encrypted-storage.service.ts
@@ -1,0 +1,189 @@
+import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EncryptionService } from '../../security/encryption.service';
+import { EncryptedPayloadDto } from './dto/encrypted-payload.dto';
+import {
+  EncryptedPayloadAccessLevel,
+  EncryptedPayloadRecord,
+  EncryptedPayloadSourceType,
+} from './entities/encrypted-payload.entity';
+import {
+  EncryptedStorageRequester,
+  canBypassPayloadAccess,
+  hashPayload,
+  stableStringify,
+} from './utils/crypto-helper';
+
+export interface DecryptedEncryptedPayload {
+  id: string;
+  sourceType: EncryptedPayloadSourceType;
+  accessLevel: EncryptedPayloadAccessLevel;
+  tenantId?: string;
+  ownerUserId?: string;
+  payload: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  payloadHash: string;
+  createdAt: string;
+}
+
+@Injectable()
+export class EncryptedStorageService {
+  private readonly logger = new Logger(EncryptedStorageService.name);
+
+  constructor(
+    @InjectRepository(EncryptedPayloadRecord)
+    private readonly payloadRepository: Repository<EncryptedPayloadRecord>,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  async storePayload(
+    dto: EncryptedPayloadDto,
+    requester: EncryptedStorageRequester,
+  ): Promise<DecryptedEncryptedPayload> {
+    this.assertCanStore(requester, dto);
+
+    const payloadHash = hashPayload(dto.payload);
+    const encryptedPayload = this.encryptionService.encrypt(stableStringify(dto.payload));
+
+    const entity = this.payloadRepository.create({
+      tenantId: dto.tenantId ?? requester.tenantId,
+      ownerUserId: dto.ownerUserId ?? requester.id,
+      sourceType: dto.sourceType,
+      accessLevel: dto.accessLevel ?? EncryptedPayloadAccessLevel.PRIVATE,
+      payloadHash,
+      encryptedPayload,
+      metadata: dto.metadata,
+      payloadSize: Buffer.byteLength(stableStringify(dto.payload), 'utf8'),
+    });
+
+    const saved = await this.payloadRepository.save(entity);
+    this.logger.log(`Stored encrypted ${saved.sourceType} payload ${saved.id}`);
+    return this.toDecryptedDto(saved, dto.payload);
+  }
+
+  async getPayload(
+    payloadId: string,
+    requester: EncryptedStorageRequester,
+  ): Promise<DecryptedEncryptedPayload> {
+    const record = await this.payloadRepository.findOne({ where: { id: payloadId } });
+    if (!record) {
+      throw new NotFoundException(`Encrypted payload not found: ${payloadId}`);
+    }
+
+    this.assertCanAccess(record, requester);
+
+    const payload = this.parsePayload(this.encryptionService.decrypt(record.encryptedPayload));
+    return this.toDecryptedDto(record, payload);
+  }
+
+  async listPayloads(
+    requester: EncryptedStorageRequester,
+  ): Promise<Array<Pick<DecryptedEncryptedPayload, 'id' | 'sourceType' | 'accessLevel' | 'tenantId' | 'ownerUserId' | 'payloadHash' | 'createdAt'>>> {
+    const records = await this.payloadRepository.find({
+      order: { createdAt: 'DESC' },
+    });
+
+    return records
+      .filter((record) => this.canSeeRecord(record, requester))
+      .map((record) => ({
+        id: record.id,
+        sourceType: record.sourceType,
+        accessLevel: record.accessLevel,
+        tenantId: record.tenantId,
+        ownerUserId: record.ownerUserId,
+        payloadHash: record.payloadHash,
+        createdAt: record.createdAt.toISOString(),
+      }));
+  }
+
+  private assertCanStore(
+    requester: EncryptedStorageRequester,
+    dto: EncryptedPayloadDto,
+  ): void {
+    if (!requester?.id) {
+      throw new ForbiddenException('Authenticated access is required');
+    }
+
+    if (
+      dto.ownerUserId &&
+      dto.ownerUserId !== requester.id &&
+      !canBypassPayloadAccess(requester)
+    ) {
+      throw new ForbiddenException('Cannot store payload on behalf of another user');
+    }
+  }
+
+  private assertCanAccess(
+    record: EncryptedPayloadRecord,
+    requester: EncryptedStorageRequester,
+  ): void {
+    if (canBypassPayloadAccess(requester)) {
+      return;
+    }
+
+    if (record.ownerUserId && record.ownerUserId === requester.id) {
+      return;
+    }
+
+    if (
+      record.accessLevel === EncryptedPayloadAccessLevel.TENANT &&
+      record.tenantId &&
+      record.tenantId === requester.tenantId
+    ) {
+      return;
+    }
+
+    throw new ForbiddenException('You are not allowed to decrypt this payload');
+  }
+
+  private canSeeRecord(
+    record: EncryptedPayloadRecord,
+    requester: EncryptedStorageRequester,
+  ): boolean {
+    if (canBypassPayloadAccess(requester)) {
+      return true;
+    }
+
+    if (record.ownerUserId && record.ownerUserId === requester.id) {
+      return true;
+    }
+
+    return (
+      record.accessLevel === EncryptedPayloadAccessLevel.TENANT &&
+      !!record.tenantId &&
+      record.tenantId === requester.tenantId
+    );
+  }
+
+  private parsePayload(raw: string): Record<string, unknown> {
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Payload must be a JSON object');
+      }
+      return parsed as Record<string, unknown>;
+    } catch (error) {
+      throw new BadRequestException(
+        `Failed to parse decrypted payload: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  private toDecryptedDto(
+    record: EncryptedPayloadRecord,
+    payload: Record<string, unknown>,
+  ): DecryptedEncryptedPayload {
+    return {
+      id: record.id,
+      sourceType: record.sourceType,
+      accessLevel: record.accessLevel,
+      tenantId: record.tenantId,
+      ownerUserId: record.ownerUserId,
+      payload,
+      metadata: record.metadata,
+      payloadHash: record.payloadHash,
+      createdAt: record.createdAt.toISOString(),
+    };
+  }
+}

--- a/src/storage/encryption/entities/encrypted-payload.entity.ts
+++ b/src/storage/encryption/entities/encrypted-payload.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum EncryptedPayloadSourceType {
+  WEBHOOK = 'webhook',
+  CALLBACK = 'callback',
+}
+
+export enum EncryptedPayloadAccessLevel {
+  PRIVATE = 'private',
+  TENANT = 'tenant',
+  ADMIN = 'admin',
+}
+
+@Entity('encrypted_payloads')
+@Index(['tenantId', 'sourceType', 'createdAt'])
+export class EncryptedPayloadRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  tenantId?: string;
+
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  ownerUserId?: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  sourceType!: EncryptedPayloadSourceType;
+
+  @Column({ type: 'varchar', length: 32, default: EncryptedPayloadAccessLevel.PRIVATE })
+  accessLevel!: EncryptedPayloadAccessLevel;
+
+  @Column({ type: 'varchar', length: 128 })
+  payloadHash!: string;
+
+  @Column({ type: 'text' })
+  encryptedPayload!: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata?: Record<string, unknown>;
+
+  @Column({ type: 'int', default: 0 })
+  payloadSize!: number;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/storage/encryption/utils/crypto-helper.ts
+++ b/src/storage/encryption/utils/crypto-helper.ts
@@ -1,0 +1,37 @@
+import * as crypto from 'crypto';
+
+export interface EncryptedStorageRequester {
+  id: string;
+  tenantId?: string;
+  roles?: string[];
+}
+
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`).join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+export function hashPayload(payload: Record<string, unknown>): string {
+  return crypto.createHash('sha256').update(stableStringify(payload)).digest('hex');
+}
+
+export function canBypassPayloadAccess(requester: EncryptedStorageRequester): boolean {
+  const roles = (requester.roles ?? []).map((role) => role.toLowerCase());
+  return (
+    roles.includes('admin') ||
+    roles.includes('tenant-admin') ||
+    roles.includes('tenant_admin') ||
+    roles.includes('security-admin') ||
+    roles.includes('security_admin')
+  );
+}


### PR DESCRIPTION
closes #593 
closes #590 
closes #589 
closes #591

Tenant quota reporting
Added a quota reporting module with a service, controller, DTOs, and usage entity.
Reports include used, remaining, and forecasted values for API calls, signal submissions, and storage.
Access is restricted to tenant admins.
Files:tenant-quota.service.ts
report.controller.ts
tenant-usage.entity.ts


Historical price cache refresh
Added a scheduled refresh job for historical price caches.
Added retry handling for transient refresh failures.
Updated the price oracle history read path to use the refreshed cache.
Files:price-cache-refresh.service.ts
refresh-historical-prices.job.ts
cache-writer.ts
price-oracle.service.ts


ABI management
Added ABI upload, validation, versioning, and retrieval by contract name and network.
Validates ABI JSON shape before storing.
Stores versioned contract metadata and hashes.
Files:abi-management.service.ts
abi-validator.ts
contract-abi.entity.ts


Encrypted payload storage
Added encrypted storage for webhook and callback payloads.
Payloads are encrypted before persistence and only decrypted for authorized callers.
Added access checks for owner, tenant-scoped access, and elevated roles.
Files:encrypted-storage.service.ts
encrypted-payload.entity.ts
crypto-helper.ts


I also wired the new modules into app.module.ts.