### PR TITLE
feat(tenancy): request-scoped TypeORM connection provider for tenant schema routing

### DIFF
--- a/src/multitenancy/quota-reporting/quota-reporting.module.ts
+++ b/src/multitenancy/quota-reporting/quota-reporting.module.ts
@@ -4,11 +4,17 @@ import { AuthModule } from '../../auth/auth.module';
 import { TenantUsage } from './entities/tenant-usage.entity';
 import { TenantQuotaService } from './tenant-quota.service';
 import { ReportController } from './report.controller';
+import { TenantDataSourceFactory } from '../../tenancy/tenant-connection.factory';
+import { TenantConnectionProvider } from '../../tenancy/tenant-connection.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([TenantUsage]), AuthModule],
   controllers: [ReportController],
-  providers: [TenantQuotaService],
+  providers: [
+    TenantQuotaService,
+    TenantDataSourceFactory,
+    TenantConnectionProvider,
+  ],
   exports: [TenantQuotaService],
 })
 export class QuotaReportingModule {}

--- a/src/multitenancy/quota-reporting/tenant-quota.service.ts
+++ b/src/multitenancy/quota-reporting/tenant-quota.service.ts
@@ -1,9 +1,10 @@
-import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Between, Repository } from 'typeorm';
 import { TenantUsage, TenantUsageType } from './entities/tenant-usage.entity';
 import { QuotaReportDto, QuotaMetricReportDto } from './dto/quota-report.dto';
 import { QuotaReportRequestDto } from './dto/quota-report-request.dto';
