### PR TITLE
Feat/validate feature flag entrypoints 797

### DIFF
--- a/docs/feature-flag-entrypoint-validation.md
+++ b/docs/feature-flag-entrypoint-validation.md
@@ -1,0 +1,146 @@
+# Feature Flag Entrypoint Validation
+
+## Overview
+
+Feature flags and contract-entrypoint-scoped kill-switches reference specific module or contract entrypoint names as configuration values, but there was no validation ensuring a flag's referenced target still exists after refactors or contract redeployments. This implementation adds a scheduled background job that continuously validates feature flags against the known contract entrypoint registry, flagging dead references before they silently do nothing in production.
+
+## Issues Resolved
+
+- ✅ **#797** - Implement background job validating feature flags reference an entrypoint that still exists
+
+## 🚀 Features Implemented
+
+### 1. Contract Entrypoint Registry
+**Files Added:**
+- `src/feature-flags/constants/contract-entrypoints.registry.ts`
+
+**Purpose:**
+- Central source of truth for all known contract entrypoints
+- Currently tracks `TradeExecutorContract` with methods: `execute_market_order`, `place_limit_order`, `cancel_order`, `get_order`
+- Provides `isValidEntrypoint()` helper for O(1) lookup validation
+- Designed for easy extension as new Soroban contracts are deployed
+
+### 2. Feature Flag Entity Extension
+**Files Modified:**
+- `src/feature-flags/entities/feature-flag.entity.ts`
+
+**New Columns Added:**
+- `contractId?: string` — Optional reference to the target contract name
+- `method?: string` — Optional reference to the specific entrypoint/method name
+- `retired?: boolean` — Marks flags that are intentionally retired (safe to ignore during validation)
+
+**Database Migration:**
+- `src/database/migrations/1752700000000-AddEntrypointMetadataToFeatureFlags.ts`
+  - Adds `contractId` (varchar, nullable)
+  - Adds `method` (varchar, nullable)
+  - Adds `retired` (boolean, default false)
+  - Creates composite index on `(contractId, method)` for query performance
+
+### 3. Background Validation Job
+**Files Added:**
+- `src/feature-flags/jobs/validate-feature-flag-entrypoints.job.ts`
+
+**Files Modified:**
+- `src/feature-flags/feature-flags.module.ts` — Imports `ScheduleModule` and registers the job provider
+- `src/feature-flags/dto/create-flag.dto.ts` — Allows `contractId`, `method`, and `retired` in create/update DTOs
+
+**Job Behavior:**
+- **Schedule**: Runs daily at 02:00 UTC via `@Cron('0 2 * * *')`
+- **Scope**: Queries all feature flags where both `contractId` and `method` are non-null
+- **Validation Logic**:
+  1. Flags marked `retired: true` are skipped and logged as "intentionally retired"
+  2. Flags referencing a contract not in the registry are flagged as invalid
+  3. Flags referencing a method not present on the known contract are flagged as invalid
+  4. Valid flags are counted and reported
+- **Reporting**:
+  - `logger.warn` for each individual invalid flag with specific reason
+  - `logger.error` with a consolidated list of all invalid flags
+  - `logger.log` with summary counts (valid, retired, invalid)
+
+**Example Log Output:**
+```
+[FeatureFlags] Feature flag "stale_entrypoint_test_fixture" references an invalid target: method "nonexistent_entrypoint" does not exist on contract "TradeExecutorContract"
+[FeatureFlags] Feature flag entrypoint validation complete — valid: 1, retired: 1, invalid: 1
+[FeatureFlags] Detected 1 feature flag(s) with missing entrypoints: stale_entrypoint_test_fixture
+```
+
+### 4. Test Fixture & Unit Tests
+**Files Added:**
+- `src/feature-flags/jobs/validate-feature-flag-entrypoints.job.spec.ts`
+
+**Files Modified:**
+- `src/database/seeds/feature-flags.seed.ts` — Added `stale_entrypoint_test_fixture` with `contractId: 'TradeExecutorContract'` and `method: 'nonexistent_entrypoint'`
+
+**Test Coverage:**
+- ✅ Detects flags with nonexistent entrypoints
+- ✅ Skips retired flags without warning
+- ✅ Passes validation for flags with known entrypoints
+- ✅ Handles unknown contracts gracefully
+- ✅ Handles empty flag set (no contract-scoped flags)
+
+**Test Fixture Details:**
+| Field | Value |
+|-------|-------|
+| `name` | `stale_entrypoint_test_fixture` |
+| `type` | `boolean` |
+| `enabled` | `false` |
+| `contractId` | `TradeExecutorContract` |
+| `method` | `nonexistent_entrypoint` |
+| `retired` | `false` |
+
+This fixture ensures the job detects invalid references in a real database state.
+
+## 🔧 API / DTO Changes
+
+### CreateFlagDto & UpdateFlagDto
+Three new optional fields have been added:
+
+```typescript
+contractId?: string;  // e.g. "TradeExecutorContract"
+method?: string;      // e.g. "execute_market_order"
+retired?: boolean;    // true = intentionally retired, skip during validation
+```
+
+Existing flags without these fields are unaffected and continue to work normally.
+
+## 🧪 Testing Strategy
+
+The job is tested in isolation using NestJS's `Test.createTestingModule()` with mocked TypeORM repositories. The `@Cron` decorator is not triggered during tests; instead, the `run()` method is invoked directly.
+
+Tests use `jest.spyOn` to mock logger methods and assert that:
+- Correct warning/error messages are emitted for invalid flags
+- Retired flags produce no warnings
+- Summary logs reflect expected counts
+
+## 🛡️ Production Considerations
+
+- **Registry Updates**: When new contracts are deployed, `KNOWN_CONTRACT_ENTRYPOINTS` must be updated. This can be automated by parsing WASM metadata or ABI files in a future enhancement.
+- **Retired Flags**: Teams should set `retired: true` on flags that are being phased out to avoid noise in validation reports.
+- **CI Integration**: The job can also be triggered manually (outside its schedule) or adapted to run in CI pipelines by exposing a trigger endpoint.
+- **Alerting**: The job currently logs errors; in production, these can be routed to alerting systems (PagerDuty, Slack) via the existing `DeadLetterService` or `JobsController`.
+
+## 📦 Files Changed
+
+```
+src/database/migrations/1752700000000-AddEntrypointMetadataToFeatureFlags.ts  | NEW
+src/database/seeds/feature-flags.seed.ts                                      | MODIFIED
+src/feature-flags/constants/contract-entrypoints.registry.ts                  | NEW
+src/feature-flags/dto/create-flag.dto.ts                                     | MODIFIED
+src/feature-flags/entities/feature-flag.entity.ts                            | MODIFIED
+src/feature-flags/feature-flags.module.ts                                    | MODIFIED
+src/feature-flags/jobs/validate-feature-flag-entrypoints.job.spec.ts         | NEW
+src/feature-flags/jobs/validate-feature-flag-entrypoints.job.ts              | NEW
+```
+
+## ✅ Verification Steps
+
+1. Run database migrations: `npm run migration:run`
+2. Seed the test fixture: `npm run seed`
+3. Start the application: `npm run start:dev`
+4. Verify the job runs at next scheduled interval (02:00 UTC) or trigger manually via the JobsController
+5. Observe logs for the `stale_entrypoint_test_fixture` being flagged as invalid
+6. Query `feature_flags` table to confirm new columns exist
+
+## 🔗 Related
+
+- closes #797

