### PR TITLE
feat(webhooks): transactional reconciliation job for Stellar payment callbacks

### DIFF
--- a/src/webhooks/entities/webhook.entity.ts
+++ b/src/webhooks/entities/webhook.entity.ts
@@ -18,7 +18,16 @@ export const SUPPORTED_WEBHOOK_EVENTS = [
   'signal.performance.updated',
   'contest.updated',
   'payout.completed',
+  'payment.stellar.received',
+  'payment.stellar.sent',
+  'payment.stellar.failed',
 ] as const;
+
+export const STELLAR_PAYMENT_EVENTS = [
+  'payment.stellar.received',
+  'payment.stellar.sent',
+  'payment.stellar.failed',
+] as const satisfies ReadonlyArray<(typeof SUPPORTED_WEBHOOK_EVENTS)[number]>;
 
 export type WebhookEventType = (typeof SUPPORTED_WEBHOOK_EVENTS)[number];
 

--- a/src/webhooks/jobs/stellar-callback-reconciliation.job.spec.ts
+++ b/src/webhooks/jobs/stellar-callback-reconciliation.job.spec.ts
@@ -1,0 +1,165 @@
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  StellarCallbackReconciliationJob,
+  MAX_RECONCILE_ATTEMPTS,
+} from './stellar-callback-reconciliation.job';
+import { WebhookDelivery } from '../entities/webhook-delivery.entity';
+import { WebhookSenderService } from '../services/webhook-sender.service';
+
+const makeDelivery = (
+  overrides: Partial<WebhookDelivery> = {},
+): WebhookDelivery =>
+  ({
+    id: 'delivery-1',
+    eventId: 'evt-abc',
+    eventType: 'payment.stellar.received',
+    webhookId: 'wh-1',
+    status: 'failed' as const,
+    attempts: 1,
+    payload: { event: 'payment.stellar.received', deliveryId: 'evt-abc' },
+    createdAt: new Date(Date.now() - 20 * 60 * 1000),
+    nextRetryAt: new Date(Date.now() - 1000),
+    webhook: { id: 'wh-1', active: true } as any,
+    ...overrides,
+  }) as WebhookDelivery;
+
+describe('StellarCallbackReconciliationJob', () => {
+  let job: StellarCallbackReconciliationJob;
+  let deliveryRepo: jest.Mocked<any>;
+  let senderService: jest.Mocked<WebhookSenderService>;
+
+  beforeEach(async () => {
+    deliveryRepo = {
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+    };
+
+    senderService = {
+      retryInPlace: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarCallbackReconciliationJob,
+        { provide: getRepositoryToken(WebhookDelivery), useValue: deliveryRepo },
+        { provide: WebhookSenderService, useValue: senderService },
+      ],
+    }).compile();
+
+    job = module.get<StellarCallbackReconciliationJob>(
+      StellarCallbackReconciliationJob,
+    );
+
+    jest.spyOn((job as any).logger, 'log').mockImplementation(() => {});
+    jest.spyOn((job as any).logger, 'debug').mockImplementation(() => {});
+    jest.spyOn((job as any).logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  const mockQueryBuilder = (results: WebhookDelivery[]) => {
+    const qb: any = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(results),
+    };
+    deliveryRepo.createQueryBuilder.mockReturnValue(qb);
+    return qb;
+  };
+
+  it('does nothing when there are no candidates', async () => {
+    mockQueryBuilder([]);
+
+    await job.reconcile();
+
+    expect(senderService.retryInPlace).not.toHaveBeenCalled();
+  });
+
+  it('retries failed delivery via senderService', async () => {
+    const delivery = makeDelivery();
+    mockQueryBuilder([delivery]);
+    deliveryRepo.findOne.mockResolvedValue(null); // no prior success
+    senderService.retryInPlace.mockResolvedValue(true);
+
+    await job.reconcile();
+
+    expect(senderService.retryInPlace).toHaveBeenCalledWith(delivery);
+  });
+
+  it('skips delivery when same eventId already succeeded', async () => {
+    const delivery = makeDelivery();
+    const successDelivery = makeDelivery({ id: 'delivery-2', status: 'success' as const });
+    mockQueryBuilder([delivery]);
+    deliveryRepo.findOne.mockResolvedValue(successDelivery);
+    deliveryRepo.save.mockResolvedValue(undefined);
+
+    await job.reconcile();
+
+    expect(senderService.retryInPlace).not.toHaveBeenCalled();
+    expect(deliveryRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: expect.stringContaining('delivery-2'),
+      }),
+    );
+  });
+
+  it('processes multiple candidates independently', async () => {
+    const d1 = makeDelivery({ id: 'd1', eventId: 'evt-1' });
+    const d2 = makeDelivery({ id: 'd2', eventId: 'evt-2' });
+    mockQueryBuilder([d1, d2]);
+    deliveryRepo.findOne.mockResolvedValue(null);
+    senderService.retryInPlace
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await job.reconcile();
+
+    expect(senderService.retryInPlace).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues processing remaining candidates when one throws', async () => {
+    const d1 = makeDelivery({ id: 'd1', eventId: 'evt-1' });
+    const d2 = makeDelivery({ id: 'd2', eventId: 'evt-2' });
+    mockQueryBuilder([d1, d2]);
+    deliveryRepo.findOne.mockResolvedValue(null);
+    senderService.retryInPlace
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce(true);
+
+    await expect(job.reconcile()).resolves.not.toThrow();
+  });
+
+  it('does not retry a delivery that has reached MAX_RECONCILE_ATTEMPTS', async () => {
+    // The query builder filters by attempts < MAX_RECONCILE_ATTEMPTS, so a
+    // maxed-out delivery should never appear in the candidates list.
+    const exhausted = makeDelivery({ attempts: MAX_RECONCILE_ATTEMPTS });
+    // Only the not-exhausted delivery reaches the job.
+    mockQueryBuilder([]);
+
+    await job.reconcile();
+
+    expect(senderService.retryInPlace).not.toHaveBeenCalledWith(exhausted);
+  });
+
+  it('treats stale pending deliveries as candidates', async () => {
+    const stalePending = makeDelivery({
+      status: 'pending' as const,
+      attempts: 0,
+      createdAt: new Date(Date.now() - 15 * 60 * 1000), // 15 min old
+    });
+    mockQueryBuilder([stalePending]);
+    deliveryRepo.findOne.mockResolvedValue(null);
+    senderService.retryInPlace.mockResolvedValue(false);
+
+    await job.reconcile();
+
+    expect(senderService.retryInPlace).toHaveBeenCalledWith(stalePending);
+  });
+});

