### PR TITLE
feat(prices): pluggable price oracle providers via dynamic module

### DIFF
--- a/src/prices/interfaces/price-oracle-provider.interface.ts
+++ b/src/prices/interfaces/price-oracle-provider.interface.ts
@@ -1,0 +1,41 @@
+import { PriceSourceResult } from '../dto/price-data.dto';
+
+/**
+ * Injection token used by consumers to obtain the active price oracle
+ * provider, regardless of which strategy is configured.
+ */
+export const PRICE_ORACLE_PROVIDER = Symbol('PRICE_ORACLE_PROVIDER');
+
+/**
+ * Internal token holding the resolved module options.
+ */
+export const PRICE_ORACLE_OPTIONS = Symbol('PRICE_ORACLE_OPTIONS');
+
+/**
+ * Common contract every pluggable price oracle provider must satisfy.
+ */
+export interface PriceOracleProvider {
+  getPrice(assetPair: string): Promise<PriceSourceResult>;
+}
+
+/**
+ * Selectable oracle provider strategies. Adding a new strategy only
+ * requires registering it in the module's strategy map.
+ */
+export enum PriceOracleStrategy {
+  SDEX = 'sdex',
+  COINGECKO = 'coingecko',
+  STELLAR_EXPERT = 'stellar-expert',
+}
+
+export interface PriceOracleModuleOptions {
+  strategy: PriceOracleStrategy;
+}
+
+export interface PriceOracleModuleAsyncOptions {
+  imports?: any[];
+  inject?: any[];
+  useFactory: (
+    ...args: any[]
+  ) => Promise<PriceOracleModuleOptions> | PriceOracleModuleOptions;
+}

--- a/src/prices/price-oracle.module.ts
+++ b/src/prices/price-oracle.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
 import { CacheModule } from '@nestjs/cache-manager';
@@ -10,6 +10,37 @@ import { PriceHistory } from './entities/price-history.entity';
 import { SdexPriceProvider } from './providers/sdex-price.provider';
 import { CoinGeckoPriceProvider } from './providers/coingecko-price.provider';
 import { StellarExpertPriceProvider } from './providers/stellar-expert-price.provider';
+import {
+  PRICE_ORACLE_OPTIONS,
+  PRICE_ORACLE_PROVIDER,
+  PriceOracleModuleAsyncOptions,
+  PriceOracleModuleOptions,
+  PriceOracleProvider,
+  PriceOracleStrategy,
+} from './interfaces/price-oracle-provider.interface';
+
+/**
+ * Maps a configured strategy to its concrete provider implementation.
+ * Register new strategies here only - consumers stay untouched.
+ */
+const STRATEGY_PROVIDERS: Record<
+  PriceOracleStrategy,
+  Type<PriceOracleProvider>
+> = {
+  [PriceOracleStrategy.SDEX]: SdexPriceProvider,
+  [PriceOracleStrategy.COINGECKO]: CoinGeckoPriceProvider,
+  [PriceOracleStrategy.STELLAR_EXPERT]: StellarExpertPriceProvider,
+};
+
+function resolveStrategyProvider(
+  strategy: PriceOracleStrategy,
+): Type<PriceOracleProvider> {
+  const provider = STRATEGY_PROVIDERS[strategy];
+  if (!provider) {
+    throw new Error(`Unknown price oracle strategy: ${strategy}`);
+  }
+  return provider;
+}
 
 @Module({
   imports: [
@@ -31,4 +62,66 @@ import { StellarExpertPriceProvider } from './providers/stellar-expert-price.pro
   ],
   exports: [PriceOracleService],
 })
-export class PriceOracleModule {}
+export class PriceOracleModule {
+  /**
+   * Register the module with a statically configured oracle strategy.
+   * Consumers inject `PRICE_ORACLE_PROVIDER`; switching the active
+   * implementation is a single config change here.
+   */
+  static forRoot(options: PriceOracleModuleOptions): DynamicModule {
+    const strategyProvider: Provider = {
+      provide: PRICE_ORACLE_PROVIDER,
+      useExisting: resolveStrategyProvider(options.strategy),
+    };
+
+    return {
+      module: PriceOracleModule,
+      providers: [strategyProvider],
+      exports: [PRICE_ORACLE_PROVIDER],
+    };
+  }
+
+  /**
+   * Register the module with an asynchronously resolved strategy
+   * (e.g. read from ConfigService at runtime).
+   */
+  static forRootAsync(options: PriceOracleModuleAsyncOptions): DynamicModule {
+    const optionsProvider: Provider = {
+      provide: PRICE_ORACLE_OPTIONS,
+      useFactory: options.useFactory,
+      inject: options.inject || [],
+    };
+
+    const strategyProvider: Provider = {
+      provide: PRICE_ORACLE_PROVIDER,
+      useFactory: (
+        opts: PriceOracleModuleOptions,
+        sdex: SdexPriceProvider,
+        coingecko: CoinGeckoPriceProvider,
+        stellarExpert: StellarExpertPriceProvider,
+      ): PriceOracleProvider => {
+        const instances: Record<PriceOracleStrategy, PriceOracleProvider> = {
+          [PriceOracleStrategy.SDEX]: sdex,
+          [PriceOracleStrategy.COINGECKO]: coingecko,
+          [PriceOracleStrategy.STELLAR_EXPERT]: stellarExpert,
+        };
+        // Validate the strategy then return the matching instance.
+        resolveStrategyProvider(opts.strategy);
+        return instances[opts.strategy];
+      },
+      inject: [
+        PRICE_ORACLE_OPTIONS,
+        SdexPriceProvider,
+        CoinGeckoPriceProvider,
+        StellarExpertPriceProvider,
+      ],
+    };
+
+    return {
+      module: PriceOracleModule,
+      imports: options.imports || [],
+      providers: [optionsProvider, strategyProvider],
+      exports: [PRICE_ORACLE_PROVIDER],
+    };
+  }
+}

