### PR TITLE
Add ESLint rule preventing direct process.env access outside config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,27 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "prettier/prettier": "error"
-  }
+    "prettier/prettier": "error",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "MemberExpression[object.name='process'][property.name='env']",
+        "message": "Direct process.env access is not allowed outside the config module. Inject and use ConfigService (src/config/config.service.ts) instead, so config access stays centralized, validated, and auditable."
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": [
+        "src/config/**/*.ts",
+        "src/database/config/**/*.ts",
+        "src/database/seeds/**/*.ts",
+        "src/security/config/**/*.ts",
+        "**/*.config.ts"
+      ],
+      "rules": {
+        "no-restricted-syntax": "off"
+      }
+    }
+  ]
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,7 +6,10 @@ import { ThrottlerModule } from '@nestjs/throttler';
 // import { CacheModule } from '@nestjs/cache-manager';
 import { stellarConfig } from './config/stellar.config';
 import { databaseConfig, redisConfig } from './config/database.config';
-import { connectionPoolConfig } from './database/config/connection-pool.config';
+import {
+  connectionPoolConfig,
+  connectionPoolReplicaConfig,
+} from './database/config/connection-pool.config';
 import { xaiConfig } from './config/xai.config';
 
 import { appConfig, sentryConfig } from './config/app.config';
@@ -99,8 +102,10 @@ import { FreighterModule } from './freighter/freighter.module';
         jwtConfig,
         xaiConfig,
         connectionPoolConfig,
+        connectionPoolReplicaConfig,
         configuration,
       ],
+      // eslint-disable-next-line no-restricted-syntax -- ConfigModule bootstrap runs before the DI container (and ConfigService) exist.
       envFilePath: [`.env.${process.env.NODE_ENV || 'development'}`, '.env'],
       cache: true,
       validationSchema: configSchema,
@@ -139,10 +144,15 @@ import { FreighterModule } from './freighter/freighter.module';
         subscribers: ['dist/subscribers/*{.ts,.js}', 'dist/common/subscribers/*{.ts,.js}'],
         ssl: configService.get<boolean>('database.ssl') ?? false,
         extra: {
-          min: parseInt(process.env.DATABASE_POOL_MIN || '10', 10),
-          max: parseInt(process.env.DATABASE_POOL_MAX || '30', 10),
-          idleTimeoutMillis: parseInt(process.env.DATABASE_POOL_IDLE_TIMEOUT || '30000', 10),
-          connectionTimeoutMillis: parseInt(process.env.DATABASE_POOL_CONNECTION_TIMEOUT || '2000', 10),
+          min: configService.get<number>('connectionPool.min') ?? 10,
+          max: configService.get<number>('connectionPool.max') ?? 30,
+          idleTimeoutMillis:
+            configService.get<number>('connectionPool.idleTimeoutMillis') ??
+            30000,
+          connectionTimeoutMillis:
+            configService.get<number>(
+              'connectionPool.connectionTimeoutMillis',
+            ) ?? 2000,
         },
       }),
     }),
@@ -163,10 +173,16 @@ import { FreighterModule } from './freighter/freighter.module';
         entities: ['dist/**/*.entity{.ts,.js}'],
         ssl: configService.get<boolean>('database.replica.ssl') ?? false,
         extra: {
-          min: parseInt(process.env.DATABASE_REPLICA_POOL_MIN || '5', 10),
-          max: parseInt(process.env.DATABASE_REPLICA_POOL_MAX || '20', 10),
-          idleTimeoutMillis: parseInt(process.env.DATABASE_REPLICA_POOL_IDLE_TIMEOUT || '30000', 10),
-          connectionTimeoutMillis: parseInt(process.env.DATABASE_REPLICA_POOL_CONNECTION_TIMEOUT || '2000', 10),
+          min: configService.get<number>('connectionPoolReplica.min') ?? 5,
+          max: configService.get<number>('connectionPoolReplica.max') ?? 20,
+          idleTimeoutMillis:
+            configService.get<number>(
+              'connectionPoolReplica.idleTimeoutMillis',
+            ) ?? 30000,
+          connectionTimeoutMillis:
+            configService.get<number>(
+              'connectionPoolReplica.connectionTimeoutMillis',
+            ) ?? 2000,
         },
       }),
     }),

