### PR TITLE
feat(jobs): wire dead-letter handling and add analytics-reports queue

### DIFF
--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
+import { BullModule } from '@nestjs/bull';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from './analytics.service';
 import { UserEvent } from './entities/user-event.entity';
@@ -44,6 +45,12 @@ import { UserPreference } from '../users/entities/user-preference.entity';
 import { DriftDetectorService } from './drift-detection/drift-detector.service';
 import { DetectDataDriftJob } from './drift-detection/jobs/detect-data-drift.job';
 import { DriftFinding } from './drift-detection/entities/drift-finding.entity';
+import { AnalyticsReportsController } from './reports/analytics-reports.controller';
+import {
+  AnalyticsReportsService,
+  ANALYTICS_REPORTS_QUEUE,
+} from './reports/analytics-reports.service';
+import { AnalyticsReportsProcessor } from './reports/analytics-reports.processor';
 
 @Module({
   imports: [
@@ -71,6 +78,7 @@ import { DriftFinding } from './drift-detection/entities/drift-finding.entity';
     ScheduleModule.forRoot(),
     TradePatternsModule,
     JobsModule,
+    BullModule.registerQueue({ name: ANALYTICS_REPORTS_QUEUE }),
   ],
   controllers: [
     AnalyticsController,
@@ -79,6 +87,7 @@ import { DriftFinding } from './drift-detection/entities/drift-finding.entity';
     FunnelController,
     CohortController,
     BehaviorTrackingController,
+    AnalyticsReportsController,
   ],
   providers: [
     AnalyticsService,
@@ -97,6 +106,8 @@ import { DriftFinding } from './drift-detection/entities/drift-finding.entity';
     BehaviorTrackingService,
     DriftDetectorService,
     DetectDataDriftJob,
+    AnalyticsReportsService,
+    AnalyticsReportsProcessor,
   ],
   exports: [
     AnalyticsService,

--- a/src/analytics/reports/analytics-reports.controller.spec.ts
+++ b/src/analytics/reports/analytics-reports.controller.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { AnalyticsReportsController } from './analytics-reports.controller';
+import { AnalyticsReportsService } from './analytics-reports.service';
+import { MetricPeriod } from '../entities/metric-snapshot.entity';
+
+const mockAnalyticsReportsService = {
+  enqueueExport: jest.fn(),
+  getJobStatus: jest.fn(),
+};
+
+describe('AnalyticsReportsController', () => {
+  let controller: AnalyticsReportsController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyticsReportsController],
+      providers: [{ provide: AnalyticsReportsService, useValue: mockAnalyticsReportsService }],
+    })
+      .overrideGuard(require('../../auth/guards/jwt-auth.guard').JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(AnalyticsReportsController);
+  });
+
+  describe('queueExport', () => {
+    it('queues the export and returns the job id', async () => {
+      mockAnalyticsReportsService.enqueueExport.mockResolvedValue({ jobId: 'job-1' });
+
+      const result = await controller.queueExport({
+        period: MetricPeriod.DAILY,
+        startDate: '2024-01-01T00:00:00.000Z',
+        endDate: '2024-01-31T00:00:00.000Z',
+        timezone: 'UTC',
+      });
+
+      expect(result).toEqual({ jobId: 'job-1' });
+      expect(mockAnalyticsReportsService.enqueueExport).toHaveBeenCalledWith({
+        period: MetricPeriod.DAILY,
+        startDate: '2024-01-01T00:00:00.000Z',
+        endDate: '2024-01-31T00:00:00.000Z',
+        timezone: 'UTC',
+      });
+    });
+
+    it('defaults period to DAILY and timezone to UTC when omitted', async () => {
+      mockAnalyticsReportsService.enqueueExport.mockResolvedValue({ jobId: 'job-2' });
+
+      await controller.queueExport({
+        startDate: '2024-01-01T00:00:00.000Z',
+        endDate: '2024-01-31T00:00:00.000Z',
+      } as any);
+
+      expect(mockAnalyticsReportsService.enqueueExport).toHaveBeenCalledWith(
+        expect.objectContaining({ period: MetricPeriod.DAILY, timezone: 'UTC' }),
+      );
+    });
+
+    it('rejects an invalid date range', async () => {
+      await expect(
+        controller.queueExport({
+          startDate: '2024-02-01T00:00:00.000Z',
+          endDate: '2024-01-01T00:00:00.000Z',
+        } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockAnalyticsReportsService.enqueueExport).not.toHaveBeenCalled();
+    });
+
+    it('rejects unparsable dates', async () => {
+      await expect(
+        controller.queueExport({ startDate: 'not-a-date', endDate: '2024-01-31T00:00:00.000Z' } as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('delegates to the service', async () => {
+      const status = { jobId: 'job-1', state: 'completed', attemptsMade: 1, result: 'csv-data' };
+      mockAnalyticsReportsService.getJobStatus.mockResolvedValue(status);
+
+      const result = await controller.getStatus('job-1');
+
+      expect(result).toEqual(status);
+      expect(mockAnalyticsReportsService.getJobStatus).toHaveBeenCalledWith('job-1');
+    });
+  });
+});

--- a/src/analytics/reports/analytics-reports.controller.ts
+++ b/src/analytics/reports/analytics-reports.controller.ts
@@ -1,0 +1,63 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { AnalyticsReportsService } from './analytics-reports.service';
+import { AnalyticsQueryDto } from '../dto/analytics-query.dto';
+import { MetricPeriod } from '../entities/metric-snapshot.entity';
+
+@ApiTags('analytics')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('analytics/reports')
+export class AnalyticsReportsController {
+  constructor(private readonly analyticsReportsService: AnalyticsReportsService) {}
+
+  /**
+   * POST /analytics/reports
+   * Queue a CSV analytics export instead of generating it on the request
+   * thread. Returns immediately with a job id — poll GET /analytics/reports/:jobId.
+   */
+  @Post()
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Queue an analytics CSV export job' })
+  async queueExport(@Body() query: AnalyticsQueryDto): Promise<{ jobId: string }> {
+    const startDate = new Date(query.startDate);
+    const endDate = new Date(query.endDate);
+
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      throw new BadRequestException('startDate and endDate must be valid ISO dates');
+    }
+
+    if (startDate >= endDate) {
+      throw new BadRequestException('startDate must be before endDate');
+    }
+
+    return this.analyticsReportsService.enqueueExport({
+      period: query.period ?? MetricPeriod.DAILY,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      timezone: query.timezone ?? 'UTC',
+    });
+  }
+
+  /**
+   * GET /analytics/reports/:jobId
+   * Status of a queued export job. `result` (the CSV body) is present once
+   * `state` is `completed`.
+   */
+  @Get(':jobId')
+  @ApiOperation({ summary: 'Get the status (and result) of a queued analytics export job' })
+  async getStatus(@Param('jobId') jobId: string) {
+    return this.analyticsReportsService.getJobStatus(jobId);
+  }
+}

--- a/src/analytics/reports/analytics-reports.processor.spec.ts
+++ b/src/analytics/reports/analytics-reports.processor.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsReportsProcessor } from './analytics-reports.processor';
+import { AnalyticsService } from '../analytics.service';
+import { DeadLetterService } from '../../jobs/dead-letter.service';
+import { MetricPeriod } from '../entities/metric-snapshot.entity';
+
+const makeJob = (overrides: Partial<{ data: unknown; attemptsMade: number; opts: { attempts?: number } }> = {}) => ({
+  id: 'job-1',
+  data:
+    overrides.data ?? {
+      period: MetricPeriod.DAILY,
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: '2024-01-31T00:00:00.000Z',
+      timezone: 'UTC',
+    },
+  attemptsMade: overrides.attemptsMade ?? 1,
+  opts: overrides.opts ?? { attempts: 3 },
+});
+
+describe('AnalyticsReportsProcessor', () => {
+  let processor: AnalyticsReportsProcessor;
+  let analyticsService: any;
+  let deadLetterService: any;
+
+  beforeEach(async () => {
+    analyticsService = {
+      exportMetrics: jest.fn().mockResolvedValue('period,active_users\ndaily,10\n'),
+    };
+    deadLetterService = {
+      capture: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsReportsProcessor,
+        { provide: AnalyticsService, useValue: analyticsService },
+        { provide: DeadLetterService, useValue: deadLetterService },
+      ],
+    }).compile();
+
+    processor = module.get(AnalyticsReportsProcessor);
+    jest.spyOn((processor as any).logger, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('handleGenerateExport', () => {
+    it('delegates to AnalyticsService.exportMetrics with parsed dates and returns the CSV', async () => {
+      const result = await processor.handleGenerateExport(makeJob() as any);
+
+      expect(analyticsService.exportMetrics).toHaveBeenCalledWith({
+        period: MetricPeriod.DAILY,
+        startDate: new Date('2024-01-01T00:00:00.000Z'),
+        endDate: new Date('2024-01-31T00:00:00.000Z'),
+        timezone: 'UTC',
+      });
+      expect(result).toBe('period,active_users\ndaily,10\n');
+    });
+  });
+
+  describe('onFailed', () => {
+    it('captures to the dead-letter queue once retry attempts are exhausted', async () => {
+      const job = makeJob({ attemptsMade: 3, opts: { attempts: 3 } });
+      await processor.onFailed(job as any, new Error('query timeout'));
+
+      expect(deadLetterService.capture).toHaveBeenCalledWith(job, expect.any(Error));
+    });
+
+    it('does not capture to the dead-letter queue while retries remain', async () => {
+      const job = makeJob({ attemptsMade: 1, opts: { attempts: 3 } });
+      await processor.onFailed(job as any, new Error('transient'));
+
+      expect(deadLetterService.capture).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/analytics/reports/analytics-reports.processor.ts
+++ b/src/analytics/reports/analytics-reports.processor.ts
@@ -1,0 +1,41 @@
+import { Processor, Process, OnQueueFailed } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { AnalyticsService } from '../analytics.service';
+import { DeadLetterService } from '../../jobs/dead-letter.service';
+import {
+  ANALYTICS_REPORTS_QUEUE,
+  GENERATE_EXPORT_JOB,
+  AnalyticsExportJobData,
+} from './analytics-reports.service';
+
+@Processor(ANALYTICS_REPORTS_QUEUE)
+export class AnalyticsReportsProcessor {
+  private readonly logger = new Logger(AnalyticsReportsProcessor.name);
+
+  constructor(
+    private readonly analyticsService: AnalyticsService,
+    private readonly deadLetterService: DeadLetterService,
+  ) {}
+
+  @Process(GENERATE_EXPORT_JOB)
+  async handleGenerateExport(job: Job<AnalyticsExportJobData>): Promise<string> {
+    const { period, startDate, endDate, timezone } = job.data;
+    this.logger.log(`Generating analytics export (job ${job.id}) for period=${period}`);
+
+    return this.analyticsService.exportMetrics({
+      period,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
+      timezone,
+    });
+  }
+
+  @OnQueueFailed()
+  async onFailed(job: Job, error: Error): Promise<void> {
+    const attempts = job.opts.attempts ?? 1;
+    if (job.attemptsMade >= attempts) {
+      await this.deadLetterService.capture(job, error);
+    }
+  }
+}

--- a/src/analytics/reports/analytics-reports.service.spec.ts
+++ b/src/analytics/reports/analytics-reports.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
+import { NotFoundException } from '@nestjs/common';
+import { AnalyticsReportsService, ANALYTICS_REPORTS_QUEUE, GENERATE_EXPORT_JOB } from './analytics-reports.service';
+import { MetricPeriod } from '../entities/metric-snapshot.entity';
+
+describe('AnalyticsReportsService', () => {
+  let service: AnalyticsReportsService;
+  let queue: any;
+
+  beforeEach(async () => {
+    queue = {
+      add: jest.fn(),
+      getJob: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsReportsService,
+        { provide: getQueueToken(ANALYTICS_REPORTS_QUEUE), useValue: queue },
+      ],
+    }).compile();
+
+    service = module.get(AnalyticsReportsService);
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('enqueueExport', () => {
+    it('adds a job with retry/backoff options and returns its id', async () => {
+      queue.add.mockResolvedValue({ id: 'job-42' });
+
+      const result = await service.enqueueExport({
+        period: MetricPeriod.DAILY,
+        startDate: '2024-01-01T00:00:00.000Z',
+        endDate: '2024-01-31T00:00:00.000Z',
+        timezone: 'UTC',
+      });
+
+      expect(result).toEqual({ jobId: 'job-42' });
+      expect(queue.add).toHaveBeenCalledWith(
+        GENERATE_EXPORT_JOB,
+        expect.objectContaining({ period: MetricPeriod.DAILY }),
+        expect.objectContaining({ attempts: 3, backoff: { type: 'exponential', delay: 5_000 } }),
+      );
+    });
+  });
+
+  describe('getJobStatus', () => {
+    it('throws NotFoundException when the job does not exist', async () => {
+      queue.getJob.mockResolvedValue(null);
+      await expect(service.getJobStatus('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('maps a completed job to state=completed with its result', async () => {
+      queue.getJob.mockResolvedValue({
+        id: 'job-42',
+        attemptsMade: 1,
+        failedReason: undefined,
+        returnvalue: 'period,active_users\ndaily,10\n',
+        getState: jest.fn().mockResolvedValue('completed'),
+      });
+
+      const result = await service.getJobStatus('job-42');
+
+      expect(result).toEqual({
+        jobId: 'job-42',
+        state: 'completed',
+        attemptsMade: 1,
+        failedReason: undefined,
+        result: 'period,active_users\ndaily,10\n',
+      });
+    });
+
+    it('maps a failed job to state=failed without a result', async () => {
+      queue.getJob.mockResolvedValue({
+        id: 'job-42',
+        attemptsMade: 3,
+        failedReason: 'DB timeout',
+        returnvalue: undefined,
+        getState: jest.fn().mockResolvedValue('failed'),
+      });
+
+      const result = await service.getJobStatus('job-42');
+
+      expect(result.state).toBe('failed');
+      expect(result.failedReason).toBe('DB timeout');
+      expect(result.result).toBeUndefined();
+    });
+
+    it.each([
+      ['waiting', 'queued'],
+      ['paused', 'queued'],
+      ['active', 'active'],
+      ['delayed', 'delayed'],
+    ])('maps bull state "%s" to "%s"', async (bullState, expected) => {
+      queue.getJob.mockResolvedValue({
+        id: 'job-1',
+        attemptsMade: 0,
+        getState: jest.fn().mockResolvedValue(bullState),
+      });
+
+      const result = await service.getJobStatus('job-1');
+      expect(result.state).toBe(expected);
+    });
+  });
+});

--- a/src/analytics/reports/analytics-reports.service.ts
+++ b/src/analytics/reports/analytics-reports.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { MetricPeriod } from '../entities/metric-snapshot.entity';
+
+export const ANALYTICS_REPORTS_QUEUE = 'analytics-reports';
+export const GENERATE_EXPORT_JOB = 'generate-export';
+
+export interface AnalyticsExportJobData {
+  period: MetricPeriod;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+}
+
+export type AnalyticsReportJobState =
+  | 'queued'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'delayed'
+  | 'unknown';
+
+export interface AnalyticsReportStatus {
+  jobId: string;
+  state: AnalyticsReportJobState;
+  attemptsMade: number;
+  failedReason?: string;
+  result?: string;
+}
+
+/**
+ * Moves heavy analytics CSV export generation (`AnalyticsService.exportMetrics`)
+ * out of the request thread. The report content itself is returned as the
+ * Bull job's `returnvalue` rather than persisted, so status/result tracking
+ * is backed entirely by the queue — no extra entity/migration needed.
+ */
+@Injectable()
+export class AnalyticsReportsService {
+  private readonly logger = new Logger(AnalyticsReportsService.name);
+
+  constructor(
+    @InjectQueue(ANALYTICS_REPORTS_QUEUE)
+    private readonly queue: Queue<AnalyticsExportJobData>,
+  ) {}
+
+  async enqueueExport(params: AnalyticsExportJobData): Promise<{ jobId: string }> {
+    const job = await this.queue.add(GENERATE_EXPORT_JOB, params, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5_000 },
+      removeOnComplete: 20,
+      removeOnFail: 10,
+    });
+
+    this.logger.log(`Analytics export job ${job.id} queued for period=${params.period}`);
+    return { jobId: String(job.id) };
+  }
+
+  async getJobStatus(jobId: string): Promise<AnalyticsReportStatus> {
+    const job = await this.queue.getJob(jobId);
+    if (!job) {
+      throw new NotFoundException(`Analytics report job ${jobId} not found`);
+    }
+
+    const bullState = await job.getState();
+    const state = this.mapState(bullState);
+
+    return {
+      jobId: String(job.id),
+      state,
+      attemptsMade: job.attemptsMade,
+      failedReason: job.failedReason,
+      result: state === 'completed' ? (job.returnvalue as string) : undefined,
+    };
+  }
+
+  private mapState(bullState: string): AnalyticsReportJobState {
+    switch (bullState) {
+      case 'waiting':
+      case 'paused':
+        return 'queued';
+      case 'active':
+        return 'active';
+      case 'completed':
+        return 'completed';
+      case 'failed':
+        return 'failed';
+      case 'delayed':
+        return 'delayed';
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/src/exports/export.processor.spec.ts
+++ b/src/exports/export.processor.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ExportProcessor } from './export.processor';
+import { ExportsService } from './exports.service';
+import { BulkExport, ExportFormat, ExportType } from './entities/bulk-export.entity';
+import { DeadLetterService } from '../jobs/dead-letter.service';
+
+const makeJob = (overrides: Partial<{ data: unknown; attemptsMade: number; opts: { attempts?: number } }> = {}) => ({
+  id: 'job-1',
+  data: overrides.data ?? { exportId: 'exp-1' },
+  attemptsMade: overrides.attemptsMade ?? 1,
+  opts: overrides.opts ?? { attempts: 3 },
+});
+
+describe('ExportProcessor', () => {
+  let processor: ExportProcessor;
+  let exportsService: any;
+  let exportRepo: any;
+  let deadLetterService: any;
+
+  beforeEach(async () => {
+    exportsService = {
+      markProcessing: jest.fn().mockResolvedValue(undefined),
+      markCompleted: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+    };
+    exportRepo = {
+      findOne: jest.fn(),
+    };
+    deadLetterService = {
+      capture: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExportProcessor,
+        { provide: ExportsService, useValue: exportsService },
+        { provide: getRepositoryToken(BulkExport), useValue: exportRepo },
+        { provide: DeadLetterService, useValue: deadLetterService },
+      ],
+    }).compile();
+
+    processor = module.get(ExportProcessor);
+    jest.spyOn((processor as any).logger, 'log').mockImplementation(() => {});
+    jest.spyOn((processor as any).logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('handleExport', () => {
+    it('marks processing then completed with the generated row count', async () => {
+      exportRepo.findOne.mockResolvedValue({
+        id: 'exp-1',
+        type: ExportType.TRANSACTIONS,
+        format: ExportFormat.CSV,
+        filters: {},
+      });
+
+      await processor.handleExport(makeJob() as any);
+
+      expect(exportsService.markProcessing).toHaveBeenCalledWith('exp-1');
+      expect(exportsService.markCompleted).toHaveBeenCalledWith('exp-1', 500);
+    });
+
+    it('marks failed and rethrows when the export record is missing', async () => {
+      exportRepo.findOne.mockResolvedValue(null);
+
+      await expect(processor.handleExport(makeJob() as any)).rejects.toThrow('Export exp-1 not found');
+      expect(exportsService.markFailed).toHaveBeenCalledWith('exp-1', 'Export exp-1 not found');
+    });
+  });
+
+  describe('onFailed', () => {
+    it('captures to the dead-letter queue once retry attempts are exhausted', async () => {
+      const job = makeJob({ attemptsMade: 3, opts: { attempts: 3 } });
+      await processor.onFailed(job as any, new Error('disk full'));
+
+      expect(deadLetterService.capture).toHaveBeenCalledWith(job, expect.any(Error));
+    });
+
+    it('does not capture to the dead-letter queue while retries remain', async () => {
+      const job = makeJob({ attemptsMade: 1, opts: { attempts: 3 } });
+      await processor.onFailed(job as any, new Error('transient'));
+
+      expect(deadLetterService.capture).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/exports/export.processor.ts
+++ b/src/exports/export.processor.ts
@@ -1,10 +1,11 @@
-import { Processor, Process } from '@nestjs/bull';
+import { Processor, Process, OnQueueFailed } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { BulkExport, ExportFormat, ExportType } from './entities/bulk-export.entity';
 import { ExportsService, EXPORT_JOB, EXPORT_QUEUE } from './exports.service';
+import { DeadLetterService } from '../jobs/dead-letter.service';
 
 interface ExportJobData {
   exportId: string;
@@ -18,6 +19,7 @@ export class ExportProcessor {
     private readonly exportsService: ExportsService,
     @InjectRepository(BulkExport)
     private readonly exportRepo: Repository<BulkExport>,
+    private readonly deadLetterService: DeadLetterService,
   ) {}
 
   @Process(EXPORT_JOB)
@@ -62,8 +64,17 @@ export class ExportProcessor {
       [ExportType.CONTEST_RESULTS]: 100,
       [ExportType.SIGNALS]: 250,
       [ExportType.PORTFOLIO]: 50,
+      [ExportType.TAX_REPORT]: 365,
     };
 
     return rowCounts[type] ?? 0;
+  }
+
+  @OnQueueFailed()
+  async onFailed(job: Job, error: Error): Promise<void> {
+    const attempts = job.opts.attempts ?? 1;
+    if (job.attemptsMade >= attempts) {
+      await this.deadLetterService.capture(job, error);
+    }
   }
 }

--- a/src/exports/exports.module.ts
+++ b/src/exports/exports.module.ts
@@ -5,11 +5,13 @@ import { BulkExport } from './entities/bulk-export.entity';
 import { ExportsService, EXPORT_QUEUE } from './exports.service';
 import { ExportsController } from './exports.controller';
 import { ExportProcessor } from './export.processor';
+import { JobsModule } from '../jobs/jobs.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([BulkExport]),
     BullModule.registerQueue({ name: EXPORT_QUEUE }),
+    JobsModule,
   ],
   controllers: [ExportsController],
   providers: [ExportsService, ExportProcessor],

--- a/src/notifications/notification.processor.spec.ts
+++ b/src/notifications/notification.processor.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotificationProcessor } from './notification.processor';
+import { Notification, NotificationStatus } from './entities/notification.entity';
+import { DeadLetterService } from '../jobs/dead-letter.service';
+
+const makeJob = (overrides: Partial<{ data: unknown; attemptsMade: number; opts: { attempts?: number } }> = {}) => ({
+  id: 'job-1',
+  data: overrides.data ?? { notificationId: 'notif-1' },
+  attemptsMade: overrides.attemptsMade ?? 1,
+  opts: overrides.opts ?? { attempts: 3 },
+});
+
+describe('NotificationProcessor', () => {
+  let processor: NotificationProcessor;
+  let notificationRepository: any;
+  let deadLetterService: any;
+
+  beforeEach(async () => {
+    notificationRepository = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+    deadLetterService = {
+      capture: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationProcessor,
+        { provide: getRepositoryToken(Notification), useValue: notificationRepository },
+        { provide: DeadLetterService, useValue: deadLetterService },
+      ],
+    }).compile();
+
+    processor = module.get(NotificationProcessor);
+    jest.spyOn((processor as any).logger, 'log').mockImplementation(() => {});
+    jest.spyOn((processor as any).logger, 'warn').mockImplementation(() => {});
+    jest.spyOn((processor as any).logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('handleDeliver', () => {
+    it('marks notification as SENT on successful delivery', async () => {
+      const notification = { id: 'notif-1', channel: 'in_app', userId: 'u1', status: NotificationStatus.PENDING };
+      notificationRepository.findOne.mockResolvedValue(notification);
+      notificationRepository.save.mockResolvedValue(notification);
+
+      await processor.handleDeliver(makeJob() as any);
+
+      expect(notification.status).toBe(NotificationStatus.SENT);
+      expect(notificationRepository.save).toHaveBeenCalledWith(notification);
+    });
+
+    it('does nothing when the notification record is missing', async () => {
+      notificationRepository.findOne.mockResolvedValue(null);
+
+      await processor.handleDeliver(makeJob() as any);
+
+      expect(notificationRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('marks notification FAILED and rethrows so Bull can retry', async () => {
+      const notification = { id: 'notif-1', channel: 'in_app', userId: 'u1', status: NotificationStatus.PENDING };
+      notificationRepository.findOne.mockResolvedValue(notification);
+      notificationRepository.save
+        .mockRejectedValueOnce(new Error('db down'))
+        .mockResolvedValueOnce(notification);
+
+      await expect(processor.handleDeliver(makeJob() as any)).rejects.toThrow('db down');
+      expect(notification.status).toBe(NotificationStatus.FAILED);
+    });
+  });
+
+  describe('onFailed', () => {
+    it('captures to the dead-letter queue once retry attempts are exhausted', async () => {
+      const job = makeJob({ attemptsMade: 3, opts: { attempts: 3 } });
+      await processor.onFailed(job as any, new Error('smtp unreachable'));
+
+      expect(deadLetterService.capture).toHaveBeenCalledWith(job, expect.any(Error));
+    });
+
+    it('does not capture to the dead-letter queue while retries remain', async () => {
+      const job = makeJob({ attemptsMade: 1, opts: { attempts: 3 } });
+      await processor.onFailed(job as any, new Error('transient'));
+
+      expect(deadLetterService.capture).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/notifications/notification.processor.ts
+++ b/src/notifications/notification.processor.ts
@@ -1,10 +1,11 @@
-import { Processor, Process } from '@nestjs/bull';
+import { Processor, Process, OnQueueFailed } from '@nestjs/bull';
 import { Job } from 'bull';
 import { Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification, NotificationStatus } from './entities/notification.entity';
 import { NOTIFICATION_QUEUE } from './notification.service';
+import { DeadLetterService } from '../jobs/dead-letter.service';
 
 @Processor(NOTIFICATION_QUEUE)
 export class NotificationProcessor {
@@ -13,6 +14,7 @@ export class NotificationProcessor {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,
+    private readonly deadLetterService: DeadLetterService,
   ) {}
 
   @Process('deliver')
@@ -38,6 +40,14 @@ export class NotificationProcessor {
       notification.status = NotificationStatus.FAILED;
       await this.notificationRepository.save(notification);
       throw error; // triggers Bull retry
+    }
+  }
+
+  @OnQueueFailed()
+  async onFailed(job: Job, error: Error): Promise<void> {
+    const attempts = job.opts.attempts ?? 1;
+    if (job.attemptsMade >= attempts) {
+      await this.deadLetterService.capture(job, error);
     }
   }
 }

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -13,11 +13,13 @@ import { NotificationsService } from './notifications.service';
 import { NotificationController } from './notification.controller';
 import { NotificationProcessor } from './notification.processor';
 import { NotificationTemplateService } from './notification-template.service';
+import { JobsModule } from '../jobs/jobs.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Notification, NotificationPreference, NotificationTemplate]),
     BullModule.registerQueue({ name: NOTIFICATION_QUEUE }),
+    JobsModule,
   ],
   controllers: [NotificationController, PreferencesController, PreferenceController],
   providers: [NotificationService, NotificationsService, PreferencesService, NotificationPreferencesService, NotificationProcessor, NotificationTemplateService],


### PR DESCRIPTION
## Summary

Closes the remaining gaps against the acceptance criteria for #642 — the repo already had two Bull queues (`notifications`, `bulk-exports`) with retries and status tracking, and a worker health check for queue processing already exists upstream (`QueueHealthIndicator`). This PR:

- **Wires dead-letter handling**: `NotificationProcessor` and `ExportProcessor` now have `@OnQueueFailed` hooks that capture jobs into the existing `DeadLetterService` (#368) once retry attempts are exhausted. Previously, exhausted jobs were just logged and dropped.
- **Adds a third queue, `analytics-reports`**, to move the heavy CSV analytics export off the request thread — `GET /analytics/export` was generating the report synchronously in the controller. `POST /analytics/reports` now returns a job id immediately (202 Accepted); `GET /analytics/reports/:jobId` polls status and result via Bull's native job state (no new entity/migration needed — the CSV is returned as the job's `returnvalue`).
- Fixes a pre-existing compile error in `export.processor.ts` (`Record<ExportType, number>` was missing the `TAX_REPORT` case, added by an earlier PR) that was blocking type-checking of the file I needed to modify.

## Acceptance criteria

- [x] At least two queues configured for async tasks — now three: `notifications`, `bulk-exports`, `analytics-reports`
- [x] Jobs include retries, dead-letter handling, and status tracking
- [x] A worker health check is available for queue processing (pre-existing `QueueHealthIndicator` / `GET /health/queue`, left untouched)
- [x] The API returns job IDs for long-running tasks (`POST /analytics/reports` → `{ jobId }`; notifications/exports already returned entity ids usable the same way)

## Test plan

- [x] 5 new spec files / 25 new tests, all passing (`notification.processor.spec.ts`, `export.processor.spec.ts`, `analytics-reports.service.spec.ts`, `analytics-reports.processor.spec.ts`, `analytics-reports.controller.spec.ts`)
- [x] `tsc --noEmit` diffed against a clean `main` baseline — zero new type errors introduced (confirmed several pre-existing unrelated errors elsewhere in the repo are unchanged)
- [x] `eslint` diffed against a clean `main` baseline — zero new lint errors introduced
- [x] Ran the full `notifications`, `exports`, `analytics`, and `jobs` test directories — all pre-existing failures verified via `git stash` to predate this change and be unrelated (broken template literals in `notifications.service.ts`, a `cron` typing issue in `job-scheduler.service.ts`, an orphaned/unregistered duplicate processor file)

Fixes #642