--- a/src/webhooks/jobs/stellar-callback-reconciliation.job.ts
+++ b/src/webhooks/jobs/stellar-callback-reconciliation.job.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan, LessThanOrEqual, IsNull, Or } from 'typeorm';
+import { WebhookDelivery } from '../entities/webhook-delivery.entity';
+import { WebhookSenderService } from '../services/webhook-sender.service';
+
+/** Maximum total delivery attempts before a record is abandoned by the reconciler. */
+export const MAX_RECONCILE_ATTEMPTS = 10;
+
+/** Deliveries stuck in 'pending' for longer than this are treated as stale. */
+const STALE_PENDING_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+
+/** Upper bound on records processed per reconciliation run to prevent runaway batches. */
+const BATCH_SIZE = 100;
+
+@Injectable()
+export class StellarCallbackReconciliationJob {
+  private readonly logger = new Logger(StellarCallbackReconciliationJob.name);
+
+  constructor(
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepo: Repository<WebhookDelivery>,
+    private readonly senderService: WebhookSenderService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async reconcile(): Promise<void> {
+    this.logger.log('Starting Stellar callback reconciliation run');
+    const now = new Date();
+
+    const candidates = await this.findCandidates(now);
+
+    if (candidates.length === 0) {
+      this.logger.debug('No failed or stale deliveries to reconcile');
+      return;
+    }
+
+    this.logger.log(
+      `Found ${candidates.length} delivery candidate(s) for reconciliation`,
+    );
+
+    let retried = 0;
+    let succeeded = 0;
+    let skipped = 0;
+
+    for (const delivery of candidates) {
+      // Idempotency guard: skip if another record for the same logical event already succeeded.
+      const alreadyDelivered = await this.deliveryRepo.findOne({
+        where: { eventId: delivery.eventId, status: 'success' },
+      });
+
+      if (alreadyDelivered) {
+        this.logger.log(
+          `Skipping duplicate: eventId=${delivery.eventId} already delivered as delivery=${alreadyDelivered.id}`,
+        );
+        delivery.errorMessage = `Superseded by successful delivery ${alreadyDelivered.id}`;
+        delivery.nextRetryAt = undefined;
+        await this.deliveryRepo.save(delivery);
+        skipped++;
+        continue;
+      }
+
+      retried++;
+      try {
+        const success = await this.senderService.retryInPlace(delivery);
+        if (success) succeeded++;
+      } catch (err) {
+        this.logger.warn(
+          `Unexpected error retrying delivery=${delivery.id}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Reconciliation complete — retried: ${retried}, succeeded: ${succeeded}, skipped (duplicate): ${skipped}, total candidates: ${candidates.length}`,
+    );
+  }
+
+  private async findCandidates(now: Date): Promise<WebhookDelivery[]> {
+    const staleThreshold = new Date(now.getTime() - STALE_PENDING_THRESHOLD_MS);
+
+    return this.deliveryRepo
+      .createQueryBuilder('d')
+      .leftJoinAndSelect('d.webhook', 'webhook')
+      .where(
+        `(
+          (d.status = 'failed'  AND d.attempts < :maxAttempts AND (d.next_retry_at IS NULL OR d.next_retry_at <= :now))
+          OR
+          (d.status = 'pending' AND d.created_at < :stale)
+        )`,
+        {
+          maxAttempts: MAX_RECONCILE_ATTEMPTS,
+          now,
+          stale: staleThreshold,
+        },
+      )
+      .andWhere('webhook.active = true')
+      .orderBy('d.created_at', 'ASC')
+      .take(BATCH_SIZE)
+      .getMany();
+  }
+}

--- a/src/webhooks/listeners/webhook-event.listener.ts
+++ b/src/webhooks/listeners/webhook-event.listener.ts
@@ -99,6 +99,46 @@ export class WebhookEventListener {
     });
   }
 
+  @OnEvent('payment.stellar.received', { async: true })
+  async onStellarPaymentReceived(event: Record<string, unknown>): Promise<void> {
+    await this.dispatch('payment.stellar.received', {
+      txHash: event['txHash'],
+      ledger: event['ledger'],
+      accountId: event['accountId'],
+      amount: event['amount'],
+      assetCode: event['assetCode'],
+      assetIssuer: event['assetIssuer'],
+      from: event['from'],
+      memo: event['memo'],
+    });
+  }
+
+  @OnEvent('payment.stellar.sent', { async: true })
+  async onStellarPaymentSent(event: Record<string, unknown>): Promise<void> {
+    await this.dispatch('payment.stellar.sent', {
+      txHash: event['txHash'],
+      ledger: event['ledger'],
+      accountId: event['accountId'],
+      amount: event['amount'],
+      assetCode: event['assetCode'],
+      assetIssuer: event['assetIssuer'],
+      to: event['to'],
+      memo: event['memo'],
+    });
+  }
+
+  @OnEvent('payment.stellar.failed', { async: true })
+  async onStellarPaymentFailed(event: Record<string, unknown>): Promise<void> {
+    await this.dispatch('payment.stellar.failed', {
+      txHash: event['txHash'],
+      ledger: event['ledger'],
+      accountId: event['accountId'],
+      amount: event['amount'],
+      assetCode: event['assetCode'],
+      reason: event['reason'],
+    });
+  }
+
   private async dispatch(
     eventName: string,
     data: Record<string, unknown>,

--- a/src/webhooks/services/webhook-sender.service.ts
+++ b/src/webhooks/services/webhook-sender.service.ts
@@ -130,6 +130,71 @@ export class WebhookSenderService {
     return updated as unknown as void;
   }
 
+  /**
+   * Performs a single HTTP delivery attempt on an EXISTING delivery record,
+   * updating it in-place. Used by the reconciliation job to avoid creating
+   * duplicate delivery records.
+   *
+   * Returns true if delivery succeeded, false otherwise.
+   */
+  async retryInPlace(delivery: WebhookDelivery): Promise<boolean> {
+    const webhook = delivery.webhook;
+    if (!webhook?.active) {
+      this.logger.warn(
+        `Skipping reconciliation retry — webhook inactive: delivery=${delivery.id} webhookId=${delivery.webhookId}`,
+      );
+      return false;
+    }
+
+    const payload = delivery.payload as unknown as WebhookPayload;
+    const signature = this.signatureGenerator.generateSignature(payload, webhook.secret);
+
+    delivery.attempts += 1;
+
+    try {
+      const response = await axios.post(webhook.url, payload, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-StellarSwipe-Signature': `sha256=${signature}`,
+          'X-StellarSwipe-Event': payload.event,
+          'X-StellarSwipe-Delivery-Id': payload.deliveryId,
+        },
+        timeout: REQUEST_TIMEOUT_MS,
+      });
+
+      delivery.status = 'success';
+      delivery.responseStatus = response.status;
+      delivery.responseBody = JSON.stringify(response.data).slice(0, 1000);
+      delivery.deliveredAt = new Date();
+      delivery.nextRetryAt = undefined;
+      delivery.errorMessage = undefined;
+      await this.deliveryRepo.save(delivery);
+
+      await this.webhookRepo.update(webhook.id, { consecutiveFailures: 0 });
+
+      this.logger.log(
+        `Reconciliation delivery succeeded: delivery=${delivery.id} event=${payload.event} attempt=${delivery.attempts}`,
+      );
+      return true;
+    } catch (err) {
+      const error = err as AxiosError;
+      const backoffMs = Math.pow(2, delivery.attempts) * 1000;
+
+      delivery.responseStatus = error.response?.status;
+      delivery.responseBody = error.response
+        ? JSON.stringify(error.response.data).slice(0, 1000)
+        : undefined;
+      delivery.errorMessage = error.message;
+      delivery.nextRetryAt = new Date(Date.now() + backoffMs);
+      await this.deliveryRepo.save(delivery);
+
+      this.logger.warn(
+        `Reconciliation delivery attempt ${delivery.attempts} failed: delivery=${delivery.id} event=${payload.event} error=${error.message} nextRetry=${delivery.nextRetryAt.toISOString()}`,
+      );
+      return false;
+    }
+  }
+
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { Webhook } from './entities/webhook.entity';
 import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhooksService } from './webhooks.service';
