### PR TITLE
feat(trades): CQRS command/query separation for trade execution flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/common": "^10.3.0",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.3.0",
+        "@nestjs/cqrs": "^10.2.8",
         "@nestjs/elasticsearch": "^11.1.0",
         "@nestjs/event-emitter": "^2.0.4",
         "@nestjs/jwt": "^11.0.2",
@@ -2145,6 +2146,34 @@
         }
       }
     },
+    "node_modules/@nestjs/cqrs": {
+      "version": "10.2.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/cqrs/-/cqrs-10.2.8.tgz",
+      "integrity": "sha512-nes4J9duwogme6CzNg8uhF5WVbSKYnNotjhHP+3kJxe6RTzcvJDZN10KpROjWJALEVO5fNmKnkGMecoOfqYzYA==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "11.0.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0",
+        "rxjs": "^7.2.0"
+      }
+    },
+    "node_modules/@nestjs/cqrs/node_modules/uuid": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/elasticsearch": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/elasticsearch/-/elasticsearch-11.1.0.tgz",
@@ -3367,6 +3396,35 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
       }
     },
     "node_modules/@simplewebauthn/server": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
     "admin": "node bin/stellar-admin",
     "export:openapi": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
     "sdk:generate-types": "bash scripts/generate-sdk-types.sh",
-    "sdk:check-drift": "bash scripts/check-sdk-drift.sh"
+    "sdk:check-drift": "bash scripts/check-sdk-drift.sh",
     "migration:ci": "npm run migration:run && npm run seed",
     "seed": "ts-node -r tsconfig-paths/register src/database/seeds/seed.ts",
-    "admin": "node bin/stellar-admin",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "changelog:init": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 --release-count 0",
     "docs:module-graph": "node scripts/generate-module-graph.js"
@@ -47,6 +46,7 @@
     "@nestjs/common": "^10.3.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.3.0",
+    "@nestjs/cqrs": "^10.2.8",
     "@nestjs/elasticsearch": "^11.1.0",
     "@nestjs/event-emitter": "^2.0.4",
     "@nestjs/jwt": "^11.0.2",

--- a/src/trades/cqrs/commands/cancel-trade.command.ts
+++ b/src/trades/cqrs/commands/cancel-trade.command.ts
@@ -1,0 +1,6 @@
+import { CloseTradeDto } from '../../dto/execute-trade.dto';
+
+/** Command to cancel/close an open trade. */
+export class CancelTradeCommand {
+  constructor(public readonly dto: CloseTradeDto) {}
+}

--- a/src/trades/cqrs/commands/execute-trade.command.ts
+++ b/src/trades/cqrs/commands/execute-trade.command.ts
@@ -1,0 +1,6 @@
+import { ExecuteTradeDto } from '../../dto/execute-trade.dto';
+
+/** Command to execute a new trade. */
+export class ExecuteTradeCommand {
+  constructor(public readonly dto: ExecuteTradeDto) {}
+}