--- a/src/database/migrations/1752700000000-AddEntrypointMetadataToFeatureFlags.ts
+++ b/src/database/migrations/1752700000000-AddEntrypointMetadataToFeatureFlags.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddEntrypointMetadataToFeatureFlags1752700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'feature_flags',
+      new TableColumn({
+        name: 'contractId',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'feature_flags',
+      new TableColumn({
+        name: 'method',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'feature_flags',
+      new TableColumn({
+        name: 'retired',
+        type: 'boolean',
+        default: false,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'feature_flags',
+      new TableIndex({
+        name: 'idx_feature_flag_contract_method',
+        columnNames: ['contractId', 'method'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('feature_flags', 'idx_feature_flag_contract_method');
+    await queryRunner.dropColumn('feature_flags', 'retired');
+    await queryRunner.dropColumn('feature_flags', 'method');
+    await queryRunner.dropColumn('feature_flags', 'contractId');
+  }
+}

--- a/src/database/seeds/feature-flags.seed.ts
+++ b/src/database/seeds/feature-flags.seed.ts
@@ -68,6 +68,16 @@ export async function seedFeatureFlags(dataSource: DataSource): Promise<void> {
         ],
       },
     },
+    {
+      name: 'stale_entrypoint_test_fixture',
+      description: 'Test fixture: flag referencing a nonexistent contract entrypoint (used by validate-feature-flag-entrypoints job)',
+      type: 'boolean' as const,
+      enabled: false,
+      contractId: 'TradeExecutorContract',
+      method: 'nonexistent_entrypoint',
+      retired: false,
+      config: {},
+    },
   ];
 
   for (const flagData of flags) {

--- a/src/feature-flags/constants/contract-entrypoints.registry.ts
+++ b/src/feature-flags/constants/contract-entrypoints.registry.ts
@@ -1,0 +1,21 @@
+export interface ContractEntrypointRegistry {
+  [contractName: string]: string[];
+}
+
+export const KNOWN_CONTRACT_ENTRYPOINTS: ContractEntrypointRegistry = {
+  TradeExecutorContract: [
+    'execute_market_order',
+    'place_limit_order',
+    'cancel_order',
+    'get_order',
+  ],
+};
+
+export function isValidEntrypoint(
+  contractName: string,
+  method: string,
+): boolean {
+  const entrypoints = KNOWN_CONTRACT_ENTRYPOINTS[contractName];
+  if (!entrypoints) return false;
+  return entrypoints.includes(method);
+}

--- a/src/feature-flags/dto/create-flag.dto.ts
+++ b/src/feature-flags/dto/create-flag.dto.ts
@@ -50,6 +50,18 @@ export class CreateFlagDto {
   @ValidateNested()
   @Type(() => FlagConfigDto)
   config?: FlagConfigDto;
+
+  @IsOptional()
+  @IsString()
+  contractId?: string;
+
+  @IsOptional()
+  @IsString()
+  method?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  retired?: boolean;
 }
 
 export class UpdateFlagDto {
@@ -65,4 +77,16 @@ export class UpdateFlagDto {
   @ValidateNested()
   @Type(() => FlagConfigDto)
   config?: FlagConfigDto;
+
+  @IsOptional()
+  @IsString()
+  contractId?: string;
+
+  @IsOptional()
+  @IsString()
+  method?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  retired?: boolean;
 }

--- a/src/feature-flags/entities/feature-flag.entity.ts
+++ b/src/feature-flags/entities/feature-flag.entity.ts
@@ -28,6 +28,15 @@ export class FeatureFlag {
   @Column({ type: 'jsonb', default: {} })
   config!: FlagConfig;
 
+  @Column({ nullable: true })
+  contractId?: string;
+
+  @Column({ nullable: true })
+  method?: string;
+
+  @Column({ default: false })
+  retired?: boolean;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/src/feature-flags/feature-flags.module.ts
+++ b/src/feature-flags/feature-flags.module.ts
@@ -2,20 +2,23 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { FeatureFlagsService } from './feature-flags.service';
 import { FeatureFlagsController } from './feature-flags.controller';
 import { FeatureFlag } from './entities/feature-flag.entity';
 import { FlagAssignment } from './entities/flag-assignment.entity';
 import { FeatureFlagGuard } from './guards/feature-flag.guard';
+import { ValidateFeatureFlagEntrypointsJob } from './jobs/validate-feature-flag-entrypoints.job';
 
 @Module({
   imports: [
     ConfigModule,
     TypeOrmModule.forFeature([FeatureFlag, FlagAssignment]),
     CacheModule.register(),
+    ScheduleModule,
   ],
   controllers: [FeatureFlagsController],
-  providers: [FeatureFlagsService, FeatureFlagGuard],
+  providers: [FeatureFlagsService, FeatureFlagGuard, ValidateFeatureFlagEntrypointsJob],
   exports: [FeatureFlagsService, FeatureFlagGuard],
 })
 export class FeatureFlagsModule {}

--- a/src/feature-flags/jobs/validate-feature-flag-entrypoints.job.spec.ts
+++ b/src/feature-flags/jobs/validate-feature-flag-entrypoints.job.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { FeatureFlag } from '../entities/feature-flag.entity';
+import { ValidateFeatureFlagEntrypointsJob } from './validate-feature-flag-entrypoints.job';
+
+describe('ValidateFeatureFlagEntrypointsJob', () => {
+  let job: ValidateFeatureFlagEntrypointsJob;
+  let mockFlagRepository: any;
+
+  beforeEach(async () => {
+    mockFlagRepository = {
+      find: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ValidateFeatureFlagEntrypointsJob,
+        {
+          provide: getRepositoryToken(FeatureFlag),
+          useValue: mockFlagRepository,
+        },
+      ],
+    }).compile();
+
+    job = module.get<ValidateFeatureFlagEntrypointsJob>(ValidateFeatureFlagEntrypointsJob);
+    jest.spyOn((job as any).logger, 'log').mockImplementation(() => {});
+    jest.spyOn((job as any).logger, 'warn').mockImplementation(() => {});
+    jest.spyOn((job as any).logger, 'error').mockImplementation(() => {});
+    jest.spyOn((job as any).logger, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should detect flags with nonexistent entrypoints', async () => {
+    mockFlagRepository.find.mockResolvedValue([
+      {
+        name: 'stale_entrypoint_test_fixture',
+        contractId: 'TradeExecutorContract',
+        method: 'nonexistent_entrypoint',
+        retired: false,
+      } as FeatureFlag,
+    ]);
+
+    await job.run();
+
+    expect((job as any).logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('references an invalid target'),
+    );
+    expect((job as any).logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Detected 1 feature flag(s) with missing entrypoints'),
+    );
+    expect((job as any).logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('valid: 0'),
+    );
+  });
+
+  it('should skip retired flags', async () => {
+    mockFlagRepository.find.mockResolvedValue([
+      {
+        name: 'old_deprecated_flag',
+        contractId: 'TradeExecutorContract',
+        method: 'nonexistent_entrypoint',
+        retired: true,
+      } as FeatureFlag,
+    ]);
+
+    await job.run();
+
+    expect((job as any).logger.warn).not.toHaveBeenCalled();
+    expect((job as any).logger.error).not.toHaveBeenCalled();
+    expect((job as any).logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('retired: 1'),
+    );
+  });
+
+  it('should validate flags with known entrypoints', async () => {
+    mockFlagRepository.find.mockResolvedValue([
+      {
+        name: 'valid_trade_flag',
+        contractId: 'TradeExecutorContract',
+        method: 'execute_market_order',
+        retired: false,
+      } as FeatureFlag,
+    ]);
+
+    await job.run();
+
+    expect((job as any).logger.warn).not.toHaveBeenCalled();
+    expect((job as any).logger.error).not.toHaveBeenCalled();
+    expect((job as any).logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('valid: 1'),
+    );
+  });
+
+  it('should handle unknown contracts gracefully', async () => {
+    mockFlagRepository.find.mockResolvedValue([
+      {
+        name: 'unknown_contract_flag',
+        contractId: 'UnknownContract',
+        method: 'some_method',
+        retired: false,
+      } as FeatureFlag,
+    ]);
+
+    await job.run();
+
+    expect((job as any).logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not in the entrypoint registry'),
+    );
+    expect((job as any).logger.error).toHaveBeenCalled();
+    expect((job as any).logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('valid: 0'),
+    );
+  });
+
+  it('should handle empty flag set', async () => {
+    mockFlagRepository.find.mockResolvedValue([]);
+
+    await job.run();
+
+    expect((job as any).logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('No contract-scoped feature flags found'),
+    );
+  });
+});

--- a/src/feature-flags/jobs/validate-feature-flag-entrypoints.job.ts
+++ b/src/feature-flags/jobs/validate-feature-flag-entrypoints.job.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Not, IsNull } from 'typeorm';
+import { Cron } from '@nestjs/schedule';
+import { FeatureFlag } from '../entities/feature-flag.entity';
+import { KNOWN_CONTRACT_ENTRYPOINTS, isValidEntrypoint } from '../constants/contract-entrypoints.registry';
+
+@Injectable()
+export class ValidateFeatureFlagEntrypointsJob {
+  private readonly logger = new Logger(ValidateFeatureFlagEntrypointsJob.name);
+
+  constructor(
+    @InjectRepository(FeatureFlag)
+    private readonly flagRepository: Repository<FeatureFlag>,
+  ) {}
+
+  @Cron('0 2 * * *', { name: 'validate-feature-flag-entrypoints', timeZone: 'UTC' })
+  async run(): Promise<void> {
+    this.logger.log('Starting feature flag entrypoint validation…');
+
+    const flags = await this.flagRepository.find({
+      where: { contractId: Not(IsNull()), method: Not(IsNull()) },
+    });
+
+    if (flags.length === 0) {
+      this.logger.log('No contract-scoped feature flags found.');
+      return;
+    }
+
+    let validCount = 0;
+    let retiredCount = 0;
+    let invalidCount = 0;
+    const invalidFlags: string[] = [];
+
+    for (const flag of flags) {
+      if (flag.retired) {
+        this.logger.debug(
+          `Flag "${flag.name}" is intentionally retired — skipping validation`,
+        );
+        retiredCount++;
+        continue;
+      }
+
+      const contractExists = flag.contractId in KNOWN_CONTRACT_ENTRYPOINTS;
+      const methodValid = contractExists && isValidEntrypoint(flag.contractId, flag.method);
+
+      if (methodValid) {
+        validCount++;
+      } else {
+        invalidCount++;
+        invalidFlags.push(flag.name);
+        const reason = !contractExists
+          ? `contract "${flag.contractId}" is not in the entrypoint registry`
+          : `method "${flag.method}" does not exist on contract "${flag.contractId}"`;
+        this.logger.warn(
+          `Feature flag "${flag.name}" references an invalid target: ${reason}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Feature flag entrypoint validation complete — valid: ${validCount}, ` +
+        `retired: ${retiredCount}, invalid: ${invalidCount}`,
+    );
+
+    if (invalidCount > 0) {
+      this.logger.error(
+        `Detected ${invalidCount} feature flag(s) with missing entrypoints: ${invalidFlags.join(', ')}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
# Feature Flag Entrypoint Validation

## Overview

Feature flags and contract-entrypoint-scoped kill-switches reference specific module or contract entrypoint names as configuration values, but there was no validation ensuring a flag's referenced target still exists after refactors or contract redeployments. This implementation adds a scheduled background job that continuously validates feature flags against the known contract entrypoint registry, flagging dead references before they silently do nothing in production.

## Issues Resolved

- ✅ **#797** - Implement background job validating feature flags reference an entrypoint that still exists

## 🚀 Features Implemented

### 1. Contract Entrypoint Registry
**Files Added:**
- `src/feature-flags/constants/contract-entrypoints.registry.ts`

**Purpose:**
- Central source of truth for all known contract entrypoints
- Currently tracks `TradeExecutorContract` with methods: `execute_market_order`, `place_limit_order`, `cancel_order`, `get_order`
- Provides `isValidEntrypoint()` helper for O(1) lookup validation
- Designed for easy extension as new Soroban contracts are deployed

### 2. Feature Flag Entity Extension
**Files Modified:**
- `src/feature-flags/entities/feature-flag.entity.ts`

**New Columns Added:**
- `contractId?: string` — Optional reference to the target contract name
- `method?: string` — Optional reference to the specific entrypoint/method name
- `retired?: boolean` — Marks flags that are intentionally retired (safe to ignore during validation)

**Database Migration:**
- `src/database/migrations/1752700000000-AddEntrypointMetadataToFeatureFlags.ts`
  - Adds `contractId` (varchar, nullable)
  - Adds `method` (varchar, nullable)
  - Adds `retired` (boolean, default false)
  - Creates composite index on `(contractId, method)` for query performance

### 3. Background Validation Job
**Files Added:**
- `src/feature-flags/jobs/validate-feature-flag-entrypoints.job.ts`

**Files Modified:**
- `src/feature-flags/feature-flags.module.ts` — Imports `ScheduleModule` and registers the job provider
- `src/feature-flags/dto/create-flag.dto.ts` — Allows `contractId`, `method`, and `retired` in create/update DTOs

**Job Behavior:**
- **Schedule**: Runs daily at 02:00 UTC via `@Cron('0 2 * * *')`
- **Scope**: Queries all feature flags where both `contractId` and `method` are non-null
- **Validation Logic**:
  1. Flags marked `retired: true` are skipped and logged as "intentionally retired"
  2. Flags referencing a contract not in the registry are flagged as invalid
  3. Flags referencing a method not present on the known contract are flagged as invalid
  4. Valid flags are counted and reported
- **Reporting**:
  - `logger.warn` for each individual invalid flag with specific reason
  - `logger.error` with a consolidated list of all invalid flags
  - `logger.log` with summary counts (valid, retired, invalid)

**Example Log Output:**
```
[FeatureFlags] Feature flag "stale_entrypoint_test_fixture" references an invalid target: method "nonexistent_entrypoint" does not exist on contract "TradeExecutorContract"
[FeatureFlags] Feature flag entrypoint validation complete — valid: 1, retired: 1, invalid: 1
[FeatureFlags] Detected 1 feature flag(s) with missing entrypoints: stale_entrypoint_test_fixture
```

### 4. Test Fixture & Unit Tests
**Files Added:**
- `src/feature-flags/jobs/validate-feature-flag-entrypoints.job.spec.ts`

**Files Modified:**
- `src/database/seeds/feature-flags.seed.ts` — Added `stale_entrypoint_test_fixture` with `contractId: 'TradeExecutorContract'` and `method: 'nonexistent_entrypoint'`

**Test Coverage:**
- ✅ Detects flags with nonexistent entrypoints
- ✅ Skips retired flags without warning
- ✅ Passes validation for flags with known entrypoints
- ✅ Handles unknown contracts gracefully
- ✅ Handles empty flag set (no contract-scoped flags)

**Test Fixture Details:**
| Field | Value |
|-------|-------|
| `name` | `stale_entrypoint_test_fixture` |
| `type` | `boolean` |
| `enabled` | `false` |
| `contractId` | `TradeExecutorContract` |
| `method` | `nonexistent_entrypoint` |
| `retired` | `false` |

This fixture ensures the job detects invalid references in a real database state.

## 🔧 API / DTO Changes

### CreateFlagDto & UpdateFlagDto
Three new optional fields have been added:

```typescript
contractId?: string;  // e.g. "TradeExecutorContract"
method?: string;      // e.g. "execute_market_order"
retired?: boolean;    // true = intentionally retired, skip during validation
```

Existing flags without these fields are unaffected and continue to work normally.

## 🧪 Testing Strategy

The job is tested in isolation using NestJS's `Test.createTestingModule()` with mocked TypeORM repositories. The `@Cron` decorator is not triggered during tests; instead, the `run()` method is invoked directly.

Tests use `jest.spyOn` to mock logger methods and assert that:
- Correct warning/error messages are emitted for invalid flags
- Retired flags produce no warnings
- Summary logs reflect expected counts

## 🛡️ Production Considerations

- **Registry Updates**: When new contracts are deployed, `KNOWN_CONTRACT_ENTRYPOINTS` must be updated. This can be automated by parsing WASM metadata or ABI files in a future enhancement.
- **Retired Flags**: Teams should set `retired: true` on flags that are being phased out to avoid noise in validation reports.
- **CI Integration**: The job can also be triggered manually (outside its schedule) or adapted to run in CI pipelines by exposing a trigger endpoint.
- **Alerting**: The job currently logs errors; in production, these can be routed to alerting systems (PagerDuty, Slack) via the existing `DeadLetterService` or `JobsController`.

## 📦 Files Changed

```
src/database/migrations/1752700000000-AddEntrypointMetadataToFeatureFlags.ts  | NEW
src/database/seeds/feature-flags.seed.ts                                      | MODIFIED
src/feature-flags/constants/contract-entrypoints.registry.ts                  | NEW
src/feature-flags/dto/create-flag.dto.ts                                     | MODIFIED
src/feature-flags/entities/feature-flag.entity.ts                            | MODIFIED
src/feature-flags/feature-flags.module.ts                                    | MODIFIED
src/feature-flags/jobs/validate-feature-flag-entrypoints.job.spec.ts         | NEW
src/feature-flags/jobs/validate-feature-flag-entrypoints.job.ts              | NEW
```

## ✅ Verification Steps

1. Run database migrations: `npm run migration:run`
2. Seed the test fixture: `npm run seed`
3. Start the application: `npm run start:dev`
4. Verify the job runs at next scheduled interval (02:00 UTC) or trigger manually via the JobsController
5. Observe logs for the `stale_entrypoint_test_fixture` being flagged as invalid
6. Query `feature_flags` table to confirm new columns exist

## 🔗 Related

- closes #797