--- a/src/prices/providers/coingecko-price.provider.ts
+++ b/src/prices/providers/coingecko-price.provider.ts
@@ -2,9 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { PriceSourceResult } from '../dto/price-data.dto';
+import { PriceOracleProvider } from '../interfaces/price-oracle-provider.interface';
 
 @Injectable()
-export class CoinGeckoPriceProvider {
+export class CoinGeckoPriceProvider implements PriceOracleProvider {
   private readonly logger = new Logger(CoinGeckoPriceProvider.name);
   private readonly baseUrl = 'https://api.coingecko.com/api/v3';
 

--- a/src/prices/providers/price-oracle-provider.contract.spec.ts
+++ b/src/prices/providers/price-oracle-provider.contract.spec.ts
@@ -1,0 +1,81 @@
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { SdexPriceProvider } from './sdex-price.provider';
+import { CoinGeckoPriceProvider } from './coingecko-price.provider';
+import { StellarExpertPriceProvider } from './stellar-expert-price.provider';
+import { PriceOracleProvider } from '../interfaces/price-oracle-provider.interface';
+
+/**
+ * Verifies every pluggable provider honours the shared
+ * `PriceOracleProvider` contract so they remain interchangeable.
+ */
+describe('PriceOracleProvider contract', () => {
+  describe('CoinGeckoPriceProvider', () => {
+    const httpService = {
+      get: jest.fn(() => of({ data: { stellar: { 'usd-coin': 0.12 } } })),
+    } as unknown as HttpService;
+    const provider: PriceOracleProvider = new CoinGeckoPriceProvider(
+      httpService,
+    );
+
+    it('returns a PriceSourceResult', async () => {
+      const result = await provider.getPrice('XLM-USDC');
+      expect(result).toEqual(
+        expect.objectContaining({
+          price: 0.12,
+          source: 'CoinGecko',
+          timestamp: expect.any(Date),
+        }),
+      );
+    });
+  });
+
+  describe('StellarExpertPriceProvider', () => {
+    const httpService = {
+      get: jest.fn(() => of({ data: { price: '0.13' } })),
+    } as unknown as HttpService;
+    const provider: PriceOracleProvider = new StellarExpertPriceProvider(
+      httpService,
+    );
+
+    it('returns a PriceSourceResult', async () => {
+      const result = await provider.getPrice('XLM-USDC');
+      expect(result).toEqual(
+        expect.objectContaining({
+          price: 0.13,
+          source: 'StellarExpert',
+          timestamp: expect.any(Date),
+        }),
+      );
+    });
+  });
+
+  describe('SdexPriceProvider', () => {
+    const provider: PriceOracleProvider = new SdexPriceProvider();
+
+    beforeEach(() => {
+      (provider as unknown as SdexPriceProvider)['server'] = {
+        orderbook: () => ({
+          limit: () => ({
+            call: () =>
+              Promise.resolve({
+                bids: [{ price: '0.10' }],
+                asks: [{ price: '0.12' }],
+              }),
+          }),
+        }),
+      } as never;
+    });
+
+    it('returns a PriceSourceResult', async () => {
+      const result = await provider.getPrice('XLM-USDC');
+      expect(result).toEqual(
+        expect.objectContaining({
+          price: 0.11,
+          source: 'SDEX',
+          timestamp: expect.any(Date),
+        }),
+      );
+    });
+  });
+});

--- a/src/prices/providers/sdex-price.provider.ts
+++ b/src/prices/providers/sdex-price.provider.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Server } from 'stellar-sdk';
 import { PriceSourceResult } from '../dto/price-data.dto';
+import { PriceOracleProvider } from '../interfaces/price-oracle-provider.interface';
 
 @Injectable()
-export class SdexPriceProvider {
+export class SdexPriceProvider implements PriceOracleProvider {
   private readonly logger = new Logger(SdexPriceProvider.name);
   private readonly server: Server;
 

--- a/src/prices/providers/stellar-expert-price.provider.ts
+++ b/src/prices/providers/stellar-expert-price.provider.ts
@@ -2,9 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { PriceSourceResult } from '../dto/price-data.dto';
+import { PriceOracleProvider } from '../interfaces/price-oracle-provider.interface';
 
 @Injectable()
-export class StellarExpertPriceProvider {
+export class StellarExpertPriceProvider implements PriceOracleProvider {
   private readonly logger = new Logger(StellarExpertPriceProvider.name);
   private readonly baseUrl = 'https://api.stellar.expert/explorer/public';
 


### PR DESCRIPTION
## Summary
Refactors `PriceOracleModule` into a dynamic module exposing `forRoot()`/`forRootAsync()` that bind a configured strategy to a single `PRICE_ORACLE_PROVIDER` injection token. The SDEX, CoinGecko and StellarExpert providers now implement a shared `PriceOracleProvider` interface, so consumers are strategy-agnostic and switching the active oracle is a config-only change.

## Validation
- `prettier --write` on touched files (clean)
- `tsc --noEmit` reports no errors in `src/prices`
- `eslint` 0 errors
- Added `price-oracle-provider.contract.spec.ts` covering all three providers against the shared contract

Closes #665