--- a/src/trades/cqrs/commands/handlers/cancel-trade.handler.spec.ts
+++ b/src/trades/cqrs/commands/handlers/cancel-trade.handler.spec.ts
@@ -1,0 +1,18 @@
+import { CancelTradeHandler } from './cancel-trade.handler';
+import { CancelTradeCommand } from '../cancel-trade.command';
+import { TradesService } from '../../../trades.service';
+
+describe('CancelTradeHandler', () => {
+  it('delegates to TradesService.closeTrade and returns its result', async () => {
+    const tradesService = {
+      closeTrade: jest.fn().mockResolvedValue({ success: true }),
+    } as unknown as TradesService;
+    const handler = new CancelTradeHandler(tradesService);
+    const dto = { tradeId: 't1', userId: 'u1' } as any;
+
+    const result = await handler.execute(new CancelTradeCommand(dto));
+
+    expect(tradesService.closeTrade).toHaveBeenCalledWith(dto);
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/trades/cqrs/commands/handlers/cancel-trade.handler.ts
+++ b/src/trades/cqrs/commands/handlers/cancel-trade.handler.ts
@@ -1,0 +1,16 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { CancelTradeCommand } from '../cancel-trade.command';
+import { TradesService } from '../../../trades.service';
+import { CloseTradeResultDto } from '../../../dto/trade-result.dto';
+
+@CommandHandler(CancelTradeCommand)
+export class CancelTradeHandler implements ICommandHandler<
+  CancelTradeCommand,
+  CloseTradeResultDto
+> {
+  constructor(private readonly tradesService: TradesService) {}
+
+  execute(command: CancelTradeCommand): Promise<CloseTradeResultDto> {
+    return this.tradesService.closeTrade(command.dto);
+  }
+}

--- a/src/trades/cqrs/commands/handlers/execute-trade.handler.spec.ts
+++ b/src/trades/cqrs/commands/handlers/execute-trade.handler.spec.ts
@@ -1,0 +1,18 @@
+import { ExecuteTradeHandler } from './execute-trade.handler';
+import { ExecuteTradeCommand } from '../execute-trade.command';
+import { TradesService } from '../../../trades.service';
+
+describe('ExecuteTradeHandler', () => {
+  it('delegates to TradesService.executeTrade and returns its result', async () => {
+    const tradesService = {
+      executeTrade: jest.fn().mockResolvedValue({ id: 't1' }),
+    } as unknown as TradesService;
+    const handler = new ExecuteTradeHandler(tradesService);
+    const dto = { userId: 'u1' } as any;
+
+    const result = await handler.execute(new ExecuteTradeCommand(dto));
+
+    expect(tradesService.executeTrade).toHaveBeenCalledWith(dto);
+    expect(result).toEqual({ id: 't1' });
+  });
+});

--- a/src/trades/cqrs/commands/handlers/execute-trade.handler.ts
+++ b/src/trades/cqrs/commands/handlers/execute-trade.handler.ts
@@ -1,0 +1,16 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { ExecuteTradeCommand } from '../execute-trade.command';
+import { TradesService } from '../../../trades.service';
+import { TradeResultDto } from '../../../dto/trade-result.dto';
+
+@CommandHandler(ExecuteTradeCommand)
+export class ExecuteTradeHandler implements ICommandHandler<
+  ExecuteTradeCommand,
+  TradeResultDto
+> {
+  constructor(private readonly tradesService: TradesService) {}
+
+  execute(command: ExecuteTradeCommand): Promise<TradeResultDto> {
+    return this.tradesService.executeTrade(command.dto);
+  }
+}

--- a/src/trades/cqrs/index.ts
+++ b/src/trades/cqrs/index.ts
@@ -1,0 +1,17 @@
+import { ExecuteTradeHandler } from './commands/handlers/execute-trade.handler';
+import { CancelTradeHandler } from './commands/handlers/cancel-trade.handler';
+import { GetTradeStatusHandler } from './queries/handlers/get-trade-status.handler';
+
+export * from './commands/execute-trade.command';
+export * from './commands/cancel-trade.command';
+export * from './queries/get-trade-status.query';
+export { ExecuteTradeHandler } from './commands/handlers/execute-trade.handler';
+export { CancelTradeHandler } from './commands/handlers/cancel-trade.handler';
+export { GetTradeStatusHandler } from './queries/handlers/get-trade-status.handler';
+
+/** All CQRS command/query handlers for the trades module. */
+export const TRADE_CQRS_HANDLERS = [
+  ExecuteTradeHandler,
+  CancelTradeHandler,
+  GetTradeStatusHandler,
+];

--- a/src/trades/cqrs/queries/get-trade-status.query.ts
+++ b/src/trades/cqrs/queries/get-trade-status.query.ts
@@ -1,0 +1,7 @@
+/** Query to look up a trade (and its status) by id for a given user. */
+export class GetTradeStatusQuery {
+  constructor(
+    public readonly tradeId: string,
+    public readonly userId: string,
+  ) {}
+}

--- a/src/trades/cqrs/queries/handlers/get-trade-status.handler.spec.ts
+++ b/src/trades/cqrs/queries/handlers/get-trade-status.handler.spec.ts
@@ -1,0 +1,17 @@
+import { GetTradeStatusHandler } from './get-trade-status.handler';
+import { GetTradeStatusQuery } from '../get-trade-status.query';
+import { TradesService } from '../../../trades.service';
+
+describe('GetTradeStatusHandler', () => {
+  it('delegates to TradesService.getTradeById and returns its result', async () => {
+    const tradesService = {
+      getTradeById: jest.fn().mockResolvedValue({ id: 't1', status: 'OPEN' }),
+    } as unknown as TradesService;
+    const handler = new GetTradeStatusHandler(tradesService);
+
+    const result = await handler.execute(new GetTradeStatusQuery('t1', 'u1'));
+
+    expect(tradesService.getTradeById).toHaveBeenCalledWith('t1', 'u1');
+    expect(result).toEqual({ id: 't1', status: 'OPEN' });
+  });
+});

--- a/src/trades/cqrs/queries/handlers/get-trade-status.handler.ts
+++ b/src/trades/cqrs/queries/handlers/get-trade-status.handler.ts
@@ -1,0 +1,16 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { GetTradeStatusQuery } from '../get-trade-status.query';
+import { TradesService } from '../../../trades.service';
+import { TradeDetailsDto } from '../../../dto/trade-result.dto';
+
+@QueryHandler(GetTradeStatusQuery)
+export class GetTradeStatusHandler implements IQueryHandler<
+  GetTradeStatusQuery,
+  TradeDetailsDto
+> {
+  constructor(private readonly tradesService: TradesService) {}
+
+  execute(query: GetTradeStatusQuery): Promise<TradeDetailsDto> {
+    return this.tradesService.getTradeById(query.tradeId, query.userId);
+  }
+}

--- a/src/trades/trades.controller.ts
+++ b/src/trades/trades.controller.ts
@@ -11,8 +11,14 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RateLimit, RateLimitTier } from '../common/decorators/rate-limit.decorator';
+import {
+  ExecuteTradeCommand,
+  CancelTradeCommand,
+  GetTradeStatusQuery,
+} from './cqrs';
 import { TradesService } from './trades.service';
 import { TradeOutcomeService } from './trade-outcome.service';
 import { TradeOutcomeQueryDto } from './dto/trade-outcome-query.dto';
@@ -38,6 +44,8 @@ export class TradesController {
     private readonly riskManager: RiskManagerService,
     private readonly partialCloseService: PartialCloseService,
     private readonly tradeOutcomeService: TradeOutcomeService,
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
   ) { }
 
   /**
@@ -48,7 +56,7 @@ export class TradesController {
   @HttpCode(HttpStatus.CREATED)
   @RateLimit({ tier: RateLimitTier.TRADE })
   async executeTrade(@Body() dto: ExecuteTradeDto): Promise<TradeResultDto> {
-    return this.tradesService.executeTrade(dto);
+    return this.commandBus.execute(new ExecuteTradeCommand(dto));
   }
 
   /**
@@ -70,7 +78,7 @@ export class TradesController {
   @HttpCode(HttpStatus.OK)
   @RateLimit({ tier: RateLimitTier.TRADE })
   async closeTrade(@Body() dto: CloseTradeDto): Promise<CloseTradeResultDto> {
-    return this.tradesService.closeTrade(dto);
+    return this.commandBus.execute(new CancelTradeCommand(dto));
   }
 
   /**
@@ -93,7 +101,7 @@ export class TradesController {
     @Param('tradeId', ParseUUIDPipe) tradeId: string,
     @Query('userId', ParseUUIDPipe) userId: string,
   ): Promise<TradeDetailsDto> {
-    return this.tradesService.getTradeById(tradeId, userId);
+    return this.queryBus.execute(new GetTradeStatusQuery(tradeId, userId));
   }
 
   /**

--- a/src/trades/trades.module.ts
+++ b/src/trades/trades.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Trade } from './entities/trade.entity';
 import { AdvancedOrder } from './entities/advanced-order.entity';
@@ -40,9 +41,11 @@ import { TradeSagaOrchestrator } from './saga/trade-saga.orchestrator';
 import { TradeSagaStepsFactory } from './saga/trade-saga.steps';
 import { TradeSagaService } from './saga/trade-saga.service';
 import { TradeSagaEntity } from './saga/trade-saga.entity';
+import { TRADE_CQRS_HANDLERS } from './cqrs';
 
 @Module({
   imports: [
+    CqrsModule,
     TypeOrmModule.forFeature([Trade, AdvancedOrder, Signal, TradeSagaEntity]),
     RiskManagerModule,
     ComplianceModule,
@@ -76,6 +79,7 @@ import { TradeSagaEntity } from './saga/trade-saga.entity';
     TradeSagaOrchestrator,
     TradeSagaStepsFactory,
     TradeSagaService,
+    ...TRADE_CQRS_HANDLERS,
   ],
   exports: [TradesService, RiskManagerService, OcoOrderService, IcebergOrderService, PartialCloseService, TradeHistoryService, TradeOutcomeService, TradeAuditService, ConfirmationPollingService, TradeExecutionOrchestratorService, TradeRetryService, TradeExecutorService, TradeSagaService],
 })


### PR DESCRIPTION
## Summary
Introduces `@nestjs/cqrs` and wires `CqrsModule` into the trades module. Trade execution and cancellation become `ExecuteTradeCommand`/`CancelTradeCommand` handled by dedicated `CommandHandler`s, and trade status lookup becomes a `GetTradeStatusQuery` `QueryHandler`. `TradesController` now dispatches via `CommandBus`/`QueryBus` instead of calling service methods directly.

## Validation
- `tsc --noEmit` reports no errors in touched files
- `prettier` clean on new files
- Unit tests cover each command/query handler in isolation

Note: also fixes a pre-existing missing comma in `package.json` scripts that blocked installing the new dependency.

Closes #660