+import { TenantConnectionProvider } from '../../tenancy/tenant-connection.provider';
 
 export interface TenantQuotaRequester {
   id: string;
@@ -24,7 +25,20 @@ export class TenantQuotaService {
   constructor(
     @InjectRepository(TenantUsage)
     private readonly usageRepository: Repository<TenantUsage>,
+    @Optional()
+    private readonly tenantConnection?: TenantConnectionProvider,
   ) {}
+
+  /**
+   * Returns the usage repository scoped to the active tenant's schema when a
+   * tenant connection is available, falling back to the default connection.
+   */
+  private async resolveUsageRepository(): Promise<Repository<TenantUsage>> {
+    if (this.tenantConnection) {
+      return this.tenantConnection.getRepository(TenantUsage);
+    }
+    return this.usageRepository;
+  }
 
   async generateReport(
     requester: TenantQuotaRequester,
@@ -37,7 +51,8 @@ export class TenantQuotaService {
     const periodEnd = request.periodEnd ? new Date(request.periodEnd) : new Date();
     const forecastDays = request.forecastDays ?? this.deriveForecastDays(periodStart, periodEnd);
 
-    const usageRows = await this.usageRepository.find({
+    const usageRepository = await this.resolveUsageRepository();
+    const usageRows = await usageRepository.find({
       where: {
         tenantId,
         recordedAt: Between(periodStart, periodEnd),

--- a/src/tenancy/tenancy.module.ts
+++ b/src/tenancy/tenancy.module.ts
@@ -1,10 +1,22 @@
 import { Module, Global } from '@nestjs/common';
 import { TenantScopingService } from './tenant-scoping.service';
 import { TenantRlsSubscriber } from './tenant-rls.subscriber';
+import { TenantDataSourceFactory } from './tenant-connection.factory';
+import { TenantConnectionProvider } from './tenant-connection.provider';
 
 @Global()
 @Module({
-  providers: [TenantScopingService, TenantRlsSubscriber],
-  exports: [TenantScopingService, TenantRlsSubscriber],
+  providers: [
+    TenantScopingService,
+    TenantRlsSubscriber,
+    TenantDataSourceFactory,
+    TenantConnectionProvider,
+  ],
+  exports: [
+    TenantScopingService,
+    TenantRlsSubscriber,
+    TenantDataSourceFactory,
+    TenantConnectionProvider,
+  ],
 })
 export class TenancyModule {}

--- a/src/tenancy/tenant-connection.factory.ts
+++ b/src/tenancy/tenant-connection.factory.ts
@@ -1,0 +1,58 @@
+/**
+ * TenantDataSourceFactory
+ *
+ * Lazily builds and caches one TypeORM `DataSource` per tenant schema,
+ * cloning the application's default connection options and overriding the
+ * `schema`. Connections are created on first use and reused for the lifetime
+ * of the process so request-scoped consumers stay cheap.
+ */
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+@Injectable()
+export class TenantDataSourceFactory implements OnModuleDestroy {
+  private readonly logger = new Logger(TenantDataSourceFactory.name);
+  private readonly dataSources = new Map<string, DataSource>();
+
+  constructor(
+    @InjectDataSource()
+    private readonly defaultDataSource: DataSource,
+  ) {}
+
+  /**
+   * Returns an initialized DataSource bound to the given tenant schema,
+   * creating and caching it on first use.
+   */
+  async getDataSource(schema: string): Promise<DataSource> {
+    const existing = this.dataSources.get(schema);
+    if (existing) {
+      if (!existing.isInitialized) {
+        await existing.initialize();
+      }
+      return existing;
+    }
+
+    const options = {
+      ...this.defaultDataSource.options,
+      name: `tenant_${schema}`,
+      schema,
+    } as DataSourceOptions;
+
+    const dataSource = new DataSource(options);
+    await dataSource.initialize();
+    this.dataSources.set(schema, dataSource);
+    this.logger.log(`Initialized tenant DataSource for schema "${schema}"`);
+
+    return dataSource;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    for (const dataSource of this.dataSources.values()) {
+      if (dataSource.isInitialized) {
+        await dataSource.destroy();
+      }
+    }
+    this.dataSources.clear();
+  }
+}

--- a/src/tenancy/tenant-connection.provider.spec.ts
+++ b/src/tenancy/tenant-connection.provider.spec.ts
@@ -1,0 +1,81 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { TenantConnectionProvider } from './tenant-connection.provider';
+import { TenantDataSourceFactory } from './tenant-connection.factory';
+
+/**
+ * Fake factory that hands back a distinct repository object per schema so we
+ * can assert that two tenants are routed to isolated data sources.
+ */
+function makeFactory() {
+  const repositoriesBySchema = new Map<string, { schema: string }>();
+  const factory = {
+    getDataSource: jest.fn(async (schema: string) => ({
+      getRepository: jest.fn(() => {
+        const existing = repositoriesBySchema.get(schema);
+        if (existing) return existing;
+        const repo = { schema };
+        repositoriesBySchema.set(schema, repo);
+        return repo;
+      }),
+    })),
+  } as unknown as TenantDataSourceFactory;
+  return { factory, repositoriesBySchema };
+}
+
+class Entity {}
+
+describe('TenantConnectionProvider', () => {
+  it('resolves the schema from the JWT tenantId claim', () => {
+    const { factory } = makeFactory();
+    const provider = new TenantConnectionProvider(
+      { user: { tenantId: 'Acme' } },
+      factory,
+    );
+
+    expect(provider.getTenantId()).toBe('Acme');
+    expect(provider.getSchemaName()).toBe('tenant_acme');
+  });
+
+  it('falls back to the X-Tenant-ID header', () => {
+    const { factory } = makeFactory();
+    const provider = new TenantConnectionProvider(
+      { headers: { 'x-tenant-id': 'globex' } },
+      factory,
+    );
+
+    expect(provider.getSchemaName()).toBe('tenant_globex');
+  });
+
+  it('rejects requests without a resolvable tenant', () => {
+    const { factory } = makeFactory();
+    const provider = new TenantConnectionProvider({ headers: {} }, factory);
+
+    expect(() => provider.getTenantId()).toThrow(UnauthorizedException);
+  });
+
+  it('routes two different tenants to isolated data sources', async () => {
+    const { factory } = makeFactory();
+
+    const tenantA = new TenantConnectionProvider(
+      { user: { tenantId: 'alpha' } },
+      factory,
+    );
+    const tenantB = new TenantConnectionProvider(
+      { user: { tenantId: 'beta' } },
+      factory,
+    );
+
+    const repoA = (await tenantA.getRepository(Entity)) as unknown as {
+      schema: string;
+    };
+    const repoB = (await tenantB.getRepository(Entity)) as unknown as {
+      schema: string;
+    };
+
+    expect(repoA.schema).toBe('tenant_alpha');
+    expect(repoB.schema).toBe('tenant_beta');
+    expect(repoA).not.toBe(repoB);
+    expect(factory.getDataSource).toHaveBeenCalledWith('tenant_alpha');
+    expect(factory.getDataSource).toHaveBeenCalledWith('tenant_beta');
+  });
+});

--- a/src/tenancy/tenant-connection.provider.ts
+++ b/src/tenancy/tenant-connection.provider.ts
@@ -1,0 +1,65 @@
+/**
+ * TenantConnectionProvider
+ *
+ * Request-scoped provider that resolves the tenant identifier from the
+ * authenticated request (JWT `tenantId` claim, falling back to the
+ * `X-Tenant-ID` header) and exposes a TypeORM `DataSource`/`Repository`
+ * bound to that tenant's schema. Feature modules inject this provider
+ * instead of managing tenant routing themselves.
+ *
+ * Requests without a resolvable tenant are rejected with a clear error.
+ */
+import {
+  Inject,
+  Injectable,
+  Scope,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { DataSource, EntityTarget, ObjectLiteral, Repository } from 'typeorm';
+import { TenantDataSourceFactory } from './tenant-connection.factory';
+
+@Injectable({ scope: Scope.REQUEST })
+export class TenantConnectionProvider {
+  constructor(
+    @Inject(REQUEST) private readonly request: Record<string, any>,
+    private readonly factory: TenantDataSourceFactory,
+  ) {}
+
+  /** Resolves the tenant id from the request, or throws if absent. */
+  getTenantId(): string {
+    const tenantId =
+      this.request?.user?.tenantId ??
+      (this.request?.headers?.['x-tenant-id'] as string | undefined);
+
+    if (!tenantId) {
+      throw new UnauthorizedException(
+        'Unable to resolve tenant: missing JWT tenantId claim or X-Tenant-ID header',
+      );
+    }
+
+    return String(tenantId);
+  }
+
+  /** Postgres schema name for the active tenant. */
+  getSchemaName(): string {
+    return `tenant_${this.sanitize(this.getTenantId())}`;
+  }
+
+  /** DataSource bound to the active tenant's schema. */
+  async getDataSource(): Promise<DataSource> {
+    return this.factory.getDataSource(this.getSchemaName());
+  }
+
+  /** Repository for `entity` scoped to the active tenant's schema. */
+  async getRepository<T extends ObjectLiteral>(
+    entity: EntityTarget<T>,
+  ): Promise<Repository<T>> {
+    const dataSource = await this.getDataSource();
+    return dataSource.getRepository(entity);
+  }
+
+  private sanitize(tenantId: string): string {
+    return tenantId.replace(/[^a-zA-Z0-9_]/g, '_').toLowerCase();
+  }
+}


### PR DESCRIPTION
## Summary
Adds a request-scoped `TenantConnectionProvider` (via `REQUEST` injection) that resolves the tenant id from the authenticated request's JWT `tenantId` claim, falling back to the `X-Tenant-ID` header, and exposes a TypeORM `DataSource`/`Repository` bound to that tenant's Postgres schema. A `TenantDataSourceFactory` lazily builds and caches one connection per schema. Requests without a resolvable tenant are rejected with an `UnauthorizedException`. The `quota-reporting` module now reads tenant usage through this provider instead of the default connection.

## Validation
- `tsc --noEmit` reports no errors in touched files
- `prettier` clean on new files
- Added `tenant-connection.provider.spec.ts` covering claim/header resolution, missing-tenant rejection, and isolation between two tenants

Closes #663