### PR TITLE
feat: add Soroban warmup and health check, transactional outbox event queue, and sparse fieldset support

### DIFF
--- a/src/common/utils/field-selection.util.spec.ts
+++ b/src/common/utils/field-selection.util.spec.ts
@@ -1,0 +1,59 @@
+import { applySparseFieldset } from './field-selection.util';
+import { BadRequestException } from '@nestjs/common';
+
+describe('applySparseFieldset', () => {
+  it('should preserve full response if fields is undefined', () => {
+    const payload = { a: 1, b: 2 };
+    expect(applySparseFieldset(payload, undefined)).toEqual(payload);
+  });
+
+  it('should select top-level object fields', () => {
+    const payload = { a: 1, b: 2, c: 3 };
+    expect(applySparseFieldset(payload, 'a,c')).toEqual({ a: 1, c: 3 });
+  });
+
+  it('should select nested object fields', () => {
+    const payload = { user: { id: 'u1', name: 'Alice' }, status: 'active' };
+    expect(applySparseFieldset(payload, 'user.id,status')).toEqual({ user: { id: 'u1' }, status: 'active' });
+  });
+
+  it('should select fields inside response arrays when top-level field names match', () => {
+    const response = {
+      signals: [
+        { id: '1', pair: 'XLM/USDC', provider: { id: 'p1' } },
+        { id: '2', pair: 'BTC/USD', provider: { id: 'p2' } },
+      ],
+      hasMore: false,
+    };
+
+    expect(applySparseFieldset(response, 'id,pair')).toEqual({
+      signals: [
+        { id: '1', pair: 'XLM/USDC' },
+        { id: '2', pair: 'BTC/USD' },
+      ],
+      hasMore: false,
+    });
+  });
+
+  it('should select nested item fields inside response arrays', () => {
+    const response = {
+      signals: [
+        { id: '1', pair: 'XLM/USDC', provider: { id: 'p1', name: 'Alpha' } },
+        { id: '2', pair: 'BTC/USD', provider: { id: 'p2', name: 'Beta' } },
+      ],
+      hasMore: true,
+    };
+
+    expect(applySparseFieldset(response, 'provider.id')).toEqual({
+      signals: [
+        { provider: { id: 'p1' } },
+        { provider: { id: 'p2' } },
+      ],
+      hasMore: true,
+    });
+  });
+
+  it('should throw if requested field does not exist', () => {
+    expect(() => applySparseFieldset({ a: 1 }, 'a,b')).toThrow(BadRequestException);
+  });
+});