--- a/src/assets/trustline-establishment.service.ts
+++ b/src/assets/trustline-establishment.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { Asset, AssetType } from './entities/asset.entity';
 import { AuditAction } from '../audit-log/audit-log.entity';
@@ -13,6 +14,7 @@ export class TrustlineEstablishmentService {
     @InjectRepository(Asset)
     private readonly assetRepo: Repository<Asset>,
     private readonly auditService: AuditService,
+    private readonly configService: ConfigService,
   ) {}
 
   async establishTrustlinesForAsset(assetId: string): Promise<{ success: boolean; errors: string[] }> {
@@ -66,7 +68,10 @@ export class TrustlineEstablishmentService {
   }
 
   private getPlatformAccounts(): string[] {
-    const accounts = process.env.PLATFORM_STELLAR_ACCOUNTS?.split(',') || [];
+    const accounts =
+      this.configService
+        .get<string>('PLATFORM_STELLAR_ACCOUNTS')
+        ?.split(',') || [];
     return accounts.map(a => a.trim()).filter(a => a.length > 0);
   }
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -10,7 +10,10 @@ import { redisCacheConfig } from '../config/redis.config';
 import { jwtConfig } from '../config/jwt.config';
 import { stellarConfig } from '../config/stellar.config';
 import { xaiConfig } from '../config/xai.config';
-import { connectionPoolConfig } from '../database/config/connection-pool.config';
+import {
+  connectionPoolConfig,
+  connectionPoolReplicaConfig,
+} from '../database/config/connection-pool.config';
 import configuration from '../config/configuration';
 import { configSchema } from '../config/schemas/config.schema';
 import { CliModule } from './cli.module';
@@ -32,8 +35,9 @@ import { GenerateReportCommand } from './commands/analytics/generate-report.comm
       load: [
         appConfig, sentryConfig, stellarConfig, databaseConfig,
         redisConfig, redisCacheConfig, jwtConfig, xaiConfig,
-        connectionPoolConfig, configuration,
+        connectionPoolConfig, connectionPoolReplicaConfig, configuration,
       ],
+      // eslint-disable-next-line no-restricted-syntax -- ConfigModule bootstrap runs before the DI container (and ConfigService) exist.
       envFilePath: [`.env.${process.env.NODE_ENV || 'development'}`, '.env'],
       validationSchema: configSchema,
       validationOptions: { allowUnknown: true, abortEarly: false },

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { ConfigService } from '@nestjs/config';
 import { LoggerService } from '../logger';
 import { SentryService } from '../sentry';
 import { CORRELATION_ID_HEADER } from '../correlation/correlation-id.store';
@@ -19,6 +20,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     private readonly logger: LoggerService,
     private readonly sentry: SentryService,
     private readonly errorClassifier: ErrorClassificationService,
+    private readonly configService: ConfigService,
   ) {
     this.logger.setContext(GlobalExceptionFilter.name);
   }
