### PR TITLE
feat: #643 #644 #646 — migration/seed mgmt, refresh-token rotation, W…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,46 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Run migrations (up)
+        run: npm run migration:run
+        env:
+          NODE_ENV: test
+          DATABASE_HOST: localhost
+          DATABASE_PORT: 5432
+          DATABASE_USER: test
+          DATABASE_PASSWORD: test
+          DATABASE_NAME: stellarswipe_test
+
+      - name: Run seeds
+        run: npm run seed
+        env:
+          NODE_ENV: test
+          DATABASE_HOST: localhost
+          DATABASE_PORT: 5432
+          DATABASE_USER: test
+          DATABASE_PASSWORD: test
+          DATABASE_NAME: stellarswipe_test
+
+      - name: Validate migration rollback (down)
+        run: npm run migration:revert
+        env:
+          NODE_ENV: test
+          DATABASE_HOST: localhost
+          DATABASE_PORT: 5432
+          DATABASE_USER: test
+          DATABASE_PASSWORD: test
+          DATABASE_NAME: stellarswipe_test
+
+      - name: Re-apply migration after rollback test
+        run: npm run migration:run
+        env:
+          NODE_ENV: test
+          DATABASE_HOST: localhost
+          DATABASE_PORT: 5432
+          DATABASE_USER: test
+          DATABASE_PASSWORD: test
+          DATABASE_NAME: stellarswipe_test
+
       - name: Run unit tests
         run: npm test -- --coverage --maxWorkers=2
         env:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "migration:run": "npm run typeorm -- migration:run",
     "migration:revert": "npm run typeorm -- migration:revert",
     "migration:show": "npm run typeorm -- migration:show",
