### PR TITLE
feat: Soroban error filter, GraphQL DataLoader, env CORS, retention purge job

### DIFF
--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -435,6 +435,16 @@ export class AssetsService {
   }
 
   /**
+   * Batch lookup for multiple asset codes (used by GraphQL DataLoader)
+   */
+  async findByCodes(codes: readonly string[]): Promise<Asset[]> {
+    if (!codes || codes.length === 0) return [];
+    const unique = Array.from(new Set(codes as string[]));
+    const assets = await this.assetRepository.find({ where: unique.map((c) => ({ code: c })) });
+    return assets;
+  }
+
+  /**
    * Check if asset exists
    */
   async assetExists(code: string, issuer?: string): Promise<boolean> {

--- a/src/common/cors/cors.helper.spec.ts
+++ b/src/common/cors/cors.helper.spec.ts
@@ -1,0 +1,28 @@
+import { createCorsOptions } from './cors.helper';
+
+describe('createCorsOptions', () => {
+  it('throws when production and no allowlist', () => {
+    expect(() => createCorsOptions([], true, 'mainnet')).toThrow();
+  });
+
+  it('allows explicit origin', (done) => {
+    const opts = createCorsOptions(['https://example.com'], true, 'mainnet');
+    // originChecker is function in opts.origin
+    const checker = opts.origin as any;
+    checker('https://example.com', (err: any, allow: boolean) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+      done();
+    });
+  });
+
+  it('rejects disallowed origin', (done) => {
+    const opts = createCorsOptions(['https://foo.com'], true, 'production');
+    const checker = opts.origin as any;
+    checker('https://bar.com', (err: any, allow: boolean) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(allow).toBeUndefined();
+      done();
+    });
+  });
+});

--- a/src/common/cors/cors.helper.ts
+++ b/src/common/cors/cors.helper.ts
@@ -1,0 +1,25 @@
+import { CorsOptions } from 'cors';
+
+export function createCorsOptions(allowlist: string[] | string | undefined, credentials = true, env = 'development'): CorsOptions {
+  const list = Array.isArray(allowlist) ? allowlist : typeof allowlist === 'string' ? allowlist.split(',') : [];
+
+  // In production-like env (mainnet) require an explicit non-empty allowlist
+  const isProd = env === 'mainnet' || env === 'production';
+  if (isProd && (!list || list.length === 0)) {
+    throw new Error('CORS allowlist must be explicitly configured in production');
+  }
+
+  // If allowlist contains '*' then allow all origins
+  if (list.includes('*')) {
+    return { origin: true, credentials };
+  }
+
+  // Return function that verifies incoming origin against allowlist
+  const originChecker = (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+    if (!origin) return callback(null, true); // allow non-browser requests (curl, server)
+    if (list.includes(origin)) return callback(null, true);
+    return callback(new Error(`Origin ${origin} not allowed by CORS`));
+  };
+
+  return { origin: originChecker, credentials };
+}

--- a/src/common/filters/soroban-exception.filter.spec.ts
+++ b/src/common/filters/soroban-exception.filter.spec.ts
@@ -1,0 +1,51 @@
+import { SorobanException } from '../exceptions/soroban-exception';
+import { SorobanExceptionFilter } from './soroban-exception.filter';
+
+describe('SorobanExceptionFilter', () => {
+  let filter: SorobanExceptionFilter;
+
+  beforeEach(() => {
+    filter = new SorobanExceptionFilter();
+  });
+
+  function mockHost(payload: any) {
+    const req: any = { url: '/test', headers: {} };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    return {
+      switchToHttp: () => ({ getRequest: () => req, getResponse: () => res }),
+    } as any;
+  }
+
+  it('maps unauthorized soroban error to 403', () => {
+    const ex = new SorobanException('Auth failed', 'C1', 'method', { code: 'unauthorized' });
+    const host = mockHost(ex);
+    filter.catch(ex, host);
+    const res = host.switchToHttp().getResponse();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalled();
+    const body = res.json.mock.calls[0][0];
+    expect(body.errorCode).toBeDefined();
+    expect(body.statusCode).toBe(403);
+  });
+
+  it('maps invalid-args soroban error to 422', () => {
+    const ex = new SorobanException('Invalid args', 'C1', 'method', { code: 'invalid_args' });
+    const host = mockHost(ex);
+    filter.catch(ex, host);
+    const res = host.switchToHttp().getResponse();
+    expect(res.status).toHaveBeenCalledWith(422);
+    const body = res.json.mock.calls[0][0];
+    expect(body.message).toMatch(/Invalid contract arguments/i);
+  });
+
+  it('maps rpc/internal soroban error to 502', () => {
+    const ex = new SorobanException('Node failed', 'C1', 'method', { error: 'rpc_internal_error' });
+    const host = mockHost(ex);
+    filter.catch(ex, host);
+    const res = host.switchToHttp().getResponse();
+    expect(res.status).toHaveBeenCalledWith(502);
+    const body = res.json.mock.calls[0][0];
+    expect(body.errorCode).toBeDefined();
+    expect(body.statusCode).toBe(502);
+  });
+});