--- a/src/common/utils/field-selection.util.ts
+++ b/src/common/utils/field-selection.util.ts
@@ -1,0 +1,151 @@
+import { BadRequestException } from '@nestjs/common';
+
+export function parseFields(fields?: string): string[] {
+  if (!fields || !fields.trim()) {
+    return [];
+  }
+
+  return fields
+    .split(',')
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
+}
+
+export function applySparseFieldset<T>(value: T, fields?: string): T {
+  const fieldPaths = parseFields(fields);
+  if (!fieldPaths.length) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => selectFields(item, fieldPaths)) as unknown as T;
+  }
+
+  if (isArrayResponse(value, 'signals', fieldPaths)) {
+    const response = value as unknown as Record<string, unknown>;
+    return {
+      ...response,
+      signals: (response.signals as unknown[]).map((item) =>
+        selectFieldsFromArrayItem(item, fieldPaths, 'signals'),
+      ),
+    } as T;
+  }
+
+  if (isArrayResponse(value, 'data', fieldPaths)) {
+    const response = value as unknown as Record<string, unknown>;
+    return {
+      ...response,
+      data: (response.data as unknown[]).map((item) =>
+        selectFieldsFromArrayItem(item, fieldPaths, 'data'),
+      ),
+    } as T;
+  }
+
+  return selectFields(value as unknown as Record<string, unknown>, fieldPaths) as T;
+}
+
+function selectFields(source: unknown, fieldPaths: string[]): unknown {
+  if (source === null || source === undefined || typeof source !== 'object') {
+    return source;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const path of fieldPaths) {
+    const segments = path.split('.').map((segment) => segment.trim()).filter(Boolean);
+    if (!segments.length) {
+      continue;
+    }
+
+    if (!hasPath(source, segments)) {
+      throw new BadRequestException(`Invalid fields parameter: ${path}`);
+    }
+
+    const value = getPath(source, segments);
+    setPath(result, segments, value);
+  }
+
+  return result;
+}
+
+function selectFieldsFromArrayItem(source: unknown, fieldPaths: string[], arrayKey: string): unknown {
+  const normalizedFields = fieldPaths.map((path) => {
+    const prefix = `${arrayKey}.`;
+    return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+  });
+
+  return selectFields(source, normalizedFields);
+}
+
+function hasPath(source: unknown, segments: string[]): boolean {
+  let current: any = source;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined) {
+      return false;
+    }
+
+    if (typeof current !== 'object' || !(segment in current)) {
+      return false;
+    }
+
+    current = current[segment];
+  }
+
+  return true;
+}
+
+function getPath(source: unknown, segments: string[]): unknown {
+  return segments.reduce((current: any, segment) => {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined;
+    }
+    return current[segment];
+  }, source as any);
+}
+
+function setPath(target: Record<string, unknown>, segments: string[], value: unknown): void {
+  let current = target;
+
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index];
+    const nextIsLeaf = index === segments.length - 1;
+
+    if (nextIsLeaf) {
+      current[segment] = value;
+      return;
+    }
+
+    if (current[segment] === undefined || current[segment] === null) {
+      current[segment] = {};
+    }
+
+    if (typeof current[segment] !== 'object') {
+      current[segment] = {};
+    }
+
+    current = current[segment] as Record<string, unknown>;
+  }
+}
+
+function isArrayResponse(value: unknown, arrayKey: string, fieldPaths: string[]): boolean {
+  if (value === null || value === undefined || typeof value !== 'object') {
+    return false;
+  }
+
+  const response = value as Record<string, unknown>;
+  const array = response[arrayKey];
+  if (!Array.isArray(array)) {
+    return false;
+  }
+
+  if (array.length === 0) {
+    return true;
+  }
+
+  return fieldPaths.every((path) => {
+    const normalizedPath = path.startsWith(`${arrayKey}.`) ? path.slice(arrayKey.length + 1) : path;
+    const segments = normalizedPath.split('.').map((segment) => segment.trim()).filter(Boolean);
+    return typeof array[0] === 'object' && array[0] !== null && hasPath(array[0], segments);
+  });
+}

--- a/src/events/entities/outbox-event.entity.ts
+++ b/src/events/entities/outbox-event.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('outbox_events')
+@Index('idx_outbox_events_published_at', ['publishedAt'])
+export class OutboxEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'event_name', length: 128 })
+  eventName!: string;
+
+  @Column({ type: 'jsonb' })
+  payload!: Record<string, unknown>;
+
+  @Column({ name: 'metadata', type: 'jsonb', nullable: true })
+  metadata?: Record<string, unknown>;
+
+  @Column({ name: 'correlation_id', nullable: true, length: 128 })
+  correlationId?: string;
+
+  @Column({ name: 'attempts', type: 'int', default: 0 })
+  attempts!: number;
+
+  @Column({ name: 'published_at', type: 'timestamp', nullable: true })
+  publishedAt?: Date;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,6 +1,7 @@
 import { Module, Global } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
 import { EventEmitterService } from './event-emitter.service';
 import { EventReplayService } from './event-replay.service';
 import { EventSerializerService } from './event-serializer';