@@ -7,15 +8,20 @@ import { WebhooksController } from './webhooks.controller';
 import { SignatureGeneratorService } from './services/signature-generator.service';
 import { WebhookSenderService } from './services/webhook-sender.service';
 import { WebhookEventListener } from './listeners/webhook-event.listener';
+import { StellarCallbackReconciliationJob } from './jobs/stellar-callback-reconciliation.job';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Webhook, WebhookDelivery])],
+  imports: [
+    TypeOrmModule.forFeature([Webhook, WebhookDelivery]),
+    ScheduleModule.forRoot(),
+  ],
   controllers: [WebhooksController],
   providers: [
     WebhooksService,
     SignatureGeneratorService,
     WebhookSenderService,
     WebhookEventListener,
+    StellarCallbackReconciliationJob,
   ],
   exports: [WebhooksService],
 })


### PR DESCRIPTION
## Summary

- Adds `StellarCallbackReconciliationJob` — a `@Cron`-scheduled background job (every 5 min) that finds failed or stale webhook delivery records and retries them safely without duplicating records.
- Adds `retryInPlace()` to `WebhookSenderService` — performs a single HTTP attempt and updates the **existing** delivery row in-place, preventing duplicate records across reconciliation cycles.
- Adds three new Stellar payment webhook event types: `payment.stellar.received`, `payment.stellar.sent`, `payment.stellar.failed` with matching `@OnEvent` handlers in `WebhookEventListener`.