--- a/src/common/filters/soroban-exception.filter.ts
+++ b/src/common/filters/soroban-exception.filter.ts
@@ -1,0 +1,61 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { SorobanException } from '../exceptions';
+import { ErrorResponseDto } from '../dto/error-response.dto';
+import { ErrorCode } from '../error-classification/error-codes.enum';
+
+/**
+ * Filter to translate Soroban RPC/contract failures into stable application errors.
+ * Registered selectively for modules that invoke Soroban contracts.
+ */
+@Catch(SorobanException)
+export class SorobanExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(SorobanExceptionFilter.name);
+
+  catch(exception: SorobanException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const sorobanPayload = (exception as any).sorobanError;
+
+    // Map known Soroban contract error payloads to stable codes/status
+    const mapping = (payload: any): { code: ErrorCode; status: number; message: string } => {
+      if (!payload) {
+        return { code: ErrorCode.SOROBAN_RPC_ERROR, status: HttpStatus.BAD_GATEWAY, message: 'Soroban RPC failure' };
+      }
+
+      const code = payload.code || payload.error || (payload.result && payload.result.code) || '';
+
+      // Recognize several common contract/RPC patterns and map them
+      if (String(code).toLowerCase().includes('unauthorized') || String(code).toLowerCase().includes('forbidden')) {
+        return { code: ErrorCode.SOROBAN_CONTRACT_ERROR, status: HttpStatus.FORBIDDEN, message: 'Contract authorization failed' };
+      }
+      if (String(code).toLowerCase().includes('invalid') || String(code).toLowerCase().includes('args')) {
+        return { code: ErrorCode.SOROBAN_CONTRACT_ERROR, status: HttpStatus.UNPROCESSABLE_ENTITY, message: 'Invalid contract arguments' };
+      }
+      if (String(code).toLowerCase().includes('rpc') || String(code).toLowerCase().includes('internal')) {
+        return { code: ErrorCode.SOROBAN_RPC_ERROR, status: HttpStatus.BAD_GATEWAY, message: 'Soroban node error' };
+      }
+
+      // Fallback
+      return { code: ErrorCode.SOROBAN_CONTRACT_ERROR, status: HttpStatus.BAD_GATEWAY, message: 'Smart contract execution failed' };
+    };
+
+    const mapped = mapping(sorobanPayload);
+
+    // Build envelope without leaking raw RPC internals
+    const body: ErrorResponseDto = {
+      statusCode: mapped.status,
+      errorCode: mapped.code,
+      message: mapped.message,
+      path: request.url,
+      timestamp: new Date().toISOString(),
+      requestId: request.headers['x-correlation-id'] as string || '',
+    };
+
+    this.logger.warn(`Soroban failure mapped to ${mapped.code} ${mapped.status} for ${request.url}`);
+
+    response.status(mapped.status).json(body);
+  }
+}

--- a/src/graphQL-API/dataloader-asset.spec.ts
+++ b/src/graphQL-API/dataloader-asset.spec.ts
@@ -1,0 +1,23 @@
+import DataLoader from 'dataloader';
+import { createDataLoader } from './dataloader-factory';
+
+describe('Asset DataLoader', () => {
+  it('batches multiple loads into a single batch call', async () => {
+    const batchFn = jest.fn(async (keys: readonly string[]) => {
+      // return dummy assets matching codes
+      return (keys as string[]).map((k) => ({ code: k, id: `id-${k}` }));
+    });
+
+    const loader = createDataLoader<string, any>(batchFn, (a) => a.code);
+
+    // Simulate N positions requesting asset metadata
+    const codes = ['XLM', 'USDC', 'AQUA', 'XLM'];
+
+    const promises = codes.map((c) => loader.load(c));
+    const results = await Promise.all(promises);
+
+    expect(batchFn).toHaveBeenCalledTimes(1);
+    expect(results.length).toBe(codes.length);
+    expect(results[0].code).toBe('XLM');
+  });
+});