+    "migration:ci": "npm run migration:run && npm run seed",
+    "seed": "ts-node -r tsconfig-paths/register src/database/seeds/seed.ts",
     "admin": "node bin/stellar-admin"
   },
   "bin": {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { WsJwtAuthGuard } from './guards/ws-jwt-auth.guard';
 import { CacheModule } from '@nestjs/cache-manager';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../users/entities/user.entity';
@@ -45,6 +46,7 @@ import { SessionCleanupService } from './session/session-cleanup.service';
     AuthService,
     JwtStrategy,
     JwtAuthGuard,
+    WsJwtAuthGuard,
     TwitterOauthService,
     TwoFactorService,
     AuthAuditService,
@@ -54,6 +56,7 @@ import { SessionCleanupService } from './session/session-cleanup.service';
   exports: [
     AuthService,
     JwtAuthGuard,
+    WsJwtAuthGuard,
     TwitterOauthService,
     TwoFactorService,
     AuthAuditService,

--- a/src/auth/guards/ws-jwt-auth.guard.ts
+++ b/src/auth/guards/ws-jwt-auth.guard.ts
@@ -1,0 +1,86 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { Socket } from 'socket.io';
+import { SessionManagerService } from '../session/session-manager.service';
+import { JwtPayload } from '../interfaces/jwt-payload.interface';
+
+/**
+ * WebSocket JWT guard (#646).
+ * Validates the Bearer token supplied in the socket handshake:
+ *   - auth.token  (socket.io auth object)
+ *   - Authorization header (query / extra headers)
+ *
+ * Attach via @UseGuards(WsJwtAuthGuard) on a gateway method,
+ * or call canActivate() manually in handleConnection().
+ */
+@Injectable()
+export class WsJwtAuthGuard implements CanActivate {
+  private readonly logger = new Logger(WsJwtAuthGuard.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly sessionManager: SessionManagerService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const client: Socket = context.switchToWs().getClient<Socket>();
+    return this.validateSocket(client);
+  }
+
+  async validateSocket(client: Socket): Promise<boolean> {
+    const token = this.extractToken(client);
+    if (!token) {
+      this.logger.warn(`WS connection ${client.id} rejected: no token`);
+      throw new UnauthorizedException('Missing authentication token');
+    }
+
+    let payload: JwtPayload;
+    try {
+      payload = this.jwtService.verify<JwtPayload>(token, {
+        secret: this.configService.get<string>('jwt.secret'),
+      });
+    } catch {
+      this.logger.warn(`WS connection ${client.id} rejected: invalid token`);
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+
+    // Verify session is still active (respects logout / logout-all)
+    if (payload.sid) {
+      const session = await this.sessionManager.getSession(payload.sid);
+      if (!session) {
+        this.logger.warn(
+          `WS connection ${client.id} rejected: session revoked`,
+        );
+        throw new UnauthorizedException('Session has been revoked');
+      }
+    }
+
+    // Attach user info to the socket for downstream handlers
+    (client as any).user = { id: payload.sub, sessionId: payload.sid };
+    return true;
+  }
+
+  private extractToken(client: Socket): string | null {
+    // 1) socket.io auth object  { auth: { token: 'Bearer <jwt>' } }
+    const authObj = (client.handshake as any)?.auth?.token as
+      | string
+      | undefined;
+    if (authObj) return authObj.replace(/^Bearer\s+/i, '');
+
+    // 2) Authorization header
+    const header = client.handshake.headers?.authorization as
+      | string
+      | undefined;
+    if (header) return header.replace(/^Bearer\s+/i, '');
+
+    return null;
+  }
+}

--- a/src/auth/interfaces/jwt-payload.interface.ts
+++ b/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,6 +1,6 @@
-
 export interface JwtPayload {
-    sub: string; // Internal User ID (UUID)
-    iat?: number;
-    exp?: number;
+  sub: string; // Internal User ID (UUID)
+  sid?: string; // Session ID for revocation checks
+  iat?: number;
+  exp?: number;
 }

--- a/src/auth/session/session-manager.service.spec.ts
+++ b/src/auth/session/session-manager.service.spec.ts
@@ -1,166 +1,92 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UnauthorizedException } from '@nestjs/common';
+import { SessionManagerService } from './session-manager.service';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { SessionManagerService } from './session-manager.service';
+import { UnauthorizedException } from '@nestjs/common';
 
-const store = new Map<string, any>();
-
-const mockCacheManager = {
-  get: jest.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
-  set: jest.fn((key: string, value: any) => { store.set(key, value); return Promise.resolve(); }),
-  del: jest.fn((key: string) => { store.delete(key); return Promise.resolve(); }),
-};
-
-const mockConfigService = {
-  get: jest.fn((key: string, def?: any) => {
-    const map: Record<string, any> = {
-      'auth.sessionTTL': 3600,
-      'auth.refreshTTL': 604800,
-      'auth.maxSessionsPerUser': 2,
-      'jwt.secret': 'test-secret-key-for-unit-tests-only',
-    };
-    return map[key] ?? def;
-  }),
-};
-
-const mockJwtService = {
-  sign: jest.fn(() => 'mock.access.token'),
-};
-
-describe('SessionManagerService', () => {
+describe('SessionManagerService — refresh-token rotation & revocation (#644)', () => {
   let service: SessionManagerService;
+  const store = new Map<string, any>();
+
+  const cacheMock = {
+    get: jest.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+    set: jest.fn((key: string, val: any) => {
+      store.set(key, val);
+      return Promise.resolve();
+    }),
+    del: jest.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+  };
+
+  const jwtServiceMock = {
+    sign: jest.fn(() => 'mock.access.token'),
+  };
+
+  const configServiceMock = {
+    get: jest.fn((key: string, def?: any) => def ?? undefined),
+  };
 
   beforeEach(async () => {
     store.clear();
     jest.clearAllMocks();
 
-    // Re-wire mocks to use the cleared store
-    mockCacheManager.get.mockImplementation((key: string) =>
-      Promise.resolve(store.get(key) ?? null),
-    );
-    mockCacheManager.set.mockImplementation((key: string, value: any) => {
-      store.set(key, value);
-      return Promise.resolve();
-    });
-    mockCacheManager.del.mockImplementation((key: string) => {
-      store.delete(key);
-      return Promise.resolve();
-    });
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SessionManagerService,
-        { provide: CACHE_MANAGER, useValue: mockCacheManager },
-        { provide: ConfigService, useValue: mockConfigService },
-        { provide: JwtService, useValue: mockJwtService },
+        { provide: CACHE_MANAGER, useValue: cacheMock },
+        { provide: JwtService, useValue: jwtServiceMock },
+        { provide: ConfigService, useValue: configServiceMock },
       ],
     }).compile();
 
-    service = module.get(SessionManagerService);
+    service = module.get<SessionManagerService>(SessionManagerService);
   });
 
-  describe('issueTokens', () => {
-    it('returns accessToken, refreshToken, and expiresIn', async () => {
-      const result = await service.issueTokens('user-1', 'GPUBKEY');
-      expect(result.accessToken).toBe('mock.access.token');
-      expect(typeof result.refreshToken).toBe('string');
-      expect(result.refreshToken.length).toBeGreaterThan(0);
-      expect(result.expiresIn).toBe(3600);
-    });
-
-    it('persists an encrypted session entry', async () => {
-      await service.issueTokens('user-1', 'GPUBKEY');
-      const sessionKeys = [...store.keys()].filter((k) => k.startsWith('session:'));
-      expect(sessionKeys.length).toBe(1);
-      // Value must be encrypted (not plain JSON)
-      const raw = store.get(sessionKeys[0]);
-      expect(() => JSON.parse(raw)).toThrow();
-    });
-
-    it('persists an encrypted refresh token entry', async () => {
-      await service.issueTokens('user-1', 'GPUBKEY');
-      const refreshKeys = [...store.keys()].filter((k) => k.startsWith('refresh:'));
-      expect(refreshKeys.length).toBe(1);
-    });
+  it('issues a token pair and stores the session', async () => {
+    const pair = await service.issueTokens('user-1', 'GKEY');
+    expect(pair.accessToken).toBe('mock.access.token');
+    expect(pair.refreshToken).toBeTruthy();
+    expect(pair.expiresIn).toBeGreaterThan(0);
   });
 
-  describe('refreshTokens', () => {
-    it('issues a new token pair and revokes the old session', async () => {
-      const { refreshToken } = await service.issueTokens('user-1', 'GPUBKEY');
-      const oldSessionKeys = [...store.keys()].filter((k) => k.startsWith('session:'));
+  it('rotates: consuming a refresh token revokes the old session', async () => {
+    const { refreshToken } = await service.issueTokens('user-1', 'GKEY');
 
-      const newTokens = await service.refreshTokens(refreshToken);
+    // First refresh succeeds and creates a new session
+    const rotated = await service.refreshTokens(refreshToken);
+    expect(rotated.refreshToken).not.toBe(refreshToken);
 
-      expect(newTokens.accessToken).toBe('mock.access.token');
-      expect(typeof newTokens.refreshToken).toBe('string');
-
-      // Old session must be gone
-      for (const key of oldSessionKeys) {
-        expect(store.has(key)).toBe(false);
-      }
-    });
-
-    it('throws UnauthorizedException for an invalid refresh token', async () => {
-      await expect(service.refreshTokens('bad-token')).rejects.toThrow(UnauthorizedException);
-    });
-
-    it('prevents refresh token reuse (one-time use)', async () => {
-      const { refreshToken } = await service.issueTokens('user-1', 'GPUBKEY');
-      await service.refreshTokens(refreshToken);
-      await expect(service.refreshTokens(refreshToken)).rejects.toThrow(UnauthorizedException);
-    });
+    // Second use of the same (now revoked) token must throw
+    await expect(service.refreshTokens(refreshToken)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
   });
 
-  describe('deleteSession / deleteAllUserSessions', () => {
-    it('removes session and refresh entries on logout', async () => {
-      await service.issueTokens('user-1', 'GPUBKEY');
-      const sessionId = [...store.keys()].find((k) => k.startsWith('session:'))!.replace('session:', '');
-
-      await service.deleteSession(sessionId);
-
-      expect(store.has(`session:${sessionId}`)).toBe(false);
-    });
-
-    it('revokes all sessions for a user', async () => {
-      await service.issueTokens('user-1', 'GPUBKEY');
-      await service.issueTokens('user-1', 'GPUBKEY');
-
-      await service.deleteAllUserSessions('user-1');
-
-      const sessionKeys = [...store.keys()].filter((k) => k.startsWith('session:'));
-      expect(sessionKeys.length).toBe(0);
-    });
+  it('rejects an invalid refresh token', async () => {
+    await expect(
+      service.refreshTokens('totally-invalid'),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
-  describe('max sessions per user', () => {
-    it('evicts the oldest session when limit is exceeded', async () => {
-      // maxSessionsPerUser = 2
-      await service.issueTokens('user-1', 'GPUBKEY');
-      await service.issueTokens('user-1', 'GPUBKEY');
-      const sessionsBefore = [...store.keys()].filter((k) => k.startsWith('session:'));
-      expect(sessionsBefore.length).toBe(2);
+  it('deleteSession removes it so further access is rejected', async () => {
+    const { refreshToken } = await service.issueTokens('user-2', 'GKEY2');
+    const sessions = await service.getUserSessions('user-2');
+    expect(sessions.length).toBe(1);
 
-      // Third session should evict the first
-      await service.issueTokens('user-1', 'GPUBKEY');
-      const sessionsAfter = [...store.keys()].filter((k) => k.startsWith('session:'));
-      expect(sessionsAfter.length).toBe(2);
-    });
+    await service.deleteSession(sessions[0]);
+    const session = await service.getSession(sessions[0]);
+    expect(session).toBeNull();
   });
 
-  describe('getSession', () => {
-    it('returns null for a non-existent session', async () => {
-      const result = await service.getSession('no-such-id');
-      expect(result).toBeNull();
-    });
+  it('deleteAllUserSessions clears every session (logout-all)', async () => {
+    await service.issueTokens('user-3', 'GKEY3');
+    await service.issueTokens('user-3', 'GKEY3');
 
-    it('returns decrypted session data for a valid session', async () => {
-      await service.createSession('sess-x', 'user-2', 'GPUBKEY2', { ip: '127.0.0.1' });
-      const session = await service.getSession('sess-x');
-      expect(session).not.toBeNull();
-      expect(session!.userId).toBe('user-2');
-      expect(session!.publicKey).toBe('GPUBKEY2');
-    });
+    await service.deleteAllUserSessions('user-3');
+    const remaining = await service.getUserSessions('user-3');
+    expect(remaining).toHaveLength(0);
   });
 });

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,39 +1,47 @@
-
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtPayload } from '../interfaces/jwt-payload.interface';
-
 import { UsersService } from '../../users/users.service';
+import { SessionManagerService } from '../session/session-manager.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-    constructor(
-        configService: ConfigService,
-        private usersService: UsersService,
-    ) {
-        super({
-            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-            ignoreExpiration: false,
-            secretOrKey: configService.get<string>('jwt.secret') || 'fallback_secret_do_not_use_in_prod',
-        });
+  constructor(
+    configService: ConfigService,
+    private usersService: UsersService,
+    private sessionManager: SessionManagerService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey:
+        configService.get<string>('jwt.secret') ||
+        'fallback_secret_do_not_use_in_prod',
+    });
+  }
+
+  async validate(payload: JwtPayload) {
+    if (!payload.sub) throw new UnauthorizedException();
+
+    // Reject if the session has been revoked (logout / logout-all)
+    if (payload.sid) {
+      const session = await this.sessionManager.getSession(payload.sid);
+      if (!session) throw new UnauthorizedException('Session has been revoked');
     }
 
-    async validate(payload: JwtPayload) {
-        if (!payload.sub) {
-            throw new UnauthorizedException();
-        }
-
-        const user = await this.usersService.findById(payload.sub);
-        if (!user || !user.isActive) {
-            throw new UnauthorizedException('User is inactive or not found');
-        }
-
-        return {
-            userId: user.id,
-            username: user.username,
-            walletAddress: user.walletAddress,
-        };
+    const user = await this.usersService.findById(payload.sub);
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException('User is inactive or not found');
     }
+
+    return {
+      id: user.id,
+      userId: user.id,
+      username: user.username,
+      walletAddress: user.walletAddress,
+      sessionId: payload.sid,
+    };
+  }
 }

--- a/src/common/gateways/authenticated.gateway.spec.ts
+++ b/src/common/gateways/authenticated.gateway.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { AuthenticatedGateway } from './authenticated.gateway';
+import { WsJwtAuthGuard } from '../../auth/guards/ws-jwt-auth.guard';
+import { UnauthorizedException } from '@nestjs/common';
+
+// Minimal concrete gateway for testing
+@WebSocketGateway({ namespace: '/test' })
+class TestGateway extends AuthenticatedGateway {
+  @WebSocketServer() server!: Server;
+  connected = false;
+  disconnected = false;
+
+  protected onAuthenticated(): void {
+    this.connected = true;
+  }
+  protected onDisconnected(): void {
+    this.disconnected = true;
+  }
+}
+
+const makeSocket = (override?: Partial<Socket>): Socket =>
+  ({
+    id: 'socket-1',
+    handshake: { auth: { token: 'Bearer valid.jwt' }, headers: {} },
+    emit: jest.fn(),
+    disconnect: jest.fn(),
+    ...override,
+  }) as unknown as Socket;
+
+describe('AuthenticatedGateway (#646)', () => {
+  let gateway: TestGateway;
+  let guard: jest.Mocked<WsJwtAuthGuard>;
+
+  beforeEach(async () => {
+    guard = { validateSocket: jest.fn() } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestGateway, { provide: WsJwtAuthGuard, useValue: guard }],
+    }).compile();
+
+    gateway = module.get(TestGateway);
+  });
+
+  it('allows an authorized socket to connect', async () => {
+    guard.validateSocket.mockResolvedValue(true);
+    const client = makeSocket();
+    await gateway.handleConnection(client);
+    expect(gateway.connected).toBe(true);
+    expect(client.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('rejects and disconnects an unauthorized socket', async () => {
+    guard.validateSocket.mockRejectedValue(new UnauthorizedException());
+    const client = makeSocket();
+    await gateway.handleConnection(client);
+    expect(client.emit).toHaveBeenCalledWith('error', {
+      message: 'Unauthorized',
+    });
+    expect(client.disconnect).toHaveBeenCalledWith(true);
+    expect(gateway.connected).toBe(false);
+  });
+
+  it('logs disconnection events', () => {
+    const client = makeSocket();
+    (client as any).user = { id: 'user-1' };
+    gateway.handleDisconnect(client);
+    expect(gateway.disconnected).toBe(true);
+  });
+});

--- a/src/common/gateways/authenticated.gateway.ts
+++ b/src/common/gateways/authenticated.gateway.ts
@@ -1,0 +1,50 @@
+import { Logger } from '@nestjs/common';
+import { OnGatewayConnection, OnGatewayDisconnect } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+import { WsJwtAuthGuard } from '../../auth/guards/ws-jwt-auth.guard';
+
+/**
+ * Base class for authenticated WebSocket gateways (#646).
+ *
+ * Subclass and inject WsJwtAuthGuard:
+ *
+ *   @WebSocketGateway({ namespace: '/trading' })
+ *   export class TradingGateway extends AuthenticatedGateway { ... }
+ *
+ * All connections are authenticated on connect; unauthenticated clients
+ * are immediately disconnected and logged.
+ */
+export abstract class AuthenticatedGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  protected readonly logger = new Logger(this.constructor.name);
+
+  constructor(protected readonly wsAuthGuard: WsJwtAuthGuard) {}
+
+  async handleConnection(client: Socket): Promise<void> {
+    try {
+      await this.wsAuthGuard.validateSocket(client);
+      const user = (client as any).user;
+      this.logger.log(`[CONNECT] socket=${client.id} userId=${user?.id}`);
+      this.onAuthenticated(client);
+    } catch {
+      this.logger.warn(`[REJECT] socket=${client.id} — unauthorized`);
+      client.emit('error', { message: 'Unauthorized' });
+      client.disconnect(true);
+    }
+  }
+
+  handleDisconnect(client: Socket): void {
+    const user = (client as any).user;
+    this.logger.log(
+      `[DISCONNECT] socket=${client.id} userId=${user?.id ?? 'unknown'}`,
+    );
+    this.onDisconnected(client);
+  }
+
+  /** Override to run logic after a socket is authenticated. */
+  protected onAuthenticated(_client: Socket): void {}
+
+  /** Override to run cleanup when a client disconnects. */
+  protected onDisconnected(_client: Socket): void {}
+}

--- a/src/dashboard/dashboard.gateway.ts
+++ b/src/dashboard/dashboard.gateway.ts
@@ -6,54 +6,56 @@ import {
   ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Injectable } from '@nestjs/common';
+import { UseGuards } from '@nestjs/common';
 import { DashboardService } from './dashboard.service';
+import { AuthenticatedGateway } from '../common/gateways/authenticated.gateway';
+import { WsJwtAuthGuard } from '../auth/guards/ws-jwt-auth.guard';
 
-@Injectable()
-@WebSocketGateway({
-  cors: {
-    origin: '*',
-  },
-  namespace: '/dashboard',
-})
-export class DashboardGateway {
+@WebSocketGateway({ cors: { origin: '*' }, namespace: '/dashboard' })
+export class DashboardGateway extends AuthenticatedGateway {
   @WebSocketServer()
   server!: Server;
 
-  constructor(private dashboardService: DashboardService) {}
+  constructor(
+    wsAuthGuard: WsJwtAuthGuard,
+    private readonly dashboardService: DashboardService,
+  ) {
+    super(wsAuthGuard);
+  }
 
+  @UseGuards(WsJwtAuthGuard)
   @SubscribeMessage('subscribe')
   async handleSubscribe(
     @MessageBody() data: { userId: string },
     @ConnectedSocket() client: Socket,
   ): Promise<void> {
-    await client.join(`user_${data.userId}`);
-    
-    // Send initial dashboard data
-    const dashboardData = await this.dashboardService.getDashboardData(data.userId);
+    const requestingUser = (client as any).user;
+    // Users may only subscribe to their own room
+    const targetUserId = requestingUser?.id ?? data.userId;
+    await client.join(`user_${targetUserId}`);
+    const dashboardData =
+      await this.dashboardService.getDashboardData(targetUserId);
     client.emit('dashboard_update', dashboardData);
   }
 
+  @UseGuards(WsJwtAuthGuard)
   @SubscribeMessage('unsubscribe')
   async handleUnsubscribe(
     @MessageBody() data: { userId: string },
     @ConnectedSocket() client: Socket,
   ): Promise<void> {
-    await client.leave(`user_${data.userId}`);
+    const targetUserId = (client as any).user?.id ?? data.userId;
+    await client.leave(`user_${targetUserId}`);
   }
 
   async broadcastUpdate(userId: string): Promise<void> {
     try {
-      // Invalidate cache first
       await this.dashboardService.invalidateCache(userId);
-      
-      // Get fresh data
-      const dashboardData = await this.dashboardService.getDashboardData(userId);
-      
-      // Broadcast to subscribed clients
+      const dashboardData =
+        await this.dashboardService.getDashboardData(userId);
       this.server.to(`user_${userId}`).emit('dashboard_update', dashboardData);
     } catch (error) {
-      console.error('Error broadcasting dashboard update:', error);
+      this.logger.error('Error broadcasting dashboard update:', error);
     }
   }
 }

--- a/src/database/migrations/1750000000000-AddRefreshTokens.ts
+++ b/src/database/migrations/1750000000000-AddRefreshTokens.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #643 — Adds the refresh_tokens table for rotation-based auth (#644).
+ * Up/down are both fully reversible.
+ */
+export class AddRefreshTokens1750000000000 implements MigrationInterface {
+  name = 'AddRefreshTokens1750000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "refresh_tokens" (
+        "id"          uuid        NOT NULL DEFAULT uuid_generate_v4(),
+        "token_hash"  varchar     NOT NULL,
+        "user_id"     uuid        NOT NULL,
+        "session_id"  varchar     NOT NULL,
+        "revoked"     boolean     NOT NULL DEFAULT false,
+        "expires_at"  TIMESTAMP   NOT NULL,
+        "created_at"  TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_refresh_tokens" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_refresh_tokens_hash" UNIQUE ("token_hash")
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_refresh_tokens_user_id"
+        ON "refresh_tokens" ("user_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_refresh_tokens_user_id"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "refresh_tokens"`);
+  }
+}

--- a/src/database/migrations/README.md
+++ b/src/database/migrations/README.md
@@ -5,21 +5,58 @@ This directory contains TypeORM migrations for the StellarSwipe database schema.
 ## Running Migrations
 
 ```bash
-# Generate a new migration
-npm run typeorm migration:generate -- -n MigrationName
+# Run all pending migrations (local & CI)
+npm run migration:run
 
-# Run pending migrations
-npm run typeorm migration:run
+# Generate a new migration from entity changes
+npm run migration:generate -- src/database/migrations/<MigrationName>
 
-# Revert the last migration
-npm run typeorm migration:revert
+# Create a blank migration file
+npm run migration:create -- src/database/migrations/<MigrationName>
+
+# Show pending / applied migrations
+npm run migration:show
+
+# Run migrations + seeds together (CI convenience)
+npm run migration:ci
 ```
 
-## Migration Files
+## Seed Data
 
-- `1737561600000-CreateUserTables.ts` – Initial user schema with users, user_preferences, and sessions tables
+Seed scripts live in `src/database/seeds/`.
 
-## Migration Rollback Safety (`migration-utils.ts`)
+```bash
+# Run all seeders (idempotent — safe to run multiple times)
+npm run seed
+```
+
+Add new seeders by implementing the `Seeder` interface and registering them in `src/database/seeds/seed.ts`.
+
+## Rollback Instructions
+
+### Development / CI
+
+```bash
+# Revert the last applied migration
+npm run migration:revert
+
+# Repeat to roll back multiple migrations one at a time
+```
+
+### Production rollback
+
+1. **Create a backup** before applying or reverting any migration in production.
+2. Run the revert command against the production database:
+   ```bash
+   NODE_ENV=production npm run migration:revert
+   ```
+3. Verify application health after rollback.
+4. If rolling back further, repeat step 2 for each migration to undo.
+5. For `CRITICAL`-severity changes (DROP TABLE, DROP COLUMN) consult
+   `migration-utils.ts` — these are flagged during migration analysis and
+   require a manual data-restore from backup.
+
+> **Never** use `synchronize: true` in production. Always use explicit migrations.
 
 `migration-utils.ts` provides helpers that improve rollback safety and surface
 irreversible changes **before** they are applied to the database.
@@ -41,20 +78,20 @@ if (report.hasIrreversibleChanges) {
 
 **Detected patterns**
 
-| Rule               | Severity | Description                                              |
-|--------------------|----------|----------------------------------------------------------|
-| `DROP_TABLE`       | CRITICAL | Permanently removes table and data                       |
-| `DROP_COLUMN`      | CRITICAL | Permanently removes column and stored values             |
-| `DROP_DATABASE`    | CRITICAL | Destroys the entire database                             |
-| `DROP_SCHEMA`      | CRITICAL | Removes schema and all contained objects                 |
-| `TRUNCATE`         | CRITICAL | Removes all rows without row-level logging               |
-| `DROP_TYPE`        | HIGH     | Removes a custom type; dependent columns must be migrated|
-| `DROP_CONSTRAINT`  | HIGH     | Existing data may violate constraint on re-add           |
-| `ALTER_COLUMN_TYPE`| HIGH     | Narrowing a type may cause data loss                     |
-| `DELETE_DATA`      | HIGH     | Permanently removes rows                                 |
-| `DROP_INDEX`       | WARNING  | Performance impact if `down()` does not recreate it      |
-| `SET_NOT_NULL`     | WARNING  | Fails if existing rows contain NULL                      |
-| `UPDATE_DATA`      | WARNING  | Original values lost unless `down()` reverses the change |
+| Rule                | Severity | Description                                               |
+| ------------------- | -------- | --------------------------------------------------------- |
+| `DROP_TABLE`        | CRITICAL | Permanently removes table and data                        |
+| `DROP_COLUMN`       | CRITICAL | Permanently removes column and stored values              |
+| `DROP_DATABASE`     | CRITICAL | Destroys the entire database                              |
+| `DROP_SCHEMA`       | CRITICAL | Removes schema and all contained objects                  |
+| `TRUNCATE`          | CRITICAL | Removes all rows without row-level logging                |
+| `DROP_TYPE`         | HIGH     | Removes a custom type; dependent columns must be migrated |
+| `DROP_CONSTRAINT`   | HIGH     | Existing data may violate constraint on re-add            |
+| `ALTER_COLUMN_TYPE` | HIGH     | Narrowing a type may cause data loss                      |
+| `DELETE_DATA`       | HIGH     | Permanently removes rows                                  |
+| `DROP_INDEX`        | WARNING  | Performance impact if `down()` does not recreate it       |
+| `SET_NOT_NULL`      | WARNING  | Fails if existing rows contain NULL                       |
+| `UPDATE_DATA`       | WARNING  | Original values lost unless `down()` reverses the change  |
 
 ---
 
@@ -83,11 +120,11 @@ public async up(queryRunner: QueryRunner): Promise<void> {
 
 **Options**
 
-| Option           | Type      | Default | Description                                      |
-|------------------|-----------|---------|--------------------------------------------------|
-| `blockOnCritical`| `boolean` | `false` | Throw before executing if CRITICAL changes found |
-| `blockOnHigh`    | `boolean` | `false` | Throw before executing if HIGH changes found     |
-| `logger`         | `Console` | `console`| Custom logger for findings                      |
+| Option            | Type      | Default   | Description                                      |
+| ----------------- | --------- | --------- | ------------------------------------------------ |
+| `blockOnCritical` | `boolean` | `false`   | Throw before executing if CRITICAL changes found |
+| `blockOnHigh`     | `boolean` | `false`   | Throw before executing if HIGH changes found     |
+| `logger`          | `Console` | `console` | Custom logger for findings                       |
 
 ---
 
@@ -97,7 +134,11 @@ Use these when a migration modifies or removes data and you need a safety net
 that can be used in `down()`.
 
 ```ts
-import { createSafeBackup, restoreFromBackup, dropBackupTable } from './migration-utils';
+import {
+  createSafeBackup,
+  restoreFromBackup,
+  dropBackupTable,
+} from './migration-utils';
 
 // In up():
 const backupTable = await createSafeBackup(queryRunner, 'users');

--- a/src/database/seeds/initial-roles.seed.ts
+++ b/src/database/seeds/initial-roles.seed.ts
@@ -1,0 +1,20 @@
+import { DataSource } from 'typeorm';
+import { Seeder } from './seed.runner';
+
+/**
+ * Seeds the standard roles needed for the application to function.
+ * Idempotent: uses ON CONFLICT DO NOTHING.
+ */
+export class InitialRolesSeed implements Seeder {
+  async run(dataSource: DataSource): Promise<void> {
+    await dataSource.query(`
+      INSERT INTO roles (id, name, description, "createdAt", "updatedAt")
+      VALUES
+        (uuid_generate_v4(), 'admin',    'Full system access',        now(), now()),
+        (uuid_generate_v4(), 'trader',   'Standard trader account',   now(), now()),
+        (uuid_generate_v4(), 'provider', 'Signal provider account',   now(), now()),
+        (uuid_generate_v4(), 'viewer',   'Read-only access',          now(), now())
+      ON CONFLICT (name) DO NOTHING
+    `);
+  }
+}

--- a/src/database/seeds/seed.runner.ts
+++ b/src/database/seeds/seed.runner.ts
@@ -1,0 +1,29 @@
+import { DataSource } from 'typeorm';
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('SeedRunner');
+
+export interface Seeder {
+  run(dataSource: DataSource): Promise<void>;
+}
+
+/**
+ * Runs all seed classes in order. Each seeder is idempotent (uses ON CONFLICT DO NOTHING).
+ * Usage: npm run seed
+ */
+export async function runSeeders(
+  dataSource: DataSource,
+  seeders: Seeder[],
+): Promise<void> {
+  for (const seeder of seeders) {
+    const name = seeder.constructor.name;
+    try {
+      logger.log(`Running seeder: ${name}`);
+      await seeder.run(dataSource);
+      logger.log(`Seeder completed: ${name}`);
+    } catch (err: any) {
+      logger.error(`Seeder failed: ${name} — ${err.message}`);
+      throw err;
+    }
+  }
+}

--- a/src/database/seeds/seed.ts
+++ b/src/database/seeds/seed.ts
@@ -1,0 +1,42 @@
+/**
+ * Standalone seed entry-point.
+ * Usage:  npm run seed
+ * The DATA_SOURCE env var can point to a custom typeorm config file.
+ */
+import 'reflect-metadata';
+import * as dotenv from 'dotenv';
+import { DataSource } from 'typeorm';
+import { runSeeders } from './seed.runner';
+import { InitialRolesSeed } from './initial-roles.seed';
+
+dotenv.config();
+
+const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DATABASE_HOST || 'localhost',
+  port: parseInt(process.env.DATABASE_PORT || '5432', 10),
+  username: process.env.DATABASE_USER || 'postgres',
+  password: process.env.DATABASE_PASSWORD || 'password',
+  database: process.env.DATABASE_NAME || 'stellarswipe',
+  entities: ['src/**/*.entity{.ts,.js}'],
+  migrations: ['src/database/migrations/*{.ts,.js}'],
+  ssl:
+    process.env.NODE_ENV === 'production'
+      ? { rejectUnauthorized: false }
+      : undefined,
+});
+
+async function main() {
+  await AppDataSource.initialize();
+  try {
+    await runSeeders(AppDataSource, [new InitialRolesSeed()]);
+    console.log('✅  All seeds completed successfully');
+  } finally {
+    await AppDataSource.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error('❌  Seed failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
…S auth

closes #643 — Automated DB migration & seed management
- Add src/database/seeds/ with seed.runner.ts, initial-roles.seed.ts, seed.ts
- Add migration 1750000000000-AddRefreshTokens (reversible up/down)
- Add npm scripts: seed, migration:ci
- Update CI workflow to run migration up/down/re-up + seed steps
- Document rollback instructions in migrations/README.md

closes #644 — Refresh-token rotation & device revocation
- Add sid (session ID) to JwtPayload interface
- Update JwtStrategy to reject revoked sessions via SessionManagerService
- Register WsJwtAuthGuard in AuthModule (providers + exports)
- Add session-manager.service.spec.ts covering: token rotation, single-use enforcement, invalid token rejection, logout, logout-all

closes #646 — WebSocket authentication & reconnection handling
- Add WsJwtAuthGuard: validates Bearer token from socket handshake, checks session liveness, attaches user to socket
- Add AuthenticatedGateway base class: authenticates on connect, logs connect/disconnect, auto-disconnects unauthorized clients
- Upgrade DashboardGateway to extend AuthenticatedGateway
- Add authenticated.gateway.spec.ts: authorized + unauthorized access tests