### PR TITLE
Implement session fingerprinting to flag anomalous login devices

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -21,6 +21,10 @@ import { AuthAuditService } from './auth-audit.service';
 import { AuditModule } from '../audit-log/audit.module';
 import { SessionManagerService } from './session/session-manager.service';
 import { SessionCleanupService } from './session/session-cleanup.service';
+import { SessionFingerprintService } from './session/session-fingerprint.service';
+import { LoginFingerprint } from './session/entities/login-fingerprint.entity';
+import { EmailModule } from '../email/email.module';
+import { AnomalousLoginListener } from './session/anomalous-login.listener';
 
 @Module({
   imports: [
@@ -37,7 +41,7 @@ import { SessionCleanupService } from './session/session-cleanup.service';
     }),
     CacheModule,
     AuditModule,
-    TypeOrmModule.forFeature([User, SocialConnection, TwoFactor]),
+    TypeOrmModule.forFeature([User, SocialConnection, TwoFactor, LoginFingerprint]),
     UsersModule,
     EmailModule,
   ],
@@ -52,6 +56,8 @@ import { SessionCleanupService } from './session/session-cleanup.service';
     AuthAuditService,
     SessionManagerService,
     SessionCleanupService,
+    SessionFingerprintService,
+    AnomalousLoginListener,
   ],
   exports: [
     AuthService,
@@ -61,6 +67,7 @@ import { SessionCleanupService } from './session/session-cleanup.service';
     TwoFactorService,
     AuthAuditService,
     SessionManagerService,
+    SessionFingerprintService,
   ],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -13,6 +13,7 @@ import { JwtPayload } from './interfaces/jwt-payload.interface';
 import { UsersService } from '../users/users.service';
 import { AuthAuditService } from './auth-audit.service';
 import { SessionManagerService } from './session/session-manager.service';
+import { SessionFingerprintService } from './session/session-fingerprint.service';
 import { Request } from 'express';
 
 @Injectable()
@@ -22,6 +23,7 @@ export class AuthService {
         private usersService: UsersService,
         private authAuditService: AuthAuditService,
         private sessionManager: SessionManagerService,
+        private sessionFingerprintService: SessionFingerprintService,
         @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) { }
 
@@ -78,6 +80,14 @@ export class AuthService {
         });
 
         if (req) await this.authAuditService.logLogin(user.id, req);
+
+        // 6. Fingerprint this login (IP + user-agent + accept-language) and
+        // flag/log if it doesn't match the user's recent login history.
+        await this.sessionFingerprintService.checkAndRecord(user.id, {
+            ipAddress: req?.ip,
+            userAgent: req?.headers?.['user-agent'] as string | undefined,
+            acceptLanguage: req?.headers?.['accept-language'] as string | undefined,
+        });
 
         return tokens;
     }

