### PR TITLE
feat(trades): Idempotency-Key interceptor for safe retry of POST trade requests

### DIFF
--- a/src/common/interceptors/idempotency.interceptor.spec.ts
+++ b/src/common/interceptors/idempotency.interceptor.spec.ts
@@ -1,0 +1,145 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ExecutionContext,
+} from '@nestjs/common';
+import { firstValueFrom, of } from 'rxjs';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+function makeContext(
+  method: string,
+  headers: Record<string, unknown> = {},
+  url = '/trades/execute',
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ method, headers, originalUrl: url }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('IdempotencyInterceptor', () => {
+  it('executes the first request and caches its response', async () => {
+    const interceptor = new IdempotencyInterceptor();
+    const handler: CallHandler = { handle: jest.fn(() => of({ id: 1 })) };
+    const ctx = makeContext('POST', { 'idempotency-key': 'abc' });
+
+    const result = await firstValueFrom(interceptor.intercept(ctx, handler));
+
+    expect(result).toEqual({ id: 1 });
+    expect(handler.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the cached response on repeat without re-running the handler', async () => {
+    const interceptor = new IdempotencyInterceptor();
+    const handler: CallHandler = { handle: jest.fn(() => of({ id: 1 })) };
+
+    const first = await firstValueFrom(
+      interceptor.intercept(
+        makeContext('POST', { 'idempotency-key': 'abc' }),
+        handler,
+      ),
+    );
+    const second = await firstValueFrom(
+      interceptor.intercept(
+        makeContext('POST', { 'idempotency-key': 'abc' }),
+        handler,
+      ),
+    );
+
+    expect(first).toEqual(second);
+    expect(handler.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('serialises concurrent requests with the same key to a single execution', async () => {
+    const interceptor = new IdempotencyInterceptor();
+    let executions = 0;
+    const handler: CallHandler = {
+      handle: jest.fn(() => {
+        executions += 1;
+        return of({ execution: executions });
+      }),
+    };
+
+    const [a, b] = await Promise.all([
+      firstValueFrom(
+        interceptor.intercept(
+          makeContext('POST', { 'idempotency-key': 'dup' }),
+          handler,
+        ),
+      ),
+      firstValueFrom(
+        interceptor.intercept(
+          makeContext('POST', { 'idempotency-key': 'dup' }),
+          handler,
+        ),
+      ),
+    ]);
+
+    expect(executions).toBe(1);
+    expect(a).toEqual(b);
+  });
+
+  it('bypasses caching for non-mutating methods', async () => {
+    const interceptor = new IdempotencyInterceptor();
+    const handler: CallHandler = { handle: jest.fn(() => of('ok')) };
+
+    await firstValueFrom(
+      interceptor.intercept(
+        makeContext('GET', { 'idempotency-key': 'abc' }),
+        handler,
+      ),
+    );
+    await firstValueFrom(
+      interceptor.intercept(
+        makeContext('GET', { 'idempotency-key': 'abc' }),
+        handler,
+      ),
+    );
+
+    expect(handler.handle).toHaveBeenCalledTimes(2);
+  });
+
+  it('proceeds normally when no Idempotency-Key header is present', async () => {
+    const interceptor = new IdempotencyInterceptor();
+    const handler: CallHandler = { handle: jest.fn(() => of('ok')) };
+
+    const result = await firstValueFrom(
+      interceptor.intercept(makeContext('POST', {}), handler),
+    );
+
+    expect(result).toBe('ok');
+  });
+
+  it('rejects an empty Idempotency-Key header', () => {
+    const interceptor = new IdempotencyInterceptor();
+    const handler: CallHandler = { handle: jest.fn(() => of('ok')) };
+
+    expect(() =>
+      interceptor.intercept(
+        makeContext('POST', { 'idempotency-key': '   ' }),
+        handler,
+      ),
+    ).toThrow(BadRequestException);
+  });
+
+  it('re-executes once a cached entry has expired', async () => {
+    const interceptor = new IdempotencyInterceptor(-1); // already expired
+    const handler: CallHandler = { handle: jest.fn(() => of({ id: 1 })) };
+
+    await firstValueFrom(
+      interceptor.intercept(
+        makeContext('POST', { 'idempotency-key': 'abc' }),
+        handler,
+      ),
+    );
+    await firstValueFrom(
+      interceptor.intercept(
+        makeContext('POST', { 'idempotency-key': 'abc' }),
+        handler,
+      ),
+    );
+
+    expect(handler.handle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/common/interceptors/idempotency.interceptor.ts
+++ b/src/common/interceptors/idempotency.interceptor.ts
@@ -1,0 +1,104 @@
+/**
+ * IdempotencyInterceptor
+ *
+ * Protects mutating endpoints (POST/PUT/PATCH/DELETE) against duplicate
+ * execution when clients retry after a timeout. Callers opt in by sending an
+ * `Idempotency-Key` header:
+ *
+ *   • The first request for a given key + route executes normally and its
+ *     response is cached for a configurable TTL.
+ *   • Subsequent requests with the same key return the cached response without
+ *     re-running the handler.
+ *   • Concurrent requests with the same key are serialised so only one
+ *     execution happens; the others await and share its result.
+ *
+ * The cache is in-memory and per-instance, which is sufficient for a single
+ * process; swap the store for a shared cache (e.g. Redis) for multi-instance
+ * deployments.
+ */
+import {
+  BadRequestException,
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, firstValueFrom, from } from 'rxjs';
+
+interface CacheEntry {
+  response: unknown;
+  expiresAt: number;
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_KEY_LENGTH = 255;
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  private readonly store = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+
+  constructor(private readonly ttlMs: number = DEFAULT_TTL_MS) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest();
+    const method = String(request?.method ?? '').toUpperCase();
+
+    if (!MUTATING_METHODS.has(method)) {
+      return next.handle();
+    }
+
+    const rawKey = request?.headers?.['idempotency-key'];
+    if (rawKey === undefined || rawKey === null) {
+      // Idempotency is opt-in: no key means no de-duplication.
+      return next.handle();
+    }
+
+    const key = Array.isArray(rawKey) ? rawKey[0] : rawKey;
+    if (
+      typeof key !== 'string' ||
+      key.trim().length === 0 ||
+      key.length > MAX_KEY_LENGTH
+    ) {
+      throw new BadRequestException('Invalid Idempotency-Key header');
+    }
+
+    const route = request?.originalUrl ?? request?.url ?? '';
+    const cacheKey = `${method}:${route}:${key}`;
+
+    return from(this.resolve(cacheKey, next));
+  }
+
+  private async resolve(cacheKey: string, next: CallHandler): Promise<unknown> {
+    const cached = this.store.get(cacheKey);
+    if (cached) {
+      if (cached.expiresAt > Date.now()) {
+        return cached.response;
+      }
+      this.store.delete(cacheKey);
+    }
+
+    // Serialise concurrent requests for the same key onto one execution.
+    const existing = this.inFlight.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+
+    const execution = (async () => {
+      const response = await firstValueFrom(next.handle());
+      this.store.set(cacheKey, {
+        response,
+        expiresAt: Date.now() + this.ttlMs,
+      });
+      return response;
+    })();
+
+    this.inFlight.set(cacheKey, execution);
+    try {
+      return await execution;
+    } finally {
+      this.inFlight.delete(cacheKey);
+    }
+  }
+}

--- a/src/trades/trades.controller.ts
+++ b/src/trades/trades.controller.ts
@@ -9,9 +9,11 @@ import {
   HttpStatus,
   ParseUUIDPipe,
   UseGuards,
+  UseInterceptors,
   Request,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IdempotencyInterceptor } from '../common/interceptors/idempotency.interceptor';
 import { RateLimit, RateLimitTier } from '../common/decorators/rate-limit.decorator';
 import { TradesService } from './trades.service';
 import { TradeOutcomeService } from './trade-outcome.service';
@@ -31,6 +33,7 @@ import {
 import { PaginatedTradeHistoryDto } from './trade-history.service';
 
 @Controller('trades')
+@UseInterceptors(IdempotencyInterceptor)
 export class TradesController {
   constructor(
     private readonly tradesService: TradesService,


### PR DESCRIPTION
## Summary
Adds `IdempotencyInterceptor` which, on mutating endpoints, reads and validates the `Idempotency-Key` header, caches the first response per key + route for a configurable TTL, returns the cached response on repeats without re-running the handler, and serialises concurrent duplicate requests onto a single execution. Wired into `TradesController`.

## Validation
- `tsc --noEmit` reports no errors in touched files
- `prettier` clean on new files
- Unit tests cover first call, repeat call, concurrent duplicates, non-mutating bypass, missing/invalid key, and TTL expiry

Closes #662