## How idempotency and deduplication work

| Mechanism | Detail |
|---|---|
| **eventId guard** | Before retrying, the job checks if a record with the same `eventId` already has `status = 'success'`. If yes, the failed record is marked as superseded and skipped. |
| **in-place update** | `retryInPlace()` mutates the existing `WebhookDelivery` row rather than calling `deliverWebhook()` which would create a new row. |
| **max attempts cap** | `MAX_RECONCILE_ATTEMPTS = 10`. The query filters `attempts < 10` so exhausted deliveries are never re-queued. |
| **exponential backoff** | `nextRetryAt = now + 2^attempts seconds`, so retries spread out as failures accumulate. |
| **stale-pending guard** | Deliveries stuck in `pending` for >10 min (e.g. process crash mid-delivery) are also surfaced as candidates. |

## Acceptance Criteria

- [x] Callback events are processed idempotently (`eventId` dedup guard)
- [x] Failed events are retried with exponential backoff (`2^attempts` seconds)
- [x] Duplicate transactions are detected and prevented (idempotency guard + `retryInPlace`)
- [x] The reconciliation job logs status and retry details (structured log after every run)

## Test plan

- [x] 7 unit tests for `StellarCallbackReconciliationJob` — all pass
- [x] 9 existing `WebhooksService` tests — all pass (no regressions)
- [x] TypeScript compilation clean on all changed files
- [ ] Integration: trigger a failed webhook delivery; verify the reconciliation job picks it up within 5 min and the delivery row is updated to `success` with no duplicate rows

Closes AgesEmpire/StellarSwipe-Backends#727

🤖 Generated with [Claude Code](https://claude.com/claude-code)