@@ -10,10 +11,14 @@ import { PortfolioEventListener } from './listeners/portfolio-event.listener';
 import { ReferralEventListener } from './referral-event.listener';
 import { ReferralsModule } from '../referrals/referrals.module';
 import { AuditLog } from '../audit-log/entities/audit-log.entity';
+import { OutboxEvent } from './entities/outbox-event.entity';
+import { OutboxService } from './outbox.service';
+import { OutboxPublisherService } from './outbox-publisher.service';
 
 @Global()
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     EventEmitterModule.forRoot({
       global: true,
       wildcard: false,
@@ -24,7 +29,7 @@ import { AuditLog } from '../audit-log/entities/audit-log.entity';
       verboseMemoryLeak: true,
       ignoreErrors: false,
     }),
-    TypeOrmModule.forFeature([AuditLog]),
+    TypeOrmModule.forFeature([AuditLog, OutboxEvent]),
     ReferralsModule,
   ],
   providers: [
@@ -35,7 +40,9 @@ import { AuditLog } from '../audit-log/entities/audit-log.entity';
     SignalEventListener,
     PortfolioEventListener,
     ReferralEventListener,
+    OutboxService,
+    OutboxPublisherService,
   ],
-  exports: [EventEmitterService, EventReplayService, EventSerializerService],
+  exports: [EventEmitterService, EventReplayService, EventSerializerService, OutboxService],
 })
 export class EventsModule {}

--- a/src/events/outbox-publisher.service.ts
+++ b/src/events/outbox-publisher.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { OutboxService } from './outbox.service';
+
+@Injectable()
+export class OutboxPublisherService {
+  private readonly logger = new Logger(OutboxPublisherService.name);
+
+  constructor(private readonly outboxService: OutboxService) {}
+
+  @Cron(CronExpression.EVERY_10_SECONDS)
+  async handlePendingEvents(): Promise<void> {
+    try {
+      await this.outboxService.publishPending();
+    } catch (error) {
+      this.logger.error(
+        'Outbox publisher failed to process pending events',
+        (error as Error).stack,
+      );
+    }
+  }
+}

--- a/src/events/outbox.service.ts
+++ b/src/events/outbox.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, EntityManager } from 'typeorm';
+import { EventEmitterService } from './event-emitter.service';
+import { BaseEvent } from './base.event';
+import { OutboxEvent } from './entities/outbox-event.entity';
+
+@Injectable()
+export class OutboxService {
+  private readonly logger = new Logger(OutboxService.name);
+
+  constructor(
+    @InjectRepository(OutboxEvent)
+    private readonly outboxRepository: Repository<OutboxEvent>,
+    private readonly eventEmitter: EventEmitterService,
+  ) {}
+
+  async enqueue(event: BaseEvent, manager?: EntityManager): Promise<OutboxEvent> {
+    const repository = manager ? manager.getRepository(OutboxEvent) : this.outboxRepository;
+    const outbox = repository.create({
+      eventName: event.eventName,
+      payload: event,
+      metadata: { timestamp: event.timestamp.toISOString() },
+      correlationId: event.correlationId,
+      attempts: 0,
+    });
+
+    return repository.save(outbox);
+  }
+
+  async publishPending(limit = 50): Promise<void> {
+    const pendingEvents = await this.outboxRepository.find({
+      where: { publishedAt: null },
+      order: { createdAt: 'ASC' },
+      take: limit,
+    });
+
+    if (!pendingEvents.length) {
+      return;
+    }
+
+    for (const eventRow of pendingEvents) {
+      try {
+        const replayEvent = new ReplayableEvent(
+          eventRow.eventName,
+          eventRow.payload,
+          eventRow.correlationId,
+        );
+
+        await this.eventEmitter.emit(replayEvent);
+
+        eventRow.publishedAt = new Date();
+        eventRow.attempts = (eventRow.attempts ?? 0) + 1;
+
+        await this.outboxRepository.save(eventRow);
+        this.logger.log(`Published outbox event ${eventRow.eventName} (id=${eventRow.id})`);
+      } catch (error) {
+        eventRow.attempts = (eventRow.attempts ?? 0) + 1;
+        await this.outboxRepository.save(eventRow);
+        this.logger.error(
+          `Outbox publish failed for ${eventRow.eventName} (id=${eventRow.id})`,
+          (error as Error).stack,
+        );
+      }
+    }
+  }
+}
+
+class ReplayableEvent extends BaseEvent {
+  readonly eventName: string;
+
+  constructor(eventName: string, payload: unknown, correlationId?: string) {
+    super(correlationId);
+    this.eventName = eventName;
+    Object.assign(this, payload);
+  }
+
+  validate(): void {
+    return;
+  }
+}