--- a/src/auth/session/anomalous-login.listener.spec.ts
+++ b/src/auth/session/anomalous-login.listener.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnomalousLoginListener } from './anomalous-login.listener';
+import { UsersService } from '../../users/users.service';
+import { EmailService } from '../../email/email.service';
+
+describe('AnomalousLoginListener (#683)', () => {
+  let listener: AnomalousLoginListener;
+
+  const usersServiceMock = {
+    findById: jest.fn(),
+  };
+  const emailServiceMock = {
+    sendEmail: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnomalousLoginListener,
+        { provide: UsersService, useValue: usersServiceMock },
+        { provide: EmailService, useValue: emailServiceMock },
+      ],
+    }).compile();
+
+    listener = module.get<AnomalousLoginListener>(AnomalousLoginListener);
+  });
+
+  it('sends a security-alert email when the user has an email on file', async () => {
+    usersServiceMock.findById.mockResolvedValue({ id: 'user-1', email: 'user@example.com' });
+
+    await listener.handleAnomalousLogin({
+      userId: 'user-1',
+      fingerprintHash: 'abc123',
+      ipAddress: '1.2.3.4',
+      userAgent: 'Chrome/100',
+      occurredAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(emailServiceMock.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@example.com',
+        template: 'security-alert',
+        variables: expect.objectContaining({ ipAddress: '1.2.3.4' }),
+      }),
+    );
+  });
+
+  it('skips sending when the user has no email on file', async () => {
+    usersServiceMock.findById.mockResolvedValue({ id: 'user-2', email: undefined });
+
+    await listener.handleAnomalousLogin({
+      userId: 'user-2',
+      fingerprintHash: 'def456',
+      occurredAt: new Date(),
+    });
+
+    expect(emailServiceMock.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('swallows email-send failures so the listener never throws', async () => {
+    usersServiceMock.findById.mockResolvedValue({ id: 'user-3', email: 'user3@example.com' });
+    emailServiceMock.sendEmail.mockRejectedValueOnce(new Error('provider down'));
+
+    await expect(
+      listener.handleAnomalousLogin({
+        userId: 'user-3',
+        fingerprintHash: 'ghi789',
+        occurredAt: new Date(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/auth/session/anomalous-login.listener.ts
+++ b/src/auth/session/anomalous-login.listener.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { SESSION_FINGERPRINT_EVENTS } from './session-fingerprint.service';
+import { UsersService } from '../../users/users.service';
+import { EmailService } from '../../email/email.service';
+
+export interface AnomalousLoginEvent {
+  userId: string;
+  fingerprintHash: string;
+  ipAddress?: string;
+  userAgent?: string;
+  occurredAt: Date;
+}
+
+/**
+ * Reacts to SessionFingerprintService's anomalous-login event by
+ * notifying the affected user via email. Kept as a separate listener
+ * (rather than inlined in the fingerprint service) so the fingerprinting
+ * logic stays decoupled from notification infrastructure.
+ */
+@Injectable()
+export class AnomalousLoginListener {
+  private readonly logger = new Logger(AnomalousLoginListener.name);
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  @OnEvent(SESSION_FINGERPRINT_EVENTS.ANOMALOUS_LOGIN)
+  async handleAnomalousLogin(payload: AnomalousLoginEvent): Promise<void> {
+    try {
+      const user = await this.usersService.findById(payload.userId);
+      if (!user?.email) {
+        this.logger.debug(
+          `Skipping anomalous-login email for user ${payload.userId}: no email on file`,
+        );
+        return;
+      }
+
+      await this.emailService.sendEmail({
+        to: user.email,
+        subject: 'Security Alert: New device sign-in',
+        template: 'security-alert',
+        variables: {
+          alertType: 'New device sign-in',
+          description:
+            'We noticed a sign-in to your account from a device, network, or browser we have not seen recently. If this was you, no action is needed.',
+          timestamp: payload.occurredAt.toISOString(),
+          ipAddress: payload.ipAddress ?? 'unknown',
+          link: 'https://app.stellarswipe.io/account/security',
+        },
+      });
+    } catch (error) {
+      // Notification failures must never break the login flow; this
+      // listener runs decoupled from the request that triggered it.
+      this.logger.error(
+        `Failed to send anomalous-login notification for user ${payload.userId}: ${error?.message}`,
+      );
+    }
+  }
+}

--- a/src/auth/session/dto/login-signals.dto.ts
+++ b/src/auth/session/dto/login-signals.dto.ts
@@ -1,0 +1,10 @@
+/**
+ * Raw request signals captured at login time, used to compute a
+ * session fingerprint. All fields are optional since not every
+ * client sends every header.
+ */
+export interface LoginSignals {
+  ipAddress?: string;
+  userAgent?: string;
+  acceptLanguage?: string;
+}

--- a/src/auth/session/entities/login-fingerprint.entity.ts
+++ b/src/auth/session/entities/login-fingerprint.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+/**
+ * Stores a hashed device/network fingerprint observed at a successful
+ * login, so future logins for the same user can be compared against
+ * recent history to detect anomalous (new device/IP/UA) sign-ins.
+ */
+@Index('idx_login_fingerprints_user_hash', ['userId', 'fingerprintHash'])
+@Index('idx_login_fingerprints_user_created', ['userId', 'createdAt'])
+@Entity('login_fingerprints')
+export class LoginFingerprint {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  /** SHA-256 hash of the normalized IP + user-agent (+ optional signals). */
+  @Column({ name: 'fingerprint_hash', length: 64 })
+  fingerprintHash!: string;
+
+  @Column({ name: 'ip_address', nullable: true })
+  ipAddress?: string;
+
+  @Column({ name: 'user_agent', type: 'text', nullable: true })
+  userAgent?: string;
+
+  @Column({ name: 'accept_language', nullable: true })
+  acceptLanguage?: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/src/auth/session/session-fingerprint.service.spec.ts
+++ b/src/auth/session/session-fingerprint.service.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  SessionFingerprintService,
+  SESSION_FINGERPRINT_EVENTS,
+} from './session-fingerprint.service';
+import { LoginFingerprint } from './entities/login-fingerprint.entity';
+
+describe('SessionFingerprintService (#683)', () => {
+  let service: SessionFingerprintService;
+  let records: LoginFingerprint[];
+
+  const repoMock = {
+    create: jest.fn((entry: Partial<LoginFingerprint>) => entry),
+    save: jest.fn((entry: LoginFingerprint) => {
+      const saved = { ...entry, id: `id-${records.length}`, createdAt: entry.createdAt ?? new Date() };
+      records.push(saved as LoginFingerprint);
+      return Promise.resolve(saved);
+    }),
+    findOne: jest.fn(({ where }: any) => {
+      const match = records.find(
+        (r) =>
+          r.userId === where.userId &&
+          r.fingerprintHash === where.fingerprintHash,
+      );
+      return Promise.resolve(match ?? null);
+    }),
+    find: jest.fn(({ where }: any) => {
+      return Promise.resolve(
+        records
+          .filter((r) => r.userId === where.userId)
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
+      );
+    }),
+  };
+
+  const configServiceMock = {
+    get: jest.fn((_key: string, def?: any) => def),
+  };
+
+  const eventEmitterMock = {
+    emit: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    records = [];
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionFingerprintService,
+        { provide: getRepositoryToken(LoginFingerprint), useValue: repoMock },
+        { provide: ConfigService, useValue: configServiceMock },
+        { provide: EventEmitter2, useValue: eventEmitterMock },
+      ],
+    }).compile();
+
+    service = module.get<SessionFingerprintService>(SessionFingerprintService);
+  });
+
+  it('computes a stable, normalized fingerprint regardless of casing/whitespace', () => {
+    const a = service.computeFingerprint({
+      ipAddress: ' 1.2.3.4 ',
+      userAgent: 'Mozilla/5.0 (Test)',
+      acceptLanguage: 'en-US',
+    });
+    const b = service.computeFingerprint({
+      ipAddress: '1.2.3.4',
+      userAgent: 'mozilla/5.0 (test)',
+      acceptLanguage: 'EN-US',
+    });
+    expect(a).toBe(b);
+    expect(a).toHaveLength(64); // sha256 hex digest
+  });
+
+  it('flags a brand-new fingerprint as anomalous and emits an event', async () => {
+    const result = await service.checkAndRecord('user-1', {
+      ipAddress: '1.2.3.4',
+      userAgent: 'Mozilla/5.0 (Test)',
+    });
+
+    expect(result.anomalous).toBe(true);
+    expect(eventEmitterMock.emit).toHaveBeenCalledWith(
+      SESSION_FINGERPRINT_EVENTS.ANOMALOUS_LOGIN,
+      expect.objectContaining({ userId: 'user-1', fingerprintHash: result.fingerprintHash }),
+    );
+  });
+
+  it('does not flag a fingerprint that matches recent history', async () => {
+    const signals = { ipAddress: '5.6.7.8', userAgent: 'Chrome/100' };
+
+    const first = await service.checkAndRecord('user-2', signals);
+    expect(first.anomalous).toBe(true);
+
+    eventEmitterMock.emit.mockClear();
+
+    const second = await service.checkAndRecord('user-2', signals);
+    expect(second.anomalous).toBe(false);
+    expect(second.fingerprintHash).toBe(first.fingerprintHash);
+    expect(eventEmitterMock.emit).not.toHaveBeenCalled();
+  });
+
+  it('flags a known user logging in from a new device/IP as anomalous', async () => {
+    await service.checkAndRecord('user-3', {
+      ipAddress: '9.9.9.9',
+      userAgent: 'Chrome/100',
+    });
+
+    const fromNewDevice = await service.checkAndRecord('user-3', {
+      ipAddress: '10.10.10.10',
+      userAgent: 'Safari/17',
+    });
+
+    expect(fromNewDevice.anomalous).toBe(true);
+    expect(eventEmitterMock.emit).toHaveBeenCalledWith(
+      SESSION_FINGERPRINT_EVENTS.ANOMALOUS_LOGIN,
+      expect.objectContaining({ userId: 'user-3' }),
+    );
+  });
+
+  it('keeps fingerprint history isolated per user', async () => {
+    await service.checkAndRecord('user-4', {
+      ipAddress: '1.1.1.1',
+      userAgent: 'Edge/1',
+    });
+
+    const otherUserSameSignals = await service.checkAndRecord('user-5', {
+      ipAddress: '1.1.1.1',
+      userAgent: 'Edge/1',
+    });
+
+    expect(otherUserSameSignals.anomalous).toBe(true);
+  });
+
+  it('isKnownFingerprint reflects persisted history directly', async () => {
+    const signals = { ipAddress: '2.2.2.2', userAgent: 'Firefox/99' };
+    const hash = service.computeFingerprint(signals);
+
+    expect(await service.isKnownFingerprint('user-6', hash)).toBe(false);
+
+    await service.checkAndRecord('user-6', signals);
+
+    expect(await service.isKnownFingerprint('user-6', hash)).toBe(true);
+  });
+});

--- a/src/auth/session/session-fingerprint.service.ts
+++ b/src/auth/session/session-fingerprint.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import * as crypto from 'crypto';
+
+import { LoginFingerprint } from './entities/login-fingerprint.entity';
+import { LoginSignals } from './dto/login-signals.dto';
+
+export const SESSION_FINGERPRINT_EVENTS = {
+  ANOMALOUS_LOGIN: 'session_fingerprint.anomalous_login',
+};
+
+export interface FingerprintCheckResult {
+  fingerprintHash: string;
+  /** True when this fingerprint was NOT found in the user's recent history. */
+  anomalous: boolean;
+}
+
+/**
+ * Computes a hash of login signals (IP + user-agent + optional
+ * accept-language) and compares it against a user's recent login
+ * history to flag logins from devices/networks not seen recently.
+ */
+@Injectable()
+export class SessionFingerprintService {
+  private readonly logger = new Logger(SessionFingerprintService.name);
+
+  /** How many days of history count as "recent" when comparing fingerprints. */
+  private readonly historyWindowDays: number;
+  /** How many recent fingerprints to retain per user (best-effort cap). */
+  private readonly maxFingerprintsPerUser: number;
+
+  constructor(
+    @InjectRepository(LoginFingerprint)
+    private readonly fingerprintRepo: Repository<LoginFingerprint>,
+    private readonly configService: ConfigService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
+    this.historyWindowDays = this.configService.get<number>(
+      'auth.fingerprintHistoryWindowDays',
+      30,
+    );
+    this.maxFingerprintsPerUser = this.configService.get<number>(
+      'auth.maxFingerprintsPerUser',
+      20,
+    );
+  }
+
+  /**
+   * Compute a stable SHA-256 hash from the login signals. IP and
+   * user-agent are normalized (lower-cased/trimmed) so trivial casing
+   * differences don't generate spurious "new" fingerprints.
+   */
+  computeFingerprint(signals: LoginSignals): string {
+    const normalized = [
+      (signals.ipAddress ?? '').trim().toLowerCase(),
+      (signals.userAgent ?? '').trim().toLowerCase(),
+      (signals.acceptLanguage ?? '').trim().toLowerCase(),
+    ].join('|');
+
+    return crypto.createHash('sha256').update(normalized).digest('hex');
+  }
+
+  /**
+   * Record a successful login's fingerprint and determine whether it
+   * matches the user's recent history. Emits an event (and logs) when
+   * the fingerprint is new/anomalous so other parts of the app (e.g.
+   * notifications) can react.
+   */
+  async checkAndRecord(
+    userId: string,
+    signals: LoginSignals,
+  ): Promise<FingerprintCheckResult> {
+    const fingerprintHash = this.computeFingerprint(signals);
+    const anomalous = !(await this.isKnownFingerprint(userId, fingerprintHash));
+
+    await this.persistFingerprint(userId, fingerprintHash, signals);
+
+    if (anomalous) {
+      this.logger.warn(
+        `Anomalous login detected for user ${userId}: fingerprint ${fingerprintHash} not seen in last ${this.historyWindowDays}d`,
+      );
+      this.eventEmitter.emit(SESSION_FINGERPRINT_EVENTS.ANOMALOUS_LOGIN, {
+        userId,
+        fingerprintHash,
+        ipAddress: signals.ipAddress,
+        userAgent: signals.userAgent,
+        occurredAt: new Date(),
+      });
+    } else {
+      this.logger.debug(
+        `Known fingerprint for user ${userId}: ${fingerprintHash}`,
+      );
+    }
+
+    return { fingerprintHash, anomalous };
+  }
+
+  /**
+   * Whether the given fingerprint hash has been seen for this user
+   * within the recent history window.
+   */
+  async isKnownFingerprint(
+    userId: string,
+    fingerprintHash: string,
+  ): Promise<boolean> {
+    const since = this.windowStart();
+    const match = await this.fingerprintRepo.findOne({
+      where: {
+        userId,
+        fingerprintHash,
+        createdAt: MoreThanOrEqual(since),
+      },
+    });
+    return !!match;
+  }
+
+  /** Recent fingerprints for a user, most recent first. */
+  async getRecentFingerprints(userId: string): Promise<LoginFingerprint[]> {
+    const since = this.windowStart();
+    return this.fingerprintRepo.find({
+      where: { userId, createdAt: MoreThanOrEqual(since) },
+      order: { createdAt: 'DESC' },
+      take: this.maxFingerprintsPerUser,
+    });
+  }
+
+  private async persistFingerprint(
+    userId: string,
+    fingerprintHash: string,
+    signals: LoginSignals,
+  ): Promise<LoginFingerprint> {
+    const entry = this.fingerprintRepo.create({
+      userId,
+      fingerprintHash,
+      ipAddress: signals.ipAddress,
+      userAgent: signals.userAgent,
+      acceptLanguage: signals.acceptLanguage,
+    });
+    return this.fingerprintRepo.save(entry);
+  }
+
+  private windowStart(): Date {
+    const since = new Date();
+    since.setDate(since.getDate() - this.historyWindowDays);
+    return since;
+  }
+}

--- a/src/database/migrations/1750100000000-CreateLoginFingerprints.ts
+++ b/src/database/migrations/1750100000000-CreateLoginFingerprints.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * #683 — Adds the login_fingerprints table backing
+ * SessionFingerprintService, which hashes IP + user-agent (+ optional
+ * signals) at each successful login and compares against a user's
+ * recent history to flag anomalous (new device/IP) sign-ins.
+ *
+ * Up/down are both fully reversible.
+ */
+export class CreateLoginFingerprints1750100000000
+  implements MigrationInterface
+{
+  name = 'CreateLoginFingerprints1750100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "login_fingerprints" (
+        "id"                uuid        NOT NULL DEFAULT uuid_generate_v4(),
+        "user_id"           uuid        NOT NULL,
+        "fingerprint_hash"  varchar(64) NOT NULL,
+        "ip_address"        varchar     NULL,
+        "user_agent"        text        NULL,
+        "accept_language"   varchar     NULL,
+        "created_at"        TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_login_fingerprints" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_login_fingerprints_user_hash"
+        ON "login_fingerprints" ("user_id", "fingerprint_hash")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_login_fingerprints_user_created"
+        ON "login_fingerprints" ("user_id", "created_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_login_fingerprints_user_created"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_login_fingerprints_user_hash"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "login_fingerprints"`);
+  }
+}


### PR DESCRIPTION
Closes #683

Computes a SHA-256 fingerprint from IP + user-agent + accept-language on every successful login and compares it against the user's recent login history (30-day window). Emits an anomalous-login event when the fingerprint wasn't seen recently; a decoupled listener notifies the user by email so a notification failure never breaks login.