### PR TITLE
feat(observability): implement request correlation IDs for API observability

### DIFF
--- a/src/audit-log/audit-logging.interceptor.ts
+++ b/src/audit-log/audit-logging.interceptor.ts
@@ -12,6 +12,7 @@ import { Request } from 'express';
 import { AuditService } from '../audit.service';
 import { AuditAction, AuditStatus } from '../entities/audit-log.entity';
 import { CreateAuditLogDto } from '../dto/audit-query.dto';
+import { CORRELATION_ID_HEADER } from '../common/correlation/correlation-id.store';
 
 export const AUDIT_ACTION_KEY = 'auditAction';
 export const AUDIT_RESOURCE_KEY = 'auditResource';
@@ -71,7 +72,7 @@ export class AuditLoggingInterceptor implements NestInterceptor {
       ipAddress: this.extractIp(request),
       userAgent: request.headers['user-agent'],
       sessionId: (request as any).sessionID,
-      requestId: request.headers['x-request-id'] as string,
+      requestId: request.headers[CORRELATION_ID_HEADER] as string,
       metadata: options.getMetadata?.(request) ?? this.buildDefaultMetadata(request),
     };
 

--- a/src/audit-log/interceptors/audit-logging.interceptor.ts
+++ b/src/audit-log/interceptors/audit-logging.interceptor.ts
@@ -12,6 +12,7 @@ import { Request } from 'express';
 import { AuditService } from '../audit.service';
 import { AuditAction, AuditStatus } from '../entities/audit-log.entity';
 import { CreateAuditLogDto } from '../dto/audit-query.dto';
+import { CORRELATION_ID_HEADER } from '../../common/correlation/correlation-id.store';
 
 export const AUDIT_ACTION_KEY = 'auditAction';
 
@@ -65,7 +66,7 @@ export class AuditLoggingInterceptor implements NestInterceptor {
       ipAddress: this.extractIp(request),
       userAgent: request.headers['user-agent'],
       sessionId: (request as any).sessionID,
-      requestId: request.headers['x-request-id'] as string,
+      requestId: request.headers[CORRELATION_ID_HEADER] as string,
       metadata: options.getMetadata?.(request) ?? this.defaultMetadata(request),
     };
 

--- a/src/documentation/generators/openapi-generator.ts
+++ b/src/documentation/generators/openapi-generator.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder, OpenAPIObject } from '@nestjs/swagger';
+import { CORRELATION_ID_HEADER } from '../../common/correlation/correlation-id.store';
 
 export interface OpenApiOutput {
   document: OpenAPIObject;
@@ -11,12 +12,33 @@ export function generateOpenApiDocument(app: INestApplication): OpenApiOutput {
   const config = new DocumentBuilder()
     .setTitle('StellarSwipe API')
     .setDescription(
-      'Copy trading DApp on Stellar blockchain. Follow top traders, automate trades, and manage your portfolio.',
+      `Copy trading DApp on Stellar blockchain. Follow top traders, automate trades, and manage your portfolio.
+
+## Request Correlation
+
+Every request is assigned a unique correlation ID for end-to-end traceability.
+
+- **Header**: \`${CORRELATION_ID_HEADER}\`
+- **Format**: UUID v4
+- **Client-supplied**: Clients may send their own UUID in this header; the API will echo it back and propagate it through all internal calls and logs. This allows you to correlate API responses with your own request logs.
+- **Server-generated**: If the header is absent the server generates a fresh UUID automatically.
+- **Response header**: The resolved correlation ID is always echoed back in the \`${CORRELATION_ID_HEADER}\` response header.
+- **Error responses**: All error payloads include the correlation ID as \`requestId\` for easy support lookups.`,
     )
     .setVersion('2.0')
     .addBearerAuth(
       { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
       'JWT',
+    )
+    .addApiKey(
+      {
+        type: 'apiKey',
+        in: 'header',
+        name: CORRELATION_ID_HEADER,
+        description:
+          'Optional client-supplied correlation ID (UUID v4). If omitted the server generates one. Always echoed back in the response header and included in all log entries and error payloads for this request.',
+      },
+      CORRELATION_ID_HEADER,
     )
     .addTag('Signals', 'Trading signals from providers')
     .addTag('Trades', 'Trade execution and management')


### PR DESCRIPTION
## Summary

- Fixes audit log `requestId` field to use the `x-correlation-id` correlation header (was incorrectly reading `x-request-id`, so audit records were never correlated to their originating request).
- Documents the `x-correlation-id` header in Swagger/OpenAPI: explains client-supplied vs server-generated semantics and registers it as a named security scheme so consumers can see and test it in Swagger UI.

The underlying correlation infrastructure (`CorrelationIdMiddleware`, `CorrelationIdStore`, `LoggingInterceptor`, `GlobalExceptionFilter`) was already complete — this PR wires the remaining gap in the audit trail and closes the documentation gap.

## Acceptance Criteria Checklist

- [x] Every request receives a unique correlation ID (from header or generated automatically) — *already done via `CorrelationIdMiddleware`*
- [x] Correlation ID is included in request logs and response headers — *already done via `LoggingInterceptor` + middleware*
- [x] Errors include the correlation ID (`requestId` field in `GlobalExceptionFilter`) — *already done*
- [x] **Audit logs include the correlation ID** — fixed in this PR (`x-request-id` → `x-correlation-id`)
- [x] **Documentation updated** — Swagger description and API key scheme added in this PR

## Test plan

- [x] `CorrelationIdMiddleware` unit tests pass (`correlation-id.middleware.spec.ts`)
- [x] `CorrelationIdStore` unit tests pass (`correlation-id.store.spec.ts`)
- [x] TypeScript compilation clean on changed files
- [ ] Integration: send a request with a custom `x-correlation-id` header and verify the same ID appears in the response header, the structured log output, and the audit log `request_id` column

Closes AgesEmpire/StellarSwipe-Backends#724

🤖 Generated with [Claude Code](https://claude.com/claude-code)