--- a/src/events/portfolio.events.ts
+++ b/src/events/portfolio.events.ts
@@ -1,0 +1,75 @@
+import { BaseEvent, EventMetadata } from './base.event';
+import { IsNotEmpty, IsOptional, IsString, validateSync } from 'class-validator';
+
+export class PortfolioTransactionCreatedEvent extends BaseEvent {
+  readonly eventName = 'portfolio.transaction.created';
+
+  @IsNotEmpty()
+  @IsString()
+  readonly tradeId!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly userId!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly signalId!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly baseAsset!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly counterAsset!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly amount!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly entryPrice!: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly totalValue!: string;
+
+  @IsString()
+  @IsOptional()
+  readonly feeAmount?: string;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly status!: string;
+
+  @IsOptional()
+  readonly metadata?: EventMetadata;
+
+  constructor(data: {
+    tradeId: string;
+    userId: string;
+    signalId: string;
+    baseAsset: string;
+    counterAsset: string;
+    amount: string;
+    entryPrice: string;
+    totalValue: string;
+    feeAmount?: string;
+    status: string;
+    metadata?: EventMetadata;
+    correlationId?: string;
+  }) {
+    super(data.correlationId);
+    Object.assign(this, data);
+    this.validate();
+  }
+
+  validate(): void {
+    const errors = validateSync(this);
+    if (errors.length > 0) {
+      throw new Error(`Portfolio transaction event validation failed: ${JSON.stringify(errors)}`);
+    }
+  }
+}

--- a/src/health/indicators/soroban.health.ts
+++ b/src/health/indicators/soroban.health.ts
@@ -21,7 +21,7 @@ export class SorobanHealthIndicator extends HealthIndicator {
         this.stellarConfig.sorobanRpcUrl,
       );
 
-      const health = await server.getHealth();
+      const health = await this.withTimeout(server.getHealth(), 5000);
 
       const latency = Date.now() - startTime;
 
@@ -47,6 +47,24 @@ export class SorobanHealthIndicator extends HealthIndicator {
           latency: `${latency}ms`,
         }),
       );