@@ -51,7 +53,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
     // Include details in development mode
     if (
-      process.env.NODE_ENV === 'development' &&
+      this.configService.get<string>('NODE_ENV') === 'development' &&
       classification.originalError
     ) {
       errorResponse.details = {

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -7,6 +7,7 @@ import {
 import { Observable } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { Request, Response } from 'express';
+import { ConfigService } from '@nestjs/config';
 import { LoggerService } from '../logger';
 import { CorrelationIdStore } from '../correlation/correlation-id.store';
 
@@ -15,6 +16,7 @@ export class LoggingInterceptor implements NestInterceptor {
   constructor(
     private readonly logger: LoggerService,
     private readonly correlationIdStore: CorrelationIdStore,
+    private readonly configService: ConfigService,
   ) {
     this.logger.setContext(LoggingInterceptor.name);
   }
@@ -45,7 +47,7 @@ export class LoggingInterceptor implements NestInterceptor {
 
     // Only log request body in development
     if (
-      process.env.NODE_ENV === 'development' &&
+      this.configService.get<string>('NODE_ENV') === 'development' &&
       body &&
       Object.keys(body).length > 0
     ) {
@@ -69,7 +71,7 @@ export class LoggingInterceptor implements NestInterceptor {
         };
 
         // Only log response body in development
-        if (process.env.NODE_ENV === 'development' && data) {
+        if (this.configService.get<string>('NODE_ENV') === 'development' && data) {
           responseLog.responseData = data;
         }
 

--- a/src/data-lake/etl/loaders/data-lake.loader.spec.ts
+++ b/src/data-lake/etl/loaders/data-lake.loader.spec.ts
@@ -43,15 +43,14 @@ describe('DataLakeLoader', () => {
       expect(l.basePath).toBe('/custom/path');
     });
 
-    it('should use DATA_LAKE_PATH env var when no arg provided', () => {
-      process.env.DATA_LAKE_PATH = '/env/path';
-      const l = new DataLakeLoader();
+    it('should use DATA_LAKE_PATH config value when no arg provided', () => {
+      const mockConfigService = { get: jest.fn().mockReturnValue('/env/path') } as any;
+      const l = new DataLakeLoader(undefined, mockConfigService);
       expect(l.basePath).toBe('/env/path');
-      delete process.env.DATA_LAKE_PATH;
+      expect(mockConfigService.get).toHaveBeenCalledWith('DATA_LAKE_PATH');
     });
 
-    it('should fall back to /tmp/data-lake when no arg or env', () => {
-      delete process.env.DATA_LAKE_PATH;
+    it('should fall back to /tmp/data-lake when no arg or config value', () => {
       const l = new DataLakeLoader();
       expect(l.basePath).toBe('/tmp/data-lake');
     });

--- a/src/data-lake/etl/loaders/data-lake.loader.ts
+++ b/src/data-lake/etl/loaders/data-lake.loader.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ParquetRecord } from '../transformers/parquet.transformer';
@@ -21,8 +22,8 @@ export class DataLakeLoader {
   private readonly logger = new Logger(DataLakeLoader.name);
   readonly basePath: string;
 
-  constructor(basePath?: string) {
-    this.basePath = basePath ?? process.env.DATA_LAKE_PATH ?? '/tmp/data-lake';
+  constructor(basePath?: string, private readonly configService?: ConfigService) {
+    this.basePath = basePath ?? this.configService?.get<string>('DATA_LAKE_PATH') ?? '/tmp/data-lake';
   }
 
   async load(parquetRecord: ParquetRecord): Promise<LoadResult> {

--- a/src/data-residency/strategies/eu-storage.strategy.ts
+++ b/src/data-residency/strategies/eu-storage.strategy.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { RegionCode } from '../entities/data-region.entity';
 
 export interface StorageStrategy {
@@ -33,8 +34,10 @@ export class EuStorageStrategy implements StorageStrategy {
     'IS', 'LI', 'NO',
   ];
 
+  constructor(private readonly configService: ConfigService) {}
+
   getStorageEndpoint(): string {
-    return process.env.EU_STORAGE_ENDPOINT ?? 'https://eu-storage.stellarswipe.internal';
+    return this.configService.get<string>('EU_STORAGE_ENDPOINT') ?? 'https://eu-storage.stellarswipe.internal';
   }
 
   getEncryptionConfig(): EncryptionConfig {

--- a/src/data-residency/strategies/us-storage.strategy.ts
+++ b/src/data-residency/strategies/us-storage.strategy.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { RegionCode } from '../entities/data-region.entity';
 import { EncryptionConfig, StorageStrategy } from './eu-storage.strategy';
 
@@ -12,8 +13,10 @@ export class UsStorageStrategy implements StorageStrategy {
     'US', 'PR', 'GU', 'VI', 'MP', 'AS',
   ];
 
+  constructor(private readonly configService: ConfigService) {}
+
   getStorageEndpoint(): string {
-    return process.env.US_STORAGE_ENDPOINT ?? 'https://us-storage.stellarswipe.internal';
+    return this.configService.get<string>('US_STORAGE_ENDPOINT') ?? 'https://us-storage.stellarswipe.internal';
   }
 
   getEncryptionConfig(): EncryptionConfig {

--- a/src/database/config/connection-pool.config.ts
+++ b/src/database/config/connection-pool.config.ts
@@ -46,6 +46,25 @@ export const connectionPoolConfig = registerAs(
 );
 
 /**
+ * Read Replica Connection Pool Configuration
+ */
+export const connectionPoolReplicaConfig = registerAs(
+  'connectionPoolReplica',
+  (): PoolOptions => ({
+    min: parseInt(process.env.DATABASE_REPLICA_POOL_MIN || '5', 10),
+    max: parseInt(process.env.DATABASE_REPLICA_POOL_MAX || '20', 10),
+    idleTimeoutMillis: parseInt(
+      process.env.DATABASE_REPLICA_POOL_IDLE_TIMEOUT || '30000',
+      10,
+    ),
+    connectionTimeoutMillis: parseInt(
+      process.env.DATABASE_REPLICA_POOL_CONNECTION_TIMEOUT || '2000',
+      10,
+    ),
+  }),
+);
+
+/**
  * Query Performance Thresholds
  */
 export const queryPerformanceConfig = registerAs('queryPerformance', () => ({

--- a/src/database/connection-pool.metrics.service.ts
+++ b/src/database/connection-pool.metrics.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/commo
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
 import { PrometheusService } from '../monitoring/metrics/prometheus.service';
 
 export interface PoolSnapshot {
@@ -36,11 +37,12 @@ export class ConnectionPoolMetricsService implements OnModuleInit, OnModuleDestr
     @InjectDataSource() private readonly dataSource: DataSource,
     private readonly eventEmitter: EventEmitter2,
     private readonly prometheus: PrometheusService,
+    private readonly configService: ConfigService,
   ) {
-    this.poolMax = parseInt(process.env.DATABASE_POOL_MAX || '30', 10);
-    this.saturationThreshold = parseFloat(process.env.DB_POOL_SATURATION_THRESHOLD || '0.90');
-    this.highUtilizationThreshold = parseFloat(process.env.DB_POOL_HIGH_UTIL_THRESHOLD || '0.75');
-    this.pollIntervalMs = parseInt(process.env.DB_POOL_POLL_INTERVAL_MS || '15000', 10);
+    this.poolMax = parseInt(this.configService.get<string>('DATABASE_POOL_MAX') || '30', 10);
+    this.saturationThreshold = parseFloat(this.configService.get<string>('DB_POOL_SATURATION_THRESHOLD') || '0.90');
+    this.highUtilizationThreshold = parseFloat(this.configService.get<string>('DB_POOL_HIGH_UTIL_THRESHOLD') || '0.75');
+    this.pollIntervalMs = parseInt(this.configService.get<string>('DB_POOL_POLL_INTERVAL_MS') || '15000', 10);
   }
 
   onModuleInit(): void {

--- a/src/database/optimization/query-analyzer.service.ts
+++ b/src/database/optimization/query-analyzer.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { DataSource, QueryRunner, QueryExecutor, Log } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
 
 /**
  * Query Performance Analysis Result
@@ -57,16 +58,17 @@ export class QueryAnalyzerService implements OnModuleInit {
   constructor(
     private readonly dataSource: DataSource,
     private readonly eventEmitter: EventEmitter2,
+    private readonly configService: ConfigService,
   ) {
     // Load configuration from environment
     this.slowQueryThresholdMs = parseInt(
-      process.env.SLOW_QUERY_THRESHOLD_MS || '100',
+      this.configService.get<string>('SLOW_QUERY_THRESHOLD_MS') || '100',
       10,
     );
-    this.enableQueryLogging = process.env.ENABLE_QUERY_LOGGING === 'true';
-    this.logExplainAnalyze = process.env.LOG_EXPLAIN_ANALYZE === 'true';
+    this.enableQueryLogging = this.configService.get<string>('ENABLE_QUERY_LOGGING') === 'true';
+    this.logExplainAnalyze = this.configService.get<string>('LOG_EXPLAIN_ANALYZE') === 'true';
     this.maxLoggedQueries = parseInt(
-      process.env.MAX_LOGGED_QUERIES || '1000',
+      this.configService.get<string>('MAX_LOGGED_QUERIES') || '1000',
       10,
     );
   }

--- a/src/database/query-monitor.service.ts
+++ b/src/database/query-monitor.service.ts
@@ -31,6 +31,7 @@ import {
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
 
 export const SLOW_QUERY_EVENT = 'db.query.slow';
 export const SLOW_RATE_EVENT = 'db.query.slow_rate_exceeded';
@@ -74,13 +75,14 @@ export class QueryMonitorService implements OnModuleInit, OnModuleDestroy {
   constructor(
     @InjectDataSource() private readonly dataSource: DataSource,
     private readonly eventEmitter: EventEmitter2,
+    private readonly configService: ConfigService,
   ) {
     this.thresholdMs = parseInt(
-      process.env.SLOW_QUERY_THRESHOLD_MS ?? '200',
+      this.configService.get<string>('SLOW_QUERY_THRESHOLD_MS') ?? '200',
       10,
     );
     this.rateAlertThreshold = parseInt(
-      process.env.SLOW_QUERY_RATE_ALERT_THRESHOLD ?? '10',
+      this.configService.get<string>('SLOW_QUERY_RATE_ALERT_THRESHOLD') ?? '10',
       10,
     );
   }

--- a/src/disaster-recovery/services/backup-manager.service.ts
+++ b/src/disaster-recovery/services/backup-manager.service.ts
@@ -73,7 +73,7 @@ export class BackupManagerService {
 
     this.logger.log('Starting full backup (pg_dump)…');
 
-    const env = { ...process.env, PGPASSWORD: this.dbPassword };
+    const env = { ...process.env, PGPASSWORD: this.dbPassword }; // eslint-disable-line no-restricted-syntax -- spawning a DB CLI child process needs the full inherited environment, not a single config value.
     const dumpCmd = [
       'pg_dump',
       `-h ${this.dbHost}`,
@@ -117,7 +117,7 @@ export class BackupManagerService {
 
     this.logger.log('Starting incremental backup (pg_basebackup)…');
 
-    const env = { ...process.env, PGPASSWORD: this.dbPassword };
+    const env = { ...process.env, PGPASSWORD: this.dbPassword }; // eslint-disable-line no-restricted-syntax -- spawning a DB CLI child process needs the full inherited environment, not a single config value.
     await execAsync(
       `pg_basebackup -h ${this.dbHost} -p ${this.dbPort} -U ${this.dbUser} -D ${targetDir} --wal-method=stream --gzip --compress=5`,
       { env },
@@ -168,7 +168,7 @@ export class BackupManagerService {
       await execAsync(`gunzip -c ${decryptedPath} > ${sqlPath}`);
 
       const testDb = `stellarswipe_verify_${Date.now()}`;
-      const env = { ...process.env, PGPASSWORD: this.dbPassword };
+      const env = { ...process.env, PGPASSWORD: this.dbPassword }; // eslint-disable-line no-restricted-syntax -- spawning a DB CLI child process needs the full inherited environment, not a single config value.
 
       await execAsync(
         `psql -h ${this.dbHost} -p ${this.dbPort} -U ${this.dbUser} -c "CREATE DATABASE ${testDb}"`,
@@ -252,7 +252,7 @@ export class BackupManagerService {
       await this.decryptFile(fullBackup, decryptedGz);
       await execAsync(`gunzip -c ${decryptedGz} > ${decryptedSql}`);
 
-      const env = { ...process.env, PGPASSWORD: this.dbPassword };
+      const env = { ...process.env, PGPASSWORD: this.dbPassword }; // eslint-disable-line no-restricted-syntax -- spawning a DB CLI child process needs the full inherited environment, not a single config value.
       await execAsync(
         `psql -h ${this.dbHost} -p ${this.dbPort} -U ${this.dbUser} -d ${targetDb} -f ${decryptedSql}`,
         { env },

--- a/src/flags/feature-flags.service.ts
+++ b/src/flags/feature-flags.service.ts
@@ -40,7 +40,7 @@ export class FeatureFlagsService {
         enabled: this.getEnvBoolean('FF_NEW_PORTFOLIO_UI', false),
         description: 'Gradual rollout of new portfolio UI',
         rolloutPercentage: parseInt(
-          process.env.FF_NEW_PORTFOLIO_UI_ROLLOUT || '0',
+          this.configService.get<string>('FF_NEW_PORTFOLIO_UI_ROLLOUT') || '0',
           10,
         ),
       },
@@ -49,7 +49,7 @@ export class FeatureFlagsService {
         enabled: this.getEnvBoolean('FF_ADVANCED_ANALYTICS', false),
         description: 'Advanced analytics features',
         rolloutPercentage: parseInt(
-          process.env.FF_ADVANCED_ANALYTICS_ROLLOUT || '0',
+          this.configService.get<string>('FF_ADVANCED_ANALYTICS_ROLLOUT') || '0',
           10,
         ),
       },
@@ -58,7 +58,7 @@ export class FeatureFlagsService {
         enabled: this.getEnvBoolean('FF_SOROBAN_CONTRACTS', false),
         description: 'Soroban smart contract integration',
         rolloutPercentage: parseInt(
-          process.env.FF_SOROBAN_CONTRACTS_ROLLOUT || '0',
+          this.configService.get<string>('FF_SOROBAN_CONTRACTS_ROLLOUT') || '0',
           10,
         ),
       },
@@ -67,7 +67,7 @@ export class FeatureFlagsService {
         enabled: this.getEnvBoolean('FF_AUTOMATED_TRADING', false),
         description: 'Automated trading features',
         rolloutPercentage: parseInt(
-          process.env.FF_AUTOMATED_TRADING_ROLLOUT || '0',
+          this.configService.get<string>('FF_AUTOMATED_TRADING_ROLLOUT') || '0',
           10,
         ),
       },
@@ -76,7 +76,7 @@ export class FeatureFlagsService {
         enabled: this.getEnvBoolean('FF_SIGNAL_MARKETPLACE', false),
         description: 'Signal marketplace features',
         rolloutPercentage: parseInt(
-          process.env.FF_SIGNAL_MARKETPLACE_ROLLOUT || '0',
+          this.configService.get<string>('FF_SIGNAL_MARKETPLACE_ROLLOUT') || '0',
           10,
         ),
       },
@@ -260,7 +260,7 @@ export class FeatureFlagsService {
    * Parse boolean from environment variable
    */
   private getEnvBoolean(key: string, defaultValue: boolean): boolean {
-    const value = process.env[key];
+    const value = this.configService.get<string>(key);
     if (value === undefined) return defaultValue;
     return value.toLowerCase() === 'true' || value === '1';
   }

--- a/src/graphQL-API/gql-exception.filter.ts
+++ b/src/graphQL-API/gql-exception.filter.ts
@@ -1,5 +1,6 @@
 import { Catch, ArgumentsHost, HttpException, Logger } from '@nestjs/common';
 import { GqlExceptionFilter, GqlArgumentsHost } from '@nestjs/graphql';
+import { ConfigService } from '@nestjs/config';
 import { GraphQLError } from 'graphql';
 
 /**
@@ -12,6 +13,8 @@ import { GraphQLError } from 'graphql';
 @Catch()
 export class GraphqlExceptionFilter implements GqlExceptionFilter {
   private readonly logger = new Logger(GraphqlExceptionFilter.name);
+
+  constructor(private readonly configService: ConfigService) {}
 
   catch(exception: unknown, host: ArgumentsHost) {
     GqlArgumentsHost.create(host);
@@ -39,7 +42,7 @@ export class GraphqlExceptionFilter implements GqlExceptionFilter {
     this.logger.error(`[GQL] Unhandled exception: ${msg}`, (exception as Error)?.stack);
 
     return new GraphQLError(
-      process.env.NODE_ENV === 'production' ? 'Internal server error' : msg,
+      this.configService.get<string>('NODE_ENV') === 'production' ? 'Internal server error' : msg,
       { extensions: { code: 'INTERNAL_SERVER_ERROR' } },
     );
   }

--- a/src/graphQL-API/graphql.module.ts
+++ b/src/graphQL-API/graphql.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { GraphQLModule as NestGraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { APP_FILTER } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 import { join } from 'path';
 import { fieldExtensionsEstimator, simpleEstimator, getComplexity } from 'graphql-query-complexity';
 import { GraphQLSchema } from 'graphql';
@@ -57,8 +58,8 @@ import { SignalsService } from '../signals/signals.service';
 
     NestGraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
-      inject: [ProvidersService, SignalsService],
-      useFactory: (providersService: ProvidersService, signalsService: SignalsService) => ({
+      inject: [ProvidersService, SignalsService, ConfigService],
+      useFactory: (providersService: ProvidersService, signalsService: SignalsService, configService: ConfigService) => ({
         /**
          * Code-first schema — NestJS generates schema.gql automatically.
          * The file is written to disk so you can inspect or commit it.
@@ -102,14 +103,14 @@ import { SignalsService } from '../signals/signals.service';
                 `Query complexity ${complexity} exceeds limit of ${limit}. Simplify your query.`,
               );
             }
-            if (process.env.NODE_ENV !== 'production') {
+            if (configService.get<string>('NODE_ENV') !== 'production') {
               console.debug(`[GraphQL] complexity: ${complexity}/${limit}`);
             }
           },
         ],
 
         /** Expose playground in non-production environments */
-        playground: process.env.NODE_ENV !== 'production',
+        playground: configService.get<string>('NODE_ENV') !== 'production',
 
         /** Subscriptions over WS — enable when needed */
         subscriptions: {
@@ -118,7 +119,7 @@ import { SignalsService } from '../signals/signals.service';
 
         /** Format errors before returning to client — strip internals in prod */
         formatError: (error) => {
-          const isProd = process.env.NODE_ENV === 'production';
+          const isProd = configService.get<string>('NODE_ENV') === 'production';
           return {
             message: error.message,
             code: error.extensions?.code,

--- a/src/health/health-summary.service.spec.ts
+++ b/src/health/health-summary.service.spec.ts
@@ -42,6 +42,7 @@ const makeService = (overrides: {
     databaseHealth as any,
     redisHealth as any,
     {} as any, // PrometheusService — recordHealthCheck is mocked at module level
+    { get: jest.fn() } as any, // ConfigService
   );
 
   return { service, databaseHealth, redisHealth, stellarHealth, sorobanHealth };

--- a/src/health/health-summary.service.ts
+++ b/src/health/health-summary.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   HealthCheckService,
   HealthCheckResult,
@@ -56,6 +57,7 @@ export class HealthSummaryService {
     private redisHealth: RedisHealthIndicator,
     private queueHealth: QueueHealthIndicator,
     private prometheus: PrometheusService,
+    private configService: ConfigService,
   ) {}
 
   async getHealthSummary(): Promise<ServiceHealthSummary> {
@@ -82,7 +84,7 @@ export class HealthSummaryService {
       timestamp: new Date().toISOString(),
       services,
       uptime: Date.now() - this.startupTime,
-      version: process.env.npm_package_version || '1.0.0',
+      version: this.configService.get<string>('npm_package_version') || '1.0.0',
     };
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ async function bootstrap() {
 // Global filters
    const errorClassifier = app.get(ErrorClassificationService);
    app.useGlobalFilters(
-     new GlobalExceptionFilter(logger, sentryService, errorClassifier),
+     new GlobalExceptionFilter(logger, sentryService, errorClassifier, configService),
      new I18nValidationExceptionFilter({ detailedErrors: false }),
    );
 
@@ -130,7 +130,7 @@ async function bootstrap() {
   app.useGlobalInterceptors(new DeadlockRetryInterceptor());
   app.useGlobalInterceptors(new TimeoutInterceptor(app.get(Reflector)));
   app.useGlobalInterceptors(
-    new LoggingInterceptor(logger, app.get(CorrelationIdStore)),
+    new LoggingInterceptor(logger, app.get(CorrelationIdStore), configService),
   );
   app.useGlobalInterceptors(new TransformInterceptor());
   app.useGlobalInterceptors(new SensitiveDataInterceptor());

--- a/src/nft/utils/metadata-generator.ts
+++ b/src/nft/utils/metadata-generator.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { MetadataSchema, NftType, NftRarity } from '../interfaces/metadata-schema.interface';
 import { buildAchievementTemplate } from '../templates/achievement-nft.template';
 import { buildTrophyTemplate } from '../templates/trophy-nft.template';
 import { buildMilestoneTemplate } from '../templates/milestone-nft.template';
 
-const DEFAULT_IMAGE_BASE = process.env.NFT_IMAGE_BASE_URL || 'https://assets.stellarswipe.io/nft';
-
 @Injectable()
 export class MetadataGenerator {
+  constructor(private readonly configService: ConfigService) {}
+
+  private get defaultImageBase(): string {
+    return this.configService.get<string>('NFT_IMAGE_BASE_URL') || 'https://assets.stellarswipe.io/nft';
+  }
+
   generate(params: {
     type: NftType;
     name: string;
@@ -16,7 +21,7 @@ export class MetadataGenerator {
     issuer: string;
     extra?: Record<string, unknown>;
   }): MetadataSchema {
-    const imageUrl = `${DEFAULT_IMAGE_BASE}/${params.type}/${params.rarity}.png`;
+    const imageUrl = `${this.defaultImageBase}/${params.type}/${params.rarity}.png`;
     const base = { ...params, imageUrl };
 
     switch (params.type) {

--- a/src/partnerships/affiliates/affiliate.service.ts
+++ b/src/partnerships/affiliates/affiliate.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { Affiliate, AffiliateStatus } from './entities/affiliate.entity';
 import { AffiliateConversion, ConversionStatus, ConversionType } from './entities/affiliate-conversion.entity';
@@ -20,6 +21,7 @@ export class AffiliateService {
     private affiliateRepository: Repository<Affiliate>,
     @InjectRepository(AffiliateConversion)
     private conversionRepository: Repository<AffiliateConversion>,
+    private configService: ConfigService,
   ) {}
 
   async createAffiliate(dto: CreateAffiliateDto): Promise<Affiliate> {
@@ -231,7 +233,7 @@ export class AffiliateService {
     const affiliate = await this.getAffiliateByUserId(userId);
     const stats = await this.getAffiliateStats(affiliate.id);
 
-    const referralLink = `${process.env.APP_URL}/signup?ref=${affiliate.affiliateCode}`;
+    const referralLink = `${this.configService.get<string>('APP_URL')}/signup?ref=${affiliate.affiliateCode}`;
 
     return {
       affiliate: {

--- a/src/settlement/latency/settlement-latency.service.ts
+++ b/src/settlement/latency/settlement-latency.service.ts
@@ -26,10 +26,11 @@ export class SettlementLatencyService {
   private readonly thresholdMs: number;
 
   constructor(private readonly configService?: ConfigService) {
+    const fromEnv = this.configService?.get<string>('SETTLEMENT_LATENCY_THRESHOLD_MS');
     this.thresholdMs = this.configService?.get<number>(
       'settlement.latencyThresholdMs',
-      Number(process.env.SETTLEMENT_LATENCY_THRESHOLD_MS ?? 30_000),
-    ) ?? Number(process.env.SETTLEMENT_LATENCY_THRESHOLD_MS ?? 30_000);
+      Number(fromEnv ?? 30_000),
+    ) ?? Number(fromEnv ?? 30_000);
   }
 
   recordTradeExecution(tradeId: string, executedAt = new Date(), assetPair?: string): void {

--- a/src/tracing/tracing.service.ts
+++ b/src/tracing/tracing.service.ts
@@ -46,11 +46,11 @@ export class TracingService {
   constructor(private readonly config: NestConfigService) {}
 
   get isEnabled(): boolean {
-    return process.env.TRACING_ENABLED === 'true';
+    return this.config.get<string>('TRACING_ENABLED') === 'true';
   }
 
   get serviceName(): string {
-    return process.env.TRACING_SERVICE_NAME ?? 'stellarswipe-backend';
+    return this.config.get<string>('TRACING_SERVICE_NAME') ?? 'stellarswipe-backend';
   }
 
   /** Extract the trace ID from an Express request. */

--- a/src/transactions/duplicates/duplicate-detector.service.ts
+++ b/src/transactions/duplicates/duplicate-detector.service.ts
@@ -18,10 +18,11 @@ export class DuplicateDetectorService {
   private readonly windowMs: number;
 
   constructor(private readonly configService?: ConfigService) {
+    const fromEnv = this.configService?.get<string>('TRANSACTION_DUPLICATE_WINDOW_MS');
     this.windowMs = this.configService?.get<number>(
       'transactions.duplicateWindowMs',
-      Number(process.env.TRANSACTION_DUPLICATE_WINDOW_MS ?? 300_000),
-    ) ?? Number(process.env.TRANSACTION_DUPLICATE_WINDOW_MS ?? 300_000);
+      Number(fromEnv ?? 300_000),
+    ) ?? Number(fromEnv ?? 300_000);
   }
 
   checkTransaction(dto: DuplicateCheckDto, now = new Date()): DuplicateCheckResultDto {


### PR DESCRIPTION
Closes #692

Adds a `no-restricted-syntax` rule that flags direct `process.env` member access, with a message pointing to `ConfigService`. Exempts designated config-factory modules (`src/config`, `database/config`, `security/config`, `**/*.config.ts`) and the standalone seed script. Fixes existing violations across app bootstrap, database metrics/query monitoring, feature flags, tracing, NFT metadata, health summary, settlement latency, duplicate detection, logging/exception interceptors and filters, the GraphQL module, the affiliate service, and the data-residency storage strategies by injecting `ConfigService`. Adds justified `eslint-disable` comments for the few legitimate exceptions (bootstrap `envFilePath` before the DI container exists; spreading `process.env` to inherit environment for spawned DB CLI subprocesses).