--- a/src/graphQL-API/dataloader-factory.ts
+++ b/src/graphQL-API/dataloader-factory.ts
@@ -71,4 +71,5 @@ export function createGroupedDataLoader<K, V>(
 export interface DataLoaderSet {
   providerById: DataLoader<string, any>;
   signalsByProviderId: DataLoader<string, any[]>;
+  assetByCode?: DataLoader<string, any>;
 }

--- a/src/graphQL-API/graphql.module.ts
+++ b/src/graphQL-API/graphql.module.ts
@@ -37,6 +37,7 @@ import { TradesModule } from '../trades/trades.module';
 import { PortfolioModule } from '../portfolio/portfolio.module';
 import { ProvidersModule } from '../providers/providers.module';
 import { UsersModule } from '../users/users.module';
+import { AssetsModule } from '../assets/assets.module';
 
 // ─── Utils ────────────────────────────────────────────────────────────────────
 import { createDataLoader, createGroupedDataLoader } from './utils/dataloader-factory';
@@ -46,6 +47,7 @@ import {
 } from './utils/complexity-calculator';
 import { ProvidersService } from '../providers/providers.service';
 import { SignalsService } from '../signals/signals.service';
+import { AssetsService } from '../assets/assets.service';
 
 @Module({
   imports: [
@@ -54,12 +56,18 @@ import { SignalsService } from '../signals/signals.service';
     TradesModule,
     PortfolioModule,
     ProvidersModule,
+    AssetsModule,
     UsersModule,
 
     NestGraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
-      inject: [ProvidersService, SignalsService, ConfigService],
-      useFactory: (providersService: ProvidersService, signalsService: SignalsService, configService: ConfigService) => ({
+      inject: [ProvidersService, SignalsService, ConfigService, AssetsService],
+      useFactory: (
+        providersService: ProvidersService,
+        signalsService: SignalsService,
+        configService: ConfigService,
+        assetsService: AssetsService,
+      ) => ({
         /**
          * Code-first schema — NestJS generates schema.gql automatically.
          * The file is written to disk so you can inspect or commit it.
@@ -78,6 +86,11 @@ import { SignalsService } from '../signals/signals.service';
             signalsByProviderId: createGroupedDataLoader(
               (providerIds) => signalsService.findByProviderIds(providerIds as string[]),
               (s) => s.providerId,
+            ),
+            // Asset metadata loader (per-request) — batches asset lookups by code
+            assetByCode: createDataLoader(
+              async (codes) => assetsService.findByCodes(codes as string[]),
+              (a) => a.code || a.id,
             ),
           },
         }),

--- a/src/graphQL-API/portfolio.resolver.ts
+++ b/src/graphQL-API/portfolio.resolver.ts
@@ -8,6 +8,7 @@ import {
   AllocationItemType,
   PositionType,
 } from '../types/portfolio.type';
+import { AssetMetaType } from '../types/asset.type';
 import { PortfolioService } from '../../portfolio/portfolio.service';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
@@ -34,7 +35,17 @@ export class PortfolioResolver {
 
   @ResolveField(() => [PositionType])
   async openPositions(@Parent() portfolio: PortfolioType): Promise<PositionType[]> {
-    return this.portfolioService.getOpenPositions(portfolio.userId);
+    const positions = await this.portfolioService.getOpenPositions(portfolio.userId);
+    return positions;
+  }
+
+  @ResolveField(() => [AssetMetaType], { nullable: true })
+  async assets(@Parent() portfolio: PortfolioType, @Context() ctx: any): Promise<AssetMetaType[]> {
+    // Example: batch-fetch asset metadata for all positions in the portfolio
+    const positions = await this.portfolioService.getOpenPositions(portfolio.userId);
+    const codes = positions.map((p) => p.assetSymbol?.split('/')[0]);
+    const assets = await ctx.loaders.assetByCode.loadMany(codes);
+    return assets as AssetMetaType[];
   }
 
   @ResolveField(() => [AllocationItemType])

--- a/src/graphQL-API/types/asset.type.ts
+++ b/src/graphQL-API/types/asset.type.ts
@@ -1,0 +1,19 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql';
+
+@ObjectType()
+export class AssetMetaType {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  code: string;
+
+  @Field({ nullable: true })
+  issuer?: string;
+
+  @Field({ nullable: true })
+  name?: string;
+
+  @Field({ nullable: true })
+  logoUrl?: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,10 +68,10 @@ async function bootstrap() {
   app.useGlobalInterceptors(new DeprecationInterceptor(app.get(Reflector)));
 
   // Enable CORS
-  app.enableCors({
-    origin: corsOrigin,
-    credentials: corsCredentials,
-  });
+  // Build CORS options using helper which validates production config
+  const { createCorsOptions } = await import('./common/cors/cors.helper');
+  const corsOptions = createCorsOptions(corsOrigin, corsCredentials, configService.get('app.environment'));
+  app.enableCors(corsOptions);
 
   // Enable compression
   app.use((compression as any)(compressionConfig));

--- a/src/privacy/retention-purge.service.spec.ts
+++ b/src/privacy/retention-purge.service.spec.ts
@@ -1,0 +1,20 @@
+import { RetentionPurgeService } from './retention-purge.service';
+import { Repository } from 'typeorm';
+
+describe('RetentionPurgeService', () => {
+  it('purges eligible deleted users and leaves recent ones', async () => {
+    const mockRepo: any = {
+      find: jest.fn().mockResolvedValue([
+        { id: '1', deletedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 40), email: 'a@x.com', displayName: 'A', bio: 'x' }, // 40 days
+        { id: '2', deletedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 10), email: 'b@x.com', displayName: 'B', bio: 'y' }, // 10 days
+      ]),
+      save: jest.fn().mockImplementation(async (u) => u),
+    } as unknown as Repository<any>;
+
+    const config: any = { get: () => 30 };
+    const service = new RetentionPurgeService(mockRepo, config as any);
+    const count = await service.purgeNowForTesting(30);
+    expect(count).toBe(1);
+    expect(mockRepo.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/privacy/retention-purge.service.ts
+++ b/src/privacy/retention-purge.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class RetentionPurgeService {
+  private readonly logger = new Logger(RetentionPurgeService.name);
+
+  constructor(
+    @InjectRepository(User) private readonly userRepo: Repository<User>,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async runDailyPurge(): Promise<void> {
+    this.logger.log('Starting retention purge job');
+    try {
+      const days = this.config.get<number>('retention.deletedUserDays') ?? 30;
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - days);
+
+      const users = await this.userRepo.find({ where: { deletedAt: MoreThan(0) } });
+      // Filter manually to compare deletedAt
+      const eligible = users.filter((u) => u.deletedAt && u.deletedAt < cutoff);
+
+      let purged = 0;
+      for (const user of eligible) {
+        // Anonymize PII fields but keep row for aggregates
+        user.email = null;
+        user.displayName = null;
+        user.bio = null;
+        await this.userRepo.save(user);
+        purged += 1;
+      }
+
+      this.logger.log(`Retention purge completed. Records purged: ${purged}`);
+    } catch (error) {
+      this.logger.error('Retention purge failed', error);
+    }
+  }
+
+  // Exposed for tests / manual run
+  async purgeNowForTesting(daysThreshold = this.config.get<number>('retention.deletedUserDays') ?? 30) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - daysThreshold);
+    const users = await this.userRepo.find();
+    const eligible = users.filter((u) => u.deletedAt && u.deletedAt < cutoff);
+    for (const user of eligible) {
+      user.email = null;
+      user.displayName = null;
+      user.bio = null;
+      await this.userRepo.save(user);
+    }
+    return eligible.length;
+  }
+}

--- a/src/trades/trades.module.ts
+++ b/src/trades/trades.module.ts
@@ -16,6 +16,8 @@ import { RiskManagerModule } from '../risk/risk-manager.module';
 import { ComplianceModule } from '../compliance/compliance.module';
 import { SdexModule } from '../sdex/sdex.module';
 import { SorobanModule } from '../soroban/soroban.module';
+import { APP_FILTER } from '@nestjs/core';
+import { SorobanExceptionFilter } from '../common/filters/soroban-exception.filter';
 import { Signal } from '../signals/entities/signal.entity';
 import { BullModule } from '@nestjs/bull';
 import { WebsocketModule } from '../websocket/websocket.module';
@@ -76,6 +78,7 @@ import { TradeSagaEntity } from './saga/trade-saga.entity';
     TradeSagaOrchestrator,
     TradeSagaStepsFactory,
     TradeSagaService,
+    { provide: APP_FILTER, useClass: SorobanExceptionFilter },
   ],
   exports: [TradesService, RiskManagerService, OcoOrderService, IcebergOrderService, PartialCloseService, TradeHistoryService, TradeOutcomeService, TradeAuditService, ConfirmationPollingService, TradeExecutionOrchestratorService, TradeRetryService, TradeExecutorService, TradeSagaService],
 })

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -6,11 +6,12 @@ import { Session } from './entities/session.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { CacheInvalidationService } from '../cache/cache-invalidation.service';
+import { RetentionPurgeService } from '../privacy/retention-purge.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, UserPreference, Session])],
   controllers: [UsersController],
-  providers: [UsersService, CacheInvalidationService],
+  providers: [UsersService, CacheInvalidationService, RetentionPurgeService],
   exports: [UsersService, TypeOrmModule],
 })
 export class UsersModule { }


### PR DESCRIPTION
closes #667 
closes #680
closes #685 
closes #688

PR description (detailed)
- Overview
  - This PR implements four focused improvements requested to improve error handling, GraphQL performance, environment-safe CORS configuration, and PII retention compliance.
- Soroban error handling
  - Adds `SorobanExceptionFilter` which specifically handles `SorobanException` instances.
  - The filter maps common contract/RPC error signatures to stable `ErrorCode` values and HTTP statuses:
    - Authorization failures => 403 + `E6001`-style mapping (SOROBAN_CONTRACT_ERROR)
    - Invalid contract args => 422 + SOROBAN_CONTRACT_ERROR
    - RPC/internal node errors => 502 + SOROBAN_RPC_ERROR
  - The filter returns `ErrorResponseDto` without raw RPC payloads, logs the mapping, and is registered in the `TradesModule` (controllers interacting with Soroban). Unit tests verify mapping for three distinct payload types.
- GraphQL DataLoader for portfolio resolver
  - Adds an `assetByCode` DataLoader to GraphQL request context (created per-request).
  - Adds `AssetsService.findByCodes` for batched asset lookups.
  - Adds `AssetMetaType` and a `portfolio.assets` resolver example that demonstrates batching asset metadata loads for a portfolio's positions.
  - Adds a unit test showing that multiple position-level requests are batched into a single backend call (prevents N+1).
- Environment-driven CORS
  - Introduces `createCorsOptions(allowlist, credentials, env)` that returns `CorsOptions`.
  - Enforces fail-fast behavior in production/mainnet when the allowlist is missing/empty to avoid accidental permissive CORS in prod.
  - Replaces direct `app.enableCors({ origin: corsOrigin, credentials })` in bootstrap with the helper.
  - Adds tests to verify allow/deny and fail-fast behavior.
- Retention purge job
  - Adds `RetentionPurgeService` that runs daily and anonymizes PII on records that have been deleted longer than configured retention.
  - `retention.deletedUserDays` config key controls the threshold (defaulted in code to 30 if missing).
  - Job logs counts and is idempotent. A helper method `purgeNowForTesting` is provided and covered by unit tests.
- Tests
  - Adds unit tests covering:
    - SorobanExceptionFilter mapping of three error types to distinct responses.
    - DataLoader batch behavior for asset lookups (single batch call for multiple loads).
    - CORS helper allow/reject behavior and fail-fast in production.
    - Retention job anonymization logic for eligible vs non-eligible records.
- Backwards compatibility / notes
  - Existing error handling pipeline remains (GlobalExceptionFilter, ErrorClassificationService). The Soroban-specific filter ensures Soroban invocation errors are normalized early for controllers that directly call Soroban.
  - DataLoader instances are per-request; if you want shared caching across requests (not recommended) we can adapt but that would risk cross-request leakage.
  - The retention job anonymizes PII rather than deleting rows to retain aggregates; change strategy available on request.

Next steps I can take (choose one)
- Run the test suite and fix any incidental CI failures.
- Replace the placeholder `portfolio.assets` example with a production field (if you want this wired to an existing schema field).
- Expand Soroban error mapping rules with concrete contract error-code mappings if you provide the canonical list.

Would you like me to run the test suite now and fix any test failures, or push these changes to a branch and open the PR for review?

Made changes.