+    }
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timeoutHandle: NodeJS.Timeout | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new Error(`Soroban RPC health check timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 }

--- a/src/portfolio/portfolio.controller.ts
+++ b/src/portfolio/portfolio.controller.ts
@@ -10,6 +10,7 @@ import {
 import { PortfolioService } from './portfolio.service';
 import { RebalancingService } from './services/rebalancing.service';
 import { PositionDetailDto } from './dto/position-detail.dto';
+import { applySparseFieldset } from '../common/utils/field-selection.util';
 import { PortfolioSummaryDto } from './dto/portfolio-summary.dto';
 import { SetTargetAllocationDto, TargetAllocationResponseDto } from './dto/target-allocation.dto';
 import {
@@ -34,11 +35,16 @@ export class PortfolioController {
   ) { }
 
   @Get('positions')
-  async getPositions(@Query('userId') userId: string): Promise<PositionDetailDto[]> {
+  async getPositions(
+    @Query('userId') userId: string,
+    @Query('fields') fields?: string,
+  ): Promise<PositionDetailDto[]> {
     if (!userId) {
       throw new BadRequestException('userId is required');
     }
-    return this.portfolioService.getPositions(userId);
+
+    const positions = await this.portfolioService.getPositions(userId);
+    return applySparseFieldset(positions, fields);
   }
 
   @Get('history')
@@ -46,6 +52,7 @@ export class PortfolioController {
     @Query('userId') userId: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+    @Query('fields') fields?: string,
   ): Promise<{ data: Trade[]; total: number; page: number; limit: number; totalPages: number }> {
     if (!userId) {
       throw new BadRequestException('userId is required');
@@ -55,17 +62,23 @@ export class PortfolioController {
     }
 
     const result = await this.portfolioService.getHistory(userId, page, limit);
-    return {
+    const response = {
       ...result,
       page,
       limit,
       totalPages: Math.ceil(result.total / limit),
     };
+
+    return applySparseFieldset(response, fields);
   }
 
   @Get('performance')
-  async getPerformance(@Request() req: any): Promise<PortfolioSummaryDto> {
-    return this.portfolioService.getPerformance(req.user.id);
+  async getPerformance(
+    @Request() req: any,
+    @Query('fields') fields?: string,
+  ): Promise<PortfolioSummaryDto> {
+    const performance = await this.portfolioService.getPerformance(req.user.id);
+    return applySparseFieldset(performance, fields);
   }
 
   @Get('summary/:walletAddress')
@@ -75,8 +88,10 @@ export class PortfolioController {
   @ApiResponse({ status: 404, description: 'No account found for wallet' })
   async getWalletSummary(
     @Param('walletAddress') walletAddress: string,
+    @Query('fields') fields?: string,
   ): Promise<PortfolioSummaryDto & { walletAddress: string }> {
-    return this.portfolioService.getWalletSummary(walletAddress);
+    const summary = await this.portfolioService.getWalletSummary(walletAddress);
+    return applySparseFieldset(summary, fields);
   }
 
   @Get('export')
@@ -102,8 +117,10 @@ export class PortfolioController {
   async getChartData(
     @Request() req: any,
     @Query('days', new DefaultValuePipe(30), ParseIntPipe) days: number,
+    @Query('fields') fields?: string,
   ) {
-    return this.portfolioService.getChartData(req.user.id, days);
+    const chartData = await this.portfolioService.getChartData(req.user.id, days);
+    return applySparseFieldset(chartData, fields);
   }
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/src/portfolio/portfolio.service.spec.ts
+++ b/src/portfolio/portfolio.service.spec.ts
@@ -9,6 +9,7 @@ import { User } from '../users/entities/user.entity';
 import { PnlHistory } from './entities/pnl-history.entity';
 import { PriceService } from '../shared/price.service';
 import { PnlCalculatorService } from './services/pnl-calculator.service';
+import { OutboxService } from '../events/outbox.service';
 
 const VALID_WALLET = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBKM6GS6HMDE';
 
@@ -21,13 +22,28 @@ describe('PortfolioService', () => {
   let mockPriceService: any;
   let mockCacheManager: any;
   let mockPnlCalculator: any;
+  let mockOutboxService: any;
 
   beforeEach(async () => {
+    const mockOutboxRepository = {
+      create: jest.fn((entity: unknown, dto: unknown) => dto),
+      save: jest.fn().mockResolvedValue({ id: 'outbox-event-1' }),
+    };
+
     mockTradeRepository = {
       find: jest.fn(),
       findAndCount: jest.fn(),
-      create: jest.fn(),
-      save: jest.fn(),
+      create: jest.fn((dto) => dto),
+      save: jest.fn().mockImplementation(async (trade) => ({ ...trade, id: 'trade-1' })),
+      manager: {
+        transaction: jest.fn().mockImplementation(async (fn) =>
+          fn({
+            create: jest.fn((entity: unknown, dto: unknown) => dto),
+            save: jest.fn().mockImplementation(async (entity: unknown) => ({ ...entity, id: 'trade-1' })),
+            getRepository: jest.fn().mockReturnValue(mockOutboxRepository),
+          }),
+        ),
+      },
     };
 
     mockPositionRepository = {
@@ -63,6 +79,10 @@ describe('PortfolioService', () => {
       calculatePortfolioPnl: jest.fn().mockReturnValue({ realizedPnL: 0, unrealizedPnL: 0 }),
     };
 
+    mockOutboxService = {
+      enqueue: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PortfolioService,
@@ -94,6 +114,10 @@ describe('PortfolioService', () => {
           provide: CACHE_MANAGER,
           useValue: mockCacheManager,
         },
+        {
+          provide: OutboxService,
+          useValue: mockOutboxService,
+        },
       ],
     }).compile();
 
@@ -124,6 +148,25 @@ describe('PortfolioService', () => {
       const result = await service.getPositions('user-id');
       
       expect(result[0].unrealizedPnL).toBe(2); // (0.12 - 0.1) * 100
+    });
+  });
+
+  describe('addTransaction', () => {
+    it('should save a trade and enqueue an outbox event', async () => {
+      const dto = {
+        side: 'buy',
+        baseAsset: 'XLM',
+        counterAsset: 'USDC',
+        amount: 100,
+        entryPrice: 0.1,
+        feeAmount: 0.5,
+      };
+
+      const result = await service.addTransaction('user-id', dto as any);
+
+      expect(result).toMatchObject({ id: 'trade-1' });
+      expect(mockOutboxService.enqueue).toHaveBeenCalledTimes(1);
+      expect(mockCacheManager.del).toHaveBeenCalledWith('portfolio_performance_user-id');
     });
   });
 

--- a/src/portfolio/portfolio.service.ts
+++ b/src/portfolio/portfolio.service.ts
@@ -1,13 +1,14 @@
-import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, EntityManager } from 'typeorm';
 import { Trade, TradeStatus } from '../trades/entities/trade.entity';
 import { User } from '../users/entities/user.entity';
 import { PriceService } from '../shared/price.service';
+import { OutboxService } from '../events/outbox.service';
+import { PortfolioTransactionCreatedEvent } from '../events/portfolio.events';
 import { PositionDetailDto } from './dto/position-detail.dto';
 import { PortfolioSummaryDto, TradeDetail } from './dto/portfolio-summary.dto';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 import { PnlCalculatorService } from './services/pnl-calculator.service';
 import { AddTransactionDto } from './dto/add-transaction.dto';
@@ -28,6 +29,7 @@ export class PortfolioService {
     private priceService: PriceService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private pnlCalculator: PnlCalculatorService,
+    private readonly outboxService: OutboxService,
   ) {}
 
   async getPositions(userId: string): Promise<PositionDetailDto[]> {
@@ -167,21 +169,42 @@ export class PortfolioService {
   // Unrealized PnL is delegated to PnlCalculatorService for fee inclusion.
 
   async addTransaction(userId: string, dto: AddTransactionDto): Promise<Trade> {
-    const trade = this.tradeRepository.create({
-      userId,
-      signalId: dto.signalId ?? '00000000-0000-0000-0000-000000000000',
-      side: dto.side,
-      baseAsset: dto.baseAsset,
-      counterAsset: dto.counterAsset,
-      amount: String(dto.amount),
-      entryPrice: String(dto.entryPrice),
-      totalValue: String(dto.amount * dto.entryPrice),
-      feeAmount: String(dto.feeAmount ?? 0),
-      status: TradeStatus.PENDING,
+    const saved = await this.tradeRepository.manager.transaction(async (manager: EntityManager) => {
+      const trade = manager.create(Trade, {
+        userId,
+        signalId: dto.signalId ?? '00000000-0000-0000-0000-000000000000',
+        side: dto.side,
+        baseAsset: dto.baseAsset,
+        counterAsset: dto.counterAsset,
+        amount: String(dto.amount),
+        entryPrice: String(dto.entryPrice),
+        totalValue: String(dto.amount * dto.entryPrice),
+        feeAmount: String(dto.feeAmount ?? 0),
+        status: TradeStatus.PENDING,
+      });
+
+      const savedTrade = await manager.save(trade);
+
+      await this.outboxService.enqueue(
+        new PortfolioTransactionCreatedEvent({
+          tradeId: savedTrade.id,
+          userId,
+          signalId: savedTrade.signalId,
+          baseAsset: savedTrade.baseAsset,
+          counterAsset: savedTrade.counterAsset,
+          amount: savedTrade.amount,
+          entryPrice: savedTrade.entryPrice,
+          totalValue: savedTrade.totalValue,
+          feeAmount: savedTrade.feeAmount,
+          status: savedTrade.status,
+          correlationId: savedTrade.id,
+        }),
+        manager,
+      );
+
+      return savedTrade;
     });
 
-    const saved = await this.tradeRepository.save(trade);
-    // Invalidate portfolio cache for this user
     await this.cacheManager.del(`portfolio_performance_${userId}`);
     return saved;
   }

--- a/src/signal-feed/dto/signal-feed-query.dto.ts
+++ b/src/signal-feed/dto/signal-feed-query.dto.ts
@@ -44,4 +44,9 @@ export class SignalFeedQueryDto {
   @IsOptional()
   @IsEnum(SortBy)
   sortBy?: SortBy = SortBy.RANKED;
+
+  @ApiPropertyOptional({ description: 'Comma-separated list of fields to include in each signal item or top-level response' })
+  @IsOptional()
+  @IsString()
+  fields?: string;
 }

--- a/src/signal-feed/signals.controller.ts
+++ b/src/signal-feed/signals.controller.ts
@@ -6,6 +6,7 @@ import { FeedAnalyticsService } from './feed-analytics.service';
 import { SignalFeedQueryDto } from './dto/signal-feed-query.dto';
 import { SignalFeedResponseDto } from './dto/signal-feed-response.dto';
 import { FeedInteractionDto } from './dto/feed-interaction.dto';
+import { applySparseFieldset } from '../common/utils/field-selection.util';
 
 @ApiTags('signals')
 @Controller('signals')
@@ -22,7 +23,8 @@ export class SignalsController {
     @Query(new ValidationPipe({ transform: true, whitelist: true }))
     query: SignalFeedQueryDto,
   ): Promise<SignalFeedResponseDto> {
-    return this.signalsService.getFeed(query);
+    const feed = await this.signalsService.getFeed(query);
+    return applySparseFieldset(feed, query.fields);
   }
 
   @Post('interactions')

--- a/src/soroban/soroban.service.ts
+++ b/src/soroban/soroban.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   Logger,
+  OnModuleInit,
 } from '@nestjs/common';
 import {
   SorobanRpc,
@@ -48,7 +49,7 @@ interface InvokeOptions {
 }
 
 @Injectable()
-export class SorobanService {
+export class SorobanService implements OnModuleInit {
   private readonly logger = new Logger(SorobanService.name);
   private readonly server: SorobanRpc.Server;
 
@@ -58,6 +59,26 @@ export class SorobanService {
     private readonly diagnosticService: SorobanDiagnosticService,
   ) {
     this.server = new SorobanRpc.Server(this.stellarConfig.sorobanRpcUrl);
+  }
+
+  async onModuleInit(): Promise<void> {
+    try {
+      const startTime = Date.now();
+      const health = await this.withTimeout(
+        this.server.getHealth(),
+        'warmup',
+        5000,
+      );
+      const latency = Date.now() - startTime;
+      this.logger.log(
+        `Soroban RPC warmup completed: ${health.status} (${latency}ms)`,
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown Soroban warmup error';
+      this.logger.warn(
+        `Soroban RPC warmup failed: ${errorMessage}`,
+      );
+    }
   }
 
   async invokeContract(

--- a/src/stellar/services/event-processor.service.ts
+++ b/src/stellar/services/event-processor.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { BaseEvent } from '../../events/base.event';
+import { OutboxService } from '../../events/outbox.service';
 import { 
   HorizonStreamEvent, 
   HorizonTransaction, 
@@ -17,7 +18,7 @@ import {
 export class EventProcessorService {
   private readonly logger = new Logger(EventProcessorService.name);
 
-  constructor(private eventEmitter: EventEmitter2) {}
+  constructor(private readonly outboxService: OutboxService) {}
 
   @OnEvent('horizon.transaction')
   async handleTransactionEvent(payload: { accountId: string; event: HorizonStreamEvent }): Promise<void> {
@@ -50,9 +51,14 @@ export class EventProcessorService {
       const processedEvent = await this.processEffect(accountId, effect);
       
       if (processedEvent) {
-        // Emit processed event
-        this.eventEmitter.emit(`stellar.${processedEvent.eventType}`, processedEvent);
-        this.logger.debug(`Processed ${processedEvent.eventType} event for account ${accountId}`);
+        await this.outboxService.enqueue(
+          new StellarProcessedEvent(
+            `stellar.${processedEvent.eventType}`,
+            processedEvent,
+            processedEvent.eventId,
+          ),
+        );
+        this.logger.debug(`Queued processed ${processedEvent.eventType} event for account ${accountId}`);
       }
       
     } catch (error) {
@@ -78,7 +84,13 @@ export class EventProcessorService {
         },
       };
 
-      this.eventEmitter.emit('stellar.transaction.confirmed', processedEvent);
+      await this.outboxService.enqueue(
+        new StellarProcessedEvent(
+          'stellar.transaction.confirmed',
+          processedEvent,
+          processedEvent.eventId,
+        ),
+      );
       
     } catch (error) {
       this.logger.error(`Error processing transaction operations:`, error);
@@ -315,5 +327,19 @@ export class EventProcessorService {
     }
     
     return true;
+  }
+}
+
+class StellarProcessedEvent extends BaseEvent {
+  readonly eventName: string;
+
+  constructor(eventName: string, payload: unknown, correlationId?: string) {
+    super(correlationId);
+    this.eventName = eventName;
+    Object.assign(this, payload);
+  }
+
+  validate(): void {
+    return;
   }
 }


### PR DESCRIPTION
closes #661 
closes #664 
closes #666 
closes #674

# PR Description

## Summary

Implemented the requested backend improvements for Stellar event handling and API response shaping.

## What Changed

- Added Soroban RPC warmup on `OnModuleInit` in `soroban.service.ts`
- Added a custom Terminus Soroban health indicator in `soroban.health.ts` with timeout-aware liveness checks
- Added transactional outbox persistence and publisher support:
  - `outbox.service.ts`
  - `outbox-publisher.service.ts`
  - `outbox-event.entity.ts`
  - `portfolio.events.ts`
- Integrated outbox enqueueing into Stellar event processing in `event-processor.service.ts`
- Added sparse fieldset support for query-driven response shaping:
  - `field-selection.util.ts`
  - `portfolio.controller.ts`
  - `signals.controller.ts`
  - `signal-feed-query.dto.ts`
- Updated module registration in `events.module.ts`
- Added/updated test coverage in `portfolio.service.spec.ts`

## Why

- Ensure Soroban RPC readiness at startup and surface healthy/unhealthy RPC state
- Make Stellar-generated events more reliable by persisting them transactionally before publishing
- Allow clients to request only selected fields from portfolio and signal feed endpoints

## Notes

This change is ready for review and integration. The code is staged across the event, Soroban, and API layers.