### PR TITLE
feat: commitlint+husky, Horizon bulkhead, @CurrentWallet & @IsStellarMemo decorators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ STELLAR_MAX_RETRIES=3
 STELLAR_MAX_CALL_DEPTH=5
 STELLAR_MAX_CALL_DEPTH_POLICY=reject # 'reject' or 'warn'
 
+# Horizon bulkhead isolation — bounded concurrency pools per call category so a
+# degraded category (e.g. reads) can't starve another (e.g. writes/submissions).
+STELLAR_HORIZON_READ_MAX_CONCURRENT=20
+STELLAR_HORIZON_READ_MAX_QUEUE=100
+STELLAR_HORIZON_WRITE_MAX_CONCURRENT=5
+STELLAR_HORIZON_WRITE_MAX_QUEUE=25
+
 # Stellar Platform Accounts (server-side signing)
 # STELLAR_SECRET_KEY       – main platform account secret (used by PayoutService)
 # STELLAR_SPONSOR_SECRET_KEY – fee-bump sponsor + sponsored-reserves account secret

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+# Run lint (and fast unit tests) before allowing a push.
+# Keep this fast: lint first, then a quick smoke test pass.
+npm run lint
+npm run test:smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+Thanks for contributing to StellarSwipe Backend! This guide covers local setup
+and the commit conventions enforced by our tooling.
+
+## Getting started
+
+```bash
+npm install
+```
+
+`npm install` runs the `prepare` script, which installs the [Husky](https://typicode.github.io/husky/)
+git hooks automatically. No manual hook setup is required.
+
+## Commit message format
+
+Commit messages **must** follow the
+[Conventional Commits](https://www.conventionalcommits.org/) specification. This
+is enforced locally by a Husky `commit-msg` hook running
+[commitlint](https://commitlint.js.org/) — commits that don't conform are
+rejected before they land.
+
+```
+<type>(<optional scope>): <subject>
+
+<optional body>
+
+<optional footer(s)>
+```
+
+### Allowed types
+
+| Type       | Use for                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `feat`     | A new feature                                                  |
+| `fix`      | A bug fix                                                      |
+| `docs`     | Documentation-only changes                                     |
+| `style`    | Formatting, whitespace, etc. (no logic change)                 |
+| `refactor` | Code change that neither fixes a bug nor adds a feature        |
+| `perf`     | A performance improvement                                      |
+| `test`     | Adding or fixing tests                                         |
+| `build`    | Build system or external dependency changes                   |
+| `ci`       | CI configuration changes                                       |
+| `chore`    | Routine tasks, tooling, maintenance                            |
+| `revert`   | Reverts a previous commit                                      |
+
+### Examples
+
+```
+feat(trades): add bulkhead isolation for Horizon API calls
+fix(auth): reject expired sessions on refresh
+docs: document conventional commit format
+refactor(wallet): extract authenticated wallet via @CurrentWallet decorator
+chore(deps): bump @stellar/stellar-sdk to 12.3.0
+```
+
+Rules of thumb:
+
+- Keep the header (`type(scope): subject`) to **100 characters or less**.
+- Use the imperative mood in the subject ("add", not "added"/"adds").
+- Don't end the subject with a period.
+- Reference issues in the footer, e.g. `Closes #123`.
+
+## Git hooks
+
+| Hook         | Runs                                              |
+| ------------ | ------------------------------------------------- |
+| `commit-msg` | `commitlint` — validates the commit message       |
+| `pre-push`   | `npm run lint` and `npm run test:smoke`           |
+
+To bypass hooks in an emergency you can pass `--no-verify` to `git commit` /
+`git push`, but please don't make a habit of it.

--- a/README.md
+++ b/README.md
@@ -321,9 +321,25 @@ kill -9 <PID>
 ## Contributing
 
 1. Create feature branch: `git checkout -b feature/new-feature`
-2. Commit changes: `git commit -am 'Add new feature'`
+2. Commit changes using the [Conventional Commits](https://www.conventionalcommits.org/) format, e.g. `git commit -m 'feat(trades): add new feature'`
 3. Push to branch: `git push origin feature/new-feature`
 4. Submit Pull Request
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full commit message format,
+allowed types, and examples.
+
+### Git hooks (commitlint + Husky)
+
+[Husky](https://typicode.github.io/husky/) git hooks are installed automatically
+when you run `npm install` (via the `prepare` script):
+
+- **`commit-msg`** — runs [commitlint](https://commitlint.js.org/) to reject any
+  commit message that doesn't follow the Conventional Commits format.
+- **`pre-push`** — runs `npm run lint` and `npm run test:smoke` before a push is
+  allowed.
+
+You can bypass hooks in an emergency with `git commit --no-verify` /
+`git push --no-verify`.
 
 ## Releases & Changelog
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,38 @@
+/**
+ * Commitlint configuration.
+ *
+ * Enforces the Conventional Commits specification so that the commit history is
+ * machine-parseable for changelog generation and history scanning.
+ *
+ * Format:  <type>(<optional scope>): <subject>
+ * Example: feat(trades): add bulkhead isolation for Horizon calls
+ *
+ * @see https://www.conventionalcommits.org/
+ */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Allowed commit types.
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'build',
+        'ci',
+        'chore',
+        'revert',
+      ],
+    ],
+    // Keep the header readable.
+    'header-max-length': [2, 'always', 100],
+    'subject-empty': [2, 'never'],
+    'type-empty': [2, 'never'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "seed": "ts-node -r tsconfig-paths/register src/database/seeds/seed.ts",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "changelog:init": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 --release-count 0",
-    "docs:module-graph": "node scripts/generate-module-graph.js"
+    "docs:module-graph": "node scripts/generate-module-graph.js",
+    "commitlint": "commitlint --edit",
+    "prepare": "husky"
   },
   "bin": {
     "stellar-admin": "bin/stellar-admin"
@@ -114,6 +116,8 @@
     "winston-daily-rotate-file": "^5.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^19.5.0",
+    "@commitlint/config-conventional": "^19.5.0",
     "@faker-js/faker": "^9.0.0",
     "@nestjs/cli": "^10.3.0",
     "@nestjs/schematics": "^10.0.3",
@@ -137,6 +141,7 @@
     "eslint": "^8.55.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
+    "husky": "^9.1.6",
     "jest": "^29.7.0",
     "prettier": "^3.1.1",
     "testcontainers": "^12.0.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { configuration } from './config/configuration';
 import { nplus1DetectionConfig } from './config/nplus1.config';
 import { configSchema } from './config/schemas/config.schema';
 import { StellarConfigService } from './config/stellar.service';
+import { HorizonBulkheadModule } from './stellar/bulkhead/horizon-bulkhead.module';
 
 import { LoggerModule } from './common/logger';
 import { CorrelationModule } from './common/correlation';
@@ -276,6 +277,7 @@ import { FreighterModule } from './freighter/freighter.module';
     RiskControlsModule,
     WalletModule,
     FreighterModule,
+    HorizonBulkheadModule,
   ],
   providers: [StellarConfigService, RateLimitMiddleware],
   exports: [StellarConfigService],

--- a/src/common/decorators/current-wallet.decorator.spec.ts
+++ b/src/common/decorators/current-wallet.decorator.spec.ts
@@ -1,0 +1,58 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { currentWalletFactory } from './current-wallet.decorator';
+
+/**
+ * Builds a minimal HTTP {@link ExecutionContext} whose request carries the
+ * provided `user` object.
+ */
+function httpContext(user: unknown): ExecutionContext {
+  return {
+    getType: () => 'http',
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('CurrentWallet decorator (currentWalletFactory)', () => {
+  describe('present-wallet cases', () => {
+    it('returns the wallet from user.walletAddress', () => {
+      const ctx = httpContext({ walletAddress: 'GABC...XYZ' });
+      expect(currentWalletFactory(undefined, ctx)).toBe('GABC...XYZ');
+    });
+
+    it('falls back to user.publicKey when walletAddress is absent', () => {
+      const ctx = httpContext({ publicKey: 'GPUBLIC...KEY' });
+      expect(currentWalletFactory(undefined, ctx)).toBe('GPUBLIC...KEY');
+    });
+
+    it('prefers walletAddress over publicKey when both are present', () => {
+      const ctx = httpContext({
+        walletAddress: 'GWALLET...ADDR',
+        publicKey: 'GPUBLIC...KEY',
+      });
+      expect(currentWalletFactory(undefined, ctx)).toBe('GWALLET...ADDR');
+    });
+  });
+
+  describe('missing-wallet cases', () => {
+    it('throws UnauthorizedException when there is no user', () => {
+      const ctx = httpContext(undefined);
+      expect(() => currentWalletFactory(undefined, ctx)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException when the wallet is an empty string', () => {
+      const ctx = httpContext({ walletAddress: '' });
+      expect(() => currentWalletFactory(undefined, ctx)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('returns undefined (no throw) when optional is true', () => {
+      const ctx = httpContext({});
+      expect(currentWalletFactory({ optional: true }, ctx)).toBeUndefined();
+    });
+  });
+});

--- a/src/common/decorators/current-wallet.decorator.ts
+++ b/src/common/decorators/current-wallet.decorator.ts
@@ -1,0 +1,78 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+/**
+ * Shape of the authenticated principal placed on the request by the
+ * JWT/Passport pipeline. The wallet address may be exposed under a couple of
+ * historically-inconsistent property names across the codebase, so we look at
+ * all of them in priority order.
+ */
+interface RequestWithWallet {
+  user?: {
+    walletAddress?: string;
+    publicKey?: string;
+  } | null;
+}
+
+/**
+ * Options for {@link CurrentWallet}.
+ */
+export interface CurrentWalletOptions {
+  /**
+   * When `true`, return `undefined` instead of throwing if no wallet is
+   * present on the request. Defaults to `false` (strict — throws
+   * {@link UnauthorizedException}).
+   */
+  optional?: boolean;
+}
+
+/**
+ * Pulls the authenticated wallet address off the current HTTP request,
+ * regardless of whether it was stored as `walletAddress` (REST JWT strategy)
+ * or `publicKey` (wallet/session flows).
+ */
+function extractWallet(ctx: ExecutionContext): string | undefined {
+  const request = ctx.switchToHttp().getRequest<RequestWithWallet>();
+  const user = request?.user;
+  const wallet = user?.walletAddress ?? user?.publicKey;
+  return wallet && wallet.length > 0 ? wallet : undefined;
+}
+
+/**
+ * Custom param decorator that extracts the authenticated wallet address from
+ * the request in one place, replacing ad-hoc `request.user.walletAddress`
+ * reads scattered across controllers.
+ *
+ * By default it throws a clear {@link UnauthorizedException} when no wallet is
+ * present (e.g. the route was reached without a valid auth guard). Pass
+ * `{ optional: true }` to receive `undefined` instead.
+ *
+ * @example
+ * // Strict (default) — guaranteed non-empty string or 401:
+ * @Post('refresh')
+ * refresh(@CurrentWallet() wallet: string) { ... }
+ *
+ * @example
+ * // Optional — returns `string | undefined`:
+ * @Get('me')
+ * me(@CurrentWallet({ optional: true }) wallet?: string) { ... }
+ */
+export function currentWalletFactory(
+  options: CurrentWalletOptions | undefined,
+  ctx: ExecutionContext,
+): string | undefined {
+  const wallet = extractWallet(ctx);
+
+  if (!wallet && !options?.optional) {
+    throw new UnauthorizedException(
+      'No authenticated wallet found on the request',
+    );
+  }
+
+  return wallet;
+}
+
+export const CurrentWallet = createParamDecorator(currentWalletFactory);

--- a/src/common/decorators/index.ts
+++ b/src/common/decorators/index.ts
@@ -10,3 +10,7 @@ export {
   MAX_CALL_DEPTH_KEY,
   type MaxCallDepthConfig,
 } from './max-call-depth.decorator';
+export {
+  CurrentWallet,
+  type CurrentWalletOptions,
+} from './current-wallet.decorator';

--- a/src/common/decorators/is-stellar-memo.decorator.ts
+++ b/src/common/decorators/is-stellar-memo.decorator.ts
@@ -1,0 +1,28 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { IsStellarMemoConstraint } from '../validators/stellar-memo.validator';
+
+/**
+ * Validates that a field holds a valid Stellar memo `{ type, value }` pair,
+ * enforcing the per-type byte-length / range constraints before a transaction
+ * is handed to the Stellar SDK.
+ *
+ * @example
+ * class BuildPaymentDto {
+ *   @IsOptional()
+ *   @ValidateNested()
+ *   @Type(() => StellarMemoDto)
+ *   @IsStellarMemo()
+ *   memo?: StellarMemoDto;
+ * }
+ */
+export function IsStellarMemo(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsStellarMemoConstraint,
+    });
+  };
+}

--- a/src/common/dto/blockchain.dto.ts
+++ b/src/common/dto/blockchain.dto.ts
@@ -5,7 +5,9 @@ import {
   IsString,
   MaxLength,
   MinLength,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   SanitizeAssetCode,
@@ -16,6 +18,8 @@ import {
   IsStellarSecretKey,
   IsValidAmount,
 } from '../decorators/validation.decorator';
+import { IsStellarMemo } from '../decorators/is-stellar-memo.decorator';
+import { StellarMemoDto } from './stellar-memo.dto';
 
 /**
  * Base DTO for operations that require only a Stellar public key.
@@ -140,7 +144,7 @@ export class StellarPaymentBaseDto {
   amount!: string;
 
   @ApiPropertyOptional({
-    description: 'Optional memo for the transaction',
+    description: 'Optional text memo for the transaction (MEMO_TEXT)',
     maxLength: 28,
   })
   @IsOptional()
@@ -148,4 +152,16 @@ export class StellarPaymentBaseDto {
   @MaxLength(28, { message: 'memo must not exceed 28 characters' })
   @SanitizeString()
   memo?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional structured memo (type + value) validated against Stellar ' +
+      'per-type constraints. Use this for non-text memos (id/hash/return).',
+    type: StellarMemoDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => StellarMemoDto)
+  @IsStellarMemo()
+  memoDetails?: StellarMemoDto;
 }

--- a/src/common/dto/stellar-memo.dto.ts
+++ b/src/common/dto/stellar-memo.dto.ts
@@ -1,0 +1,28 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { StellarMemoType } from '../validators/stellar-memo.validator';
+
+/**
+ * Structured Stellar memo. Pair a memo `type` with its `value` so the value
+ * can be validated against the type-specific constraints (see
+ * {@link IsStellarMemo}).
+ */
+export class StellarMemoDto {
+  @ApiPropertyOptional({
+    enum: StellarMemoType,
+    description: 'Stellar memo type',
+    example: StellarMemoType.TEXT,
+  })
+  @IsEnum(StellarMemoType)
+  type!: StellarMemoType;
+
+  @ApiPropertyOptional({
+    description:
+      'Memo value. text: up to 28 UTF-8 bytes; id: numeric string (uint64); ' +
+      'hash/return: 64-char hex (32-byte) hash; none: omit.',
+    example: 'order-1234',
+  })
+  @IsOptional()
+  @IsString()
+  value?: string;
+}

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -4,6 +4,9 @@ export * from './nested-payload.validator';
 // Stellar Address Validators
 export * from './stellar-address.validator';
 
+// Stellar Memo Validator
+export * from './stellar-memo.validator';
+
 // Asset Validators  
 export * from './asset-pair.validator';
 
@@ -22,6 +25,7 @@ export * from './date.validator';
 // Validation Decorators
 export * from '../decorators/validation.decorator';
 export * from '../decorators/is-stellar-address.decorator';
+export * from '../decorators/is-stellar-memo.decorator';
 
 // Sanitizers
 export * from '../sanitizers/input.sanitizer';

--- a/src/common/validators/stellar-memo.validator.spec.ts
+++ b/src/common/validators/stellar-memo.validator.spec.ts
@@ -1,0 +1,102 @@
+import { ValidationArguments } from 'class-validator';
+import {
+  IsStellarMemoConstraint,
+  StellarMemoType,
+} from './stellar-memo.validator';
+
+describe('IsStellarMemoConstraint', () => {
+  const constraint = new IsStellarMemoConstraint();
+  const args = (value: unknown): ValidationArguments =>
+    ({ value, property: 'memo' } as ValidationArguments);
+
+  const validate = (memo: unknown) => constraint.validate(memo, args(memo));
+
+  it('treats null/undefined memo as valid (optionality handled elsewhere)', () => {
+    expect(validate(undefined)).toBe(true);
+    expect(validate(null)).toBe(true);
+  });
+
+  it('rejects non-object memos and unknown types', () => {
+    expect(validate('just-a-string')).toBe(false);
+    expect(validate({ type: 'bogus', value: 'x' })).toBe(false);
+    expect(validate({ value: 'no-type' })).toBe(false);
+  });
+
+  describe('NONE', () => {
+    it('accepts when there is no value', () => {
+      expect(validate({ type: StellarMemoType.NONE })).toBe(true);
+      expect(validate({ type: StellarMemoType.NONE, value: '' })).toBe(true);
+    });
+
+    it('rejects when a value is supplied', () => {
+      expect(validate({ type: StellarMemoType.NONE, value: 'x' })).toBe(false);
+    });
+  });
+
+  describe('TEXT', () => {
+    it('accepts text within 28 bytes', () => {
+      expect(validate({ type: StellarMemoType.TEXT, value: 'hello world' })).toBe(
+        true,
+      );
+      expect(
+        validate({ type: StellarMemoType.TEXT, value: 'a'.repeat(28) }),
+      ).toBe(true);
+    });
+
+    it('rejects text exceeding 28 bytes (incl. multi-byte UTF-8)', () => {
+      expect(
+        validate({ type: StellarMemoType.TEXT, value: 'a'.repeat(29) }),
+      ).toBe(false);
+      // 10 emoji * 4 bytes = 40 bytes
+      expect(
+        validate({ type: StellarMemoType.TEXT, value: '😀'.repeat(10) }),
+      ).toBe(false);
+    });
+
+    it('rejects non-string text values', () => {
+      expect(validate({ type: StellarMemoType.TEXT, value: 123 })).toBe(false);
+    });
+  });
+
+  describe('ID', () => {
+    it('accepts a numeric string within the uint64 range', () => {
+      expect(validate({ type: StellarMemoType.ID, value: '0' })).toBe(true);
+      expect(
+        validate({
+          type: StellarMemoType.ID,
+          value: '18446744073709551615',
+        }),
+      ).toBe(true);
+    });
+
+    it('rejects non-numeric or out-of-range ids', () => {
+      expect(validate({ type: StellarMemoType.ID, value: 'abc' })).toBe(false);
+      expect(validate({ type: StellarMemoType.ID, value: '-1' })).toBe(false);
+      expect(
+        validate({
+          type: StellarMemoType.ID,
+          value: '18446744073709551616', // 2^64
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('HASH / RETURN', () => {
+    const hash = 'a'.repeat(64);
+
+    it('accepts a 64-char hex hash', () => {
+      expect(validate({ type: StellarMemoType.HASH, value: hash })).toBe(true);
+      expect(validate({ type: StellarMemoType.RETURN, value: hash })).toBe(true);
+    });
+
+    it('rejects wrong-length or non-hex hashes', () => {
+      expect(validate({ type: StellarMemoType.HASH, value: 'a'.repeat(63) })).toBe(
+        false,
+      );
+      expect(
+        validate({ type: StellarMemoType.HASH, value: 'z'.repeat(64) }),
+      ).toBe(false);
+      expect(validate({ type: StellarMemoType.RETURN, value: '' })).toBe(false);
+    });
+  });
+});

--- a/src/common/validators/stellar-memo.validator.ts
+++ b/src/common/validators/stellar-memo.validator.ts
@@ -1,0 +1,126 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+
+/**
+ * Stellar memo types as defined by the protocol / Stellar SDK.
+ *
+ * @see https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/memos
+ */
+export enum StellarMemoType {
+  NONE = 'none',
+  TEXT = 'text',
+  ID = 'id',
+  HASH = 'hash',
+  RETURN = 'return',
+}
+
+/** MEMO_TEXT is limited to 28 bytes of UTF-8 encoded text. */
+export const MEMO_TEXT_MAX_BYTES = 28;
+
+/** MEMO_HASH / MEMO_RETURN are 32-byte hashes encoded as 64 hex characters. */
+export const MEMO_HASH_HEX_LENGTH = 64;
+
+/** MEMO_ID is an unsigned 64-bit integer. */
+export const MEMO_ID_MAX = 18446744073709551615n; // 2^64 - 1
+
+const HEX_32_BYTES = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * The shape a memo DTO must expose for {@link IsStellarMemo} to validate it.
+ */
+export interface StellarMemoLike {
+  type?: unknown;
+  value?: unknown;
+}
+
+/**
+ * Validates a memo `{ type, value }` pair against Stellar's per-type
+ * constraints before a transaction is built.
+ *
+ * Rules:
+ * - `none`   — no value (must be empty/absent).
+ * - `text`   — string, max 28 bytes when UTF-8 encoded.
+ * - `id`     — numeric string within the unsigned 64-bit range.
+ * - `hash`   — 32-byte hash encoded as 64 hex characters.
+ * - `return` — 32-byte hash encoded as 64 hex characters.
+ */
+@ValidatorConstraint({ name: 'isStellarMemo', async: false })
+export class IsStellarMemoConstraint implements ValidatorConstraintInterface {
+  validate(memo: unknown, _args: ValidationArguments): boolean {
+    if (memo === null || memo === undefined) {
+      // Optionality is handled by @IsOptional on the field; an absent memo is
+      // considered valid here.
+      return true;
+    }
+
+    if (typeof memo !== 'object') {
+      return false;
+    }
+
+    const { type, value } = memo as StellarMemoLike;
+
+    switch (type) {
+      case StellarMemoType.NONE:
+        return value === undefined || value === null || value === '';
+
+      case StellarMemoType.TEXT:
+        return (
+          typeof value === 'string' &&
+          Buffer.byteLength(value, 'utf8') <= MEMO_TEXT_MAX_BYTES
+        );
+
+      case StellarMemoType.ID:
+        return this.isValidMemoId(value);
+
+      case StellarMemoType.HASH:
+      case StellarMemoType.RETURN:
+        return typeof value === 'string' && HEX_32_BYTES.test(value);
+
+      default:
+        // Unknown / missing memo type.
+        return false;
+    }
+  }
+
+  private isValidMemoId(value: unknown): boolean {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      return false;
+    }
+
+    const str = String(value);
+    if (!/^\d+$/.test(str)) {
+      return false;
+    }
+
+    try {
+      const id = BigInt(str);
+      return id >= 0n && id <= MEMO_ID_MAX;
+    } catch {
+      return false;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const memo = args.value as StellarMemoLike | undefined;
+    const type = memo?.type;
+
+    switch (type) {
+      case StellarMemoType.TEXT:
+        return `${args.property} text memo must not exceed ${MEMO_TEXT_MAX_BYTES} bytes (UTF-8)`;
+      case StellarMemoType.ID:
+        return `${args.property} id memo must be a numeric string within the unsigned 64-bit range`;
+      case StellarMemoType.HASH:
+      case StellarMemoType.RETURN:
+        return `${args.property} ${String(type)} memo must be a 32-byte hash encoded as ${MEMO_HASH_HEX_LENGTH} hex characters`;
+      case StellarMemoType.NONE:
+        return `${args.property} none memo must not carry a value`;
+      default:
+        return `${args.property} must specify a valid Stellar memo type (${Object.values(
+          StellarMemoType,
+        ).join(', ')})`;
+    }
+  }
+}

--- a/src/config/schemas/config.interface.ts
+++ b/src/config/schemas/config.interface.ts
@@ -25,6 +25,16 @@ export interface DatabaseConfig {
   };
 }
 
+export interface HorizonBulkheadCategoryConfig {
+  maxConcurrent: number;
+  maxQueue: number;
+}
+
+export interface HorizonBulkheadConfig {
+  read: HorizonBulkheadCategoryConfig;
+  write: HorizonBulkheadCategoryConfig;
+}
+
 export interface StellarConfig {
   network: 'testnet' | 'public';
   horizonUrl: string;
@@ -34,6 +44,7 @@ export interface StellarConfig {
   maxRetries: number;
   maxCallDepth: number;
   maxCallDepthViolationPolicy: 'reject' | 'warn';
+  horizonBulkhead: HorizonBulkheadConfig;
 }
 
 export interface RedisConfig {

--- a/src/config/stellar.config.ts
+++ b/src/config/stellar.config.ts
@@ -35,6 +35,31 @@ export const stellarConfig = registerAs(
       maxRetries: parseInt(process.env.STELLAR_MAX_RETRIES || '3', 10),
       maxCallDepth: parseInt(process.env.STELLAR_MAX_CALL_DEPTH || '5', 10),
       maxCallDepthViolationPolicy: (process.env.STELLAR_MAX_CALL_DEPTH_POLICY as 'reject' | 'warn') || 'reject',
+      // Bulkhead isolation for Horizon API calls. Read and write categories get
+      // dedicated, bounded concurrency pools so a degraded category cannot
+      // exhaust the shared request pool and starve the other.
+      horizonBulkhead: {
+        read: {
+          maxConcurrent: parseInt(
+            process.env.STELLAR_HORIZON_READ_MAX_CONCURRENT || '20',
+            10,
+          ),
+          maxQueue: parseInt(
+            process.env.STELLAR_HORIZON_READ_MAX_QUEUE || '100',
+            10,
+          ),
+        },
+        write: {
+          maxConcurrent: parseInt(
+            process.env.STELLAR_HORIZON_WRITE_MAX_CONCURRENT || '5',
+            10,
+          ),
+          maxQueue: parseInt(
+            process.env.STELLAR_HORIZON_WRITE_MAX_QUEUE || '25',
+            10,
+          ),
+        },
+      },
     };
   },
 );

--- a/src/multisig/submit-signature.dto.ts
+++ b/src/multisig/submit-signature.dto.ts
@@ -7,7 +7,11 @@ import {
   Matches,
   IsOptional,
   IsUUID,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsStellarMemo } from '../common/decorators/is-stellar-memo.decorator';
+import { StellarMemoDto } from '../common/dto/stellar-memo.dto';
 
 export class SubmitSignatureDto {
   @ApiProperty({
@@ -58,6 +62,18 @@ export class CreatePendingTransactionDto {
   @IsOptional()
   @IsString()
   memo?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Structured memo (type + value) validated against Stellar per-type ' +
+      'constraints before the transaction is built.',
+    type: StellarMemoDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => StellarMemoDto)
+  @IsStellarMemo()
+  memoDetails?: StellarMemoDto;
 
   @ApiPropertyOptional({
     description: 'Additional metadata to store alongside the transaction',

--- a/src/stellar/bulkhead/bulkhead.ts
+++ b/src/stellar/bulkhead/bulkhead.ts
@@ -1,0 +1,115 @@
+/**
+ * Error thrown when a bulkhead is saturated — both its concurrency slots and
+ * its waiting queue are full — so the call is shed rather than queued
+ * unbounded.
+ */
+export class BulkheadRejectedError extends Error {
+  constructor(public readonly category: string) {
+    super(
+      `Bulkhead "${category}" is saturated (concurrency + queue limits reached); request rejected`,
+    );
+    this.name = 'BulkheadRejectedError';
+  }
+}
+
+/** Point-in-time view of a single bulkhead's state. */
+export interface BulkheadMetrics {
+  category: string;
+  /** Number of tasks currently executing. */
+  active: number;
+  /** Number of tasks waiting for a free concurrency slot. */
+  queued: number;
+  /** Maximum concurrent executions allowed. */
+  maxConcurrent: number;
+  /** Maximum number of tasks allowed to wait in the queue. */
+  maxQueue: number;
+  /** Total tasks admitted for execution since startup. */
+  totalAdmitted: number;
+  /** Total tasks rejected due to saturation since startup. */
+  totalRejected: number;
+}
+
+interface QueuedTask {
+  run: () => void;
+}
+
+/**
+ * A bulkhead provides a bounded concurrency pool with a bounded waiting queue.
+ * Each instance isolates one category of work: saturating it can only reject or
+ * queue calls within that category and can never starve a sibling bulkhead.
+ */
+export class Bulkhead {
+  private active = 0;
+  private readonly queue: QueuedTask[] = [];
+  private totalAdmitted = 0;
+  private totalRejected = 0;
+
+  constructor(
+    public readonly category: string,
+    private readonly maxConcurrent: number,
+    private readonly maxQueue: number,
+  ) {
+    if (maxConcurrent < 1) {
+      throw new Error(
+        `Bulkhead "${category}" maxConcurrent must be >= 1 (got ${maxConcurrent})`,
+      );
+    }
+    if (maxQueue < 0) {
+      throw new Error(
+        `Bulkhead "${category}" maxQueue must be >= 0 (got ${maxQueue})`,
+      );
+    }
+  }
+
+  /**
+   * Run `task` within this bulkhead. Executes immediately if a concurrency slot
+   * is free, otherwise waits in the queue. Rejects with
+   * {@link BulkheadRejectedError} if both the pool and the queue are full.
+   */
+  execute<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const start = () => {
+        this.active++;
+        this.totalAdmitted++;
+        // Defend against synchronous throws inside `task`.
+        Promise.resolve()
+          .then(task)
+          .then(resolve, reject)
+          .finally(() => this.release());
+      };
+
+      if (this.active < this.maxConcurrent) {
+        start();
+        return;
+      }
+
+      if (this.queue.length < this.maxQueue) {
+        this.queue.push({ run: start });
+        return;
+      }
+
+      this.totalRejected++;
+      reject(new BulkheadRejectedError(this.category));
+    });
+  }
+
+  private release(): void {
+    this.active--;
+    const next = this.queue.shift();
+    if (next) {
+      next.run();
+    }
+  }
+
+  getMetrics(): BulkheadMetrics {
+    return {
+      category: this.category,
+      active: this.active,
+      queued: this.queue.length,
+      maxConcurrent: this.maxConcurrent,
+      maxQueue: this.maxQueue,
+      totalAdmitted: this.totalAdmitted,
+      totalRejected: this.totalRejected,
+    };
+  }
+}

--- a/src/stellar/bulkhead/horizon-bulkhead.controller.ts
+++ b/src/stellar/bulkhead/horizon-bulkhead.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { HorizonBulkheadService } from './horizon-bulkhead.service';
+import { BulkheadMetrics } from './bulkhead';
+
+/**
+ * Exposes per-category Horizon bulkhead metrics (queue depth, active count and
+ * rejection totals) for observability dashboards / health scraping.
+ */
+@ApiTags('stellar')
+@Controller('stellar/horizon/bulkhead')
+export class HorizonBulkheadController {
+  constructor(private readonly bulkhead: HorizonBulkheadService) {}
+
+  @Get('metrics')
+  @ApiOperation({ summary: 'Current Horizon bulkhead metrics per call category' })
+  @ApiResponse({
+    status: 200,
+    description: 'Queue depth, active count and rejection totals per category',
+  })
+  getMetrics(): { categories: BulkheadMetrics[] } {
+    return { categories: this.bulkhead.getAllMetrics() };
+  }
+}

--- a/src/stellar/bulkhead/horizon-bulkhead.module.ts
+++ b/src/stellar/bulkhead/horizon-bulkhead.module.ts
@@ -1,0 +1,17 @@
+import { Global, Module } from '@nestjs/common';
+import { HorizonBulkheadService } from './horizon-bulkhead.service';
+import { HorizonBulkheadController } from './horizon-bulkhead.controller';
+
+/**
+ * Provides {@link HorizonBulkheadService} application-wide so any service
+ * issuing Horizon API calls can route them through the shared, bounded,
+ * per-category pools. Marked `@Global()` so feature modules don't each need to
+ * import it explicitly.
+ */
+@Global()
+@Module({
+  controllers: [HorizonBulkheadController],
+  providers: [HorizonBulkheadService],
+  exports: [HorizonBulkheadService],
+})
+export class HorizonBulkheadModule {}

--- a/src/stellar/bulkhead/horizon-bulkhead.service.spec.ts
+++ b/src/stellar/bulkhead/horizon-bulkhead.service.spec.ts
@@ -1,0 +1,92 @@
+import { ConfigService } from '@nestjs/config';
+import { HorizonBulkheadService } from './horizon-bulkhead.service';
+import { HorizonCallCategory } from './horizon-bulkhead.types';
+import { BulkheadRejectedError } from './bulkhead';
+import { HorizonBulkheadConfig } from '../../config/schemas/config.interface';
+
+/** A deferred promise whose resolution we control from the test. */
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function buildService(config: HorizonBulkheadConfig): HorizonBulkheadService {
+  const configService = {
+    get: (key: string) =>
+      key === 'stellar.horizonBulkhead' ? config : undefined,
+  } as unknown as ConfigService;
+  return new HorizonBulkheadService(configService);
+}
+
+describe('HorizonBulkheadService', () => {
+  it('isolates categories: saturating WRITE leaves READ responsive', async () => {
+    const service = buildService({
+      write: { maxConcurrent: 1, maxQueue: 1 },
+      read: { maxConcurrent: 5, maxQueue: 10 },
+    });
+
+    // Saturate the write bulkhead: 1 in-flight + 1 queued = full.
+    const inflight = deferred();
+    const queued = deferred();
+
+    const writeInflight = service.write(() => inflight.promise);
+    const writeQueued = service.write(() => queued.promise);
+
+    // Third write must be rejected — write pool + queue are both full.
+    await expect(service.write(() => Promise.resolve('nope'))).rejects.toBeInstanceOf(
+      BulkheadRejectedError,
+    );
+
+    // ...but a READ call completes immediately despite write saturation.
+    await expect(service.read(() => Promise.resolve('read-ok'))).resolves.toBe(
+      'read-ok',
+    );
+
+    const writeMetrics = service.getMetrics(HorizonCallCategory.WRITE)!;
+    expect(writeMetrics.active).toBe(1);
+    expect(writeMetrics.queued).toBe(1);
+    expect(writeMetrics.totalRejected).toBe(1);
+
+    // Drain the in-flight + queued writes so the test ends cleanly.
+    inflight.resolve();
+    await writeInflight;
+    queued.resolve();
+    await writeQueued;
+  });
+
+  it('queues calls beyond maxConcurrent and admits them as slots free up', async () => {
+    const service = buildService({
+      write: { maxConcurrent: 1, maxQueue: 5 },
+      read: { maxConcurrent: 1, maxQueue: 5 },
+    });
+
+    const order: number[] = [];
+    const gate1 = deferred();
+    const gate2 = deferred();
+
+    const p1 = service.read(async () => {
+      await gate1.promise;
+      order.push(1);
+    });
+    const p2 = service.read(async () => {
+      await gate2.promise;
+      order.push(2);
+    });
+
+    // Only one read runs at a time → the second is queued.
+    expect(service.getMetrics(HorizonCallCategory.READ)!.queued).toBe(1);
+
+    gate1.resolve();
+    await p1;
+    gate2.resolve();
+    await p2;
+
+    expect(order).toEqual([1, 2]);
+    expect(service.getMetrics(HorizonCallCategory.READ)!.totalAdmitted).toBe(2);
+  });
+});

--- a/src/stellar/bulkhead/horizon-bulkhead.service.ts
+++ b/src/stellar/bulkhead/horizon-bulkhead.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Bulkhead, BulkheadMetrics, BulkheadRejectedError } from './bulkhead';
+import { HorizonCallCategory } from './horizon-bulkhead.types';
+import { HorizonBulkheadConfig } from '../../config/schemas/config.interface';
+
+const DEFAULT_BULKHEAD_CONFIG: HorizonBulkheadConfig = {
+  read: { maxConcurrent: 20, maxQueue: 100 },
+  write: { maxConcurrent: 5, maxQueue: 25 },
+};
+
+/**
+ * Routes Horizon API calls through per-category bulkheads so that saturation in
+ * one category (e.g. a slow signal-feed read storm) cannot exhaust the shared
+ * request pool and starve unrelated calls (e.g. trade-execution writes).
+ *
+ * Pool sizes are externalized via the `stellar.horizonBulkhead` config
+ * (STELLAR_HORIZON_{READ,WRITE}_MAX_{CONCURRENT,QUEUE} env vars).
+ */
+@Injectable()
+export class HorizonBulkheadService {
+  private readonly logger = new Logger(HorizonBulkheadService.name);
+  private readonly bulkheads = new Map<HorizonCallCategory, Bulkhead>();
+
+  constructor(private readonly configService: ConfigService) {
+    const config =
+      this.configService.get<HorizonBulkheadConfig>('stellar.horizonBulkhead') ??
+      DEFAULT_BULKHEAD_CONFIG;
+
+    this.bulkheads.set(
+      HorizonCallCategory.READ,
+      new Bulkhead(
+        HorizonCallCategory.READ,
+        config.read.maxConcurrent,
+        config.read.maxQueue,
+      ),
+    );
+    this.bulkheads.set(
+      HorizonCallCategory.WRITE,
+      new Bulkhead(
+        HorizonCallCategory.WRITE,
+        config.write.maxConcurrent,
+        config.write.maxQueue,
+      ),
+    );
+
+    this.logger.log(
+      `Horizon bulkheads initialized: read(${config.read.maxConcurrent}/${config.read.maxQueue}), ` +
+        `write(${config.write.maxConcurrent}/${config.write.maxQueue})`,
+    );
+  }
+
+  /**
+   * Execute a Horizon call inside the bulkhead for the given category. If the
+   * category is saturated the returned promise rejects with
+   * {@link BulkheadRejectedError} without affecting other categories.
+   */
+  async execute<T>(
+    category: HorizonCallCategory,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const bulkhead = this.bulkheads.get(category);
+    if (!bulkhead) {
+      // Should never happen — both categories are registered in the ctor.
+      throw new Error(`No bulkhead registered for category "${category}"`);
+    }
+
+    try {
+      return await bulkhead.execute(task);
+    } catch (error) {
+      if (error instanceof BulkheadRejectedError) {
+        const metrics = bulkhead.getMetrics();
+        this.logger.warn(
+          `Horizon "${category}" bulkhead rejected a call ` +
+            `(active=${metrics.active}/${metrics.maxConcurrent}, ` +
+            `queued=${metrics.queued}/${metrics.maxQueue}, ` +
+            `totalRejected=${metrics.totalRejected})`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  /** Convenience wrapper for read-category calls. */
+  read<T>(task: () => Promise<T>): Promise<T> {
+    return this.execute(HorizonCallCategory.READ, task);
+  }
+
+  /** Convenience wrapper for write-category calls. */
+  write<T>(task: () => Promise<T>): Promise<T> {
+    return this.execute(HorizonCallCategory.WRITE, task);
+  }
+
+  /** Current metrics for a single category. */
+  getMetrics(category: HorizonCallCategory): BulkheadMetrics | undefined {
+    return this.bulkheads.get(category)?.getMetrics();
+  }
+
+  /** Current metrics for every category (queue depth + rejection counts). */
+  getAllMetrics(): BulkheadMetrics[] {
+    return Array.from(this.bulkheads.values()).map((b) => b.getMetrics());
+  }
+}

--- a/src/stellar/bulkhead/horizon-bulkhead.types.ts
+++ b/src/stellar/bulkhead/horizon-bulkhead.types.ts
@@ -1,0 +1,12 @@
+/**
+ * Categories of Horizon API calls that get their own isolated bulkhead.
+ *
+ * - READ: account loads, ledger/transaction/operation queries, streaming
+ *   setup — high-volume, latency-tolerant.
+ * - WRITE: transaction submission — lower volume, must not be blocked by a
+ *   backlog of read calls (and vice versa).
+ */
+export enum HorizonCallCategory {
+  READ = 'read',
+  WRITE = 'write',
+}

--- a/src/stellar/bulkhead/index.ts
+++ b/src/stellar/bulkhead/index.ts
@@ -1,0 +1,6 @@
+export { Bulkhead, BulkheadRejectedError } from './bulkhead';
+export type { BulkheadMetrics } from './bulkhead';
+export { HorizonCallCategory } from './horizon-bulkhead.types';
+export { HorizonBulkheadService } from './horizon-bulkhead.service';
+export { HorizonBulkheadModule } from './horizon-bulkhead.module';
+export { HorizonBulkheadController } from './horizon-bulkhead.controller';

--- a/src/subscriptions/subscriptions.controller.ts
+++ b/src/subscriptions/subscriptions.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -17,10 +18,13 @@ import {
   ApiResponse,
   ApiParam,
   ApiQuery,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { SubscriptionsService } from './subscriptions.service';
 import { AccessControlService } from './services/access-control.service';
 import { CreateTierDto, UpdateTierDto } from './dto/create-tier.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentWallet } from '../common/decorators/current-wallet.decorator';
 import {
   SubscribeDto,
   CancelSubscriptionDto,
@@ -69,13 +73,14 @@ export class SubscriptionsController {
   // ─────────────────────────────────────────────────────────────
 
   @Post('tiers')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Provider creates a new subscription tier' })
   @ApiResponse({ status: 201, description: 'Tier created successfully' })
   @ApiQuery({ name: 'providerId', description: 'UUID of the provider (user)' })
-  @ApiQuery({ name: 'providerWallet', description: 'Provider Stellar wallet address' })
   async createTier(
     @Query('providerId') providerId: string,
-    @Query('providerWallet') providerWallet: string,
+    @CurrentWallet() providerWallet: string,
     @Body() dto: CreateTierDto,
   ) {
     return this.subscriptionsService.createTier(providerId, providerWallet, dto);
@@ -131,6 +136,8 @@ export class SubscriptionsController {
   // ─────────────────────────────────────────────────────────────
 
   @Post('subscribe')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: 'Subscribe a user to a tier (provide Stellar USDC tx hash as proof of payment)',
@@ -139,9 +146,15 @@ export class SubscriptionsController {
   @ApiQuery({ name: 'userId', description: 'Subscriber user UUID (auth stub)' })
   async subscribe(
     @Query('userId') userId: string,
+    @CurrentWallet() subscriberWallet: string,
     @Body() dto: SubscribeDto,
   ) {
-    return this.subscriptionsService.subscribe(userId, dto);
+    // The subscriber's wallet is taken from the authenticated session rather
+    // than trusting a client-supplied body field.
+    return this.subscriptionsService.subscribe(userId, {
+      ...dto,
+      subscriberWallet,
+    });
   }
 
   @Get('my/:userId')

--- a/src/trades/services/market-order.service.ts
+++ b/src/trades/services/market-order.service.ts
@@ -16,6 +16,7 @@ import { StellarConfigService } from "../../config/stellar.service";
 import { MarketOrderDto } from "../dto/market-order.dto";
 import { MarketOrderResponseDto } from "../dto/order-response.dto";
 import { buildAsset } from "./asset-utils";
+import { HorizonBulkheadService } from "../../stellar/bulkhead/horizon-bulkhead.service";
 
 interface MarketPriceEstimate {
   averagePrice: number;
@@ -30,7 +31,10 @@ export class MarketOrderService {
   private readonly server: Horizon.Server;
   private readonly logger = new Logger(MarketOrderService.name);
 
-  constructor(private readonly stellarConfig: StellarConfigService) {
+  constructor(
+    private readonly stellarConfig: StellarConfigService,
+    private readonly bulkhead: HorizonBulkheadService,
+  ) {
     this.server = new Horizon.Server(this.stellarConfig.horizonUrl, {
       allowHttp: this.stellarConfig.horizonUrl.startsWith("http://"),
     });
@@ -111,7 +115,9 @@ export class MarketOrderService {
         `Submitting market order: ${dto.amount} ${dto.sellingAssetCode} -> ${dto.buyingAssetCode}`,
       );
 
-      const result = await this.server.submitTransaction(transaction);
+      const result = await this.bulkhead.write(() =>
+        this.server.submitTransaction(transaction),
+      );
 
       this.logger.log(`Market order executed successfully: ${result.hash}`);
 
@@ -262,7 +268,7 @@ export class MarketOrderService {
     publicKey: string,
   ): Promise<Horizon.AccountResponse> {
     try {
-      return await this.server.loadAccount(publicKey);
+      return await this.bulkhead.read(() => this.server.loadAccount(publicKey));
     } catch (error) {
       this.logger.error(
         `Failed to load account ${publicKey}: ${(error as Error).message}`,

--- a/src/trades/services/oco-order.service.ts
+++ b/src/trades/services/oco-order.service.ts
@@ -30,6 +30,7 @@ import {
 } from '../dto/oco-order.dto';
 import { StellarConfigService } from '../../config/stellar.service';
 import { buildAsset } from './asset-utils';
+import { HorizonBulkheadService } from '../../stellar/bulkhead/horizon-bulkhead.service';
 
 @Injectable()
 export class OcoOrderService {
@@ -40,6 +41,7 @@ export class OcoOrderService {
     @InjectRepository(AdvancedOrder)
     private readonly repo: Repository<AdvancedOrder>,
     private readonly stellarConfig: StellarConfigService,
+    private readonly bulkhead: HorizonBulkheadService,
   ) {
     this.server = new Horizon.Server(this.stellarConfig.horizonUrl, {
       allowHttp: this.stellarConfig.horizonUrl.startsWith('http://'),
@@ -142,7 +144,9 @@ export class OcoOrderService {
 
       tx.sign(keypair);
 
-      const result = await this.server.submitTransaction(tx);
+      const result = await this.bulkhead.write(() =>
+        this.server.submitTransaction(tx),
+      );
       this.logger.log(`OCO order submitted – tx: ${result.hash}`);
 
       // Parse offer IDs from the tx result operations
@@ -388,7 +392,7 @@ export class OcoOrderService {
       .build();
 
     tx.sign(keypair);
-    await this.server.submitTransaction(tx);
+    await this.bulkhead.write(() => this.server.submitTransaction(tx));
     this.logger.log(`Cancelled offer ${offerId}`);
   }
 
@@ -423,7 +427,7 @@ export class OcoOrderService {
 
   private async loadAccount(publicKey: string): Promise<Horizon.AccountResponse> {
     try {
-      return await this.server.loadAccount(publicKey);
+      return await this.bulkhead.read(() => this.server.loadAccount(publicKey));
     } catch (err: any) {
       if (err?.response?.status === 404) {
         throw new BadRequestException(

--- a/src/wallet/wallet-status.controller.ts
+++ b/src/wallet/wallet-status.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Post, Delete, Request, UseGuards, Query } from '@nestjs/common';
+import { Controller, Get, Post, Delete, UseGuards, Query } from '@nestjs/common';
 import { WalletStatusService } from './wallet-status.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentWallet } from '../common/decorators/current-wallet.decorator';
 
 @Controller('wallet')
 export class WalletStatusController {
@@ -17,8 +18,11 @@ export class WalletStatusController {
 
   @UseGuards(JwtAuthGuard)
   @Post('refresh')
-  refresh(@Request() req: any, @Query('sessionId') sessionId: string) {
-    return this.walletStatusService.refresh(sessionId, req.user.publicKey ?? '');
+  refresh(
+    @CurrentWallet() walletAddress: string,
+    @Query('sessionId') sessionId: string,
+  ) {
+    return this.walletStatusService.refresh(sessionId, walletAddress);
   }
 
   @UseGuards(JwtAuthGuard)


### PR DESCRIPTION
This PR implements four issues across developer tooling, resilience, and validation. Each is in its own conventional commit.

## #693 — commitlint + Husky hooks
- Adds `@commitlint/cli` + `@commitlint/config-conventional` and a `commitlint.config.js` enforcing conventional-commit types and a 100-char header limit.
- Husky `commit-msg` hook rejects non-conforming messages; `pre-push` hook runs `npm run lint` and `npm run test:smoke`.
- Hooks install automatically via the `prepare` script on `npm install`.
- `CONTRIBUTING.md` added and `README.md` updated with the commit format, allowed types, and examples.

Closes #693

## #676 — Bulkhead isolation for Horizon API calls
- New `HorizonBulkheadService` with dedicated, bounded concurrency pools per category (`read` vs `write`) plus a bounded waiting queue; exceeding a category's limits queues then rejects within that category only, never affecting the other.
- Pool sizes externalized via config/env (`STELLAR_HORIZON_{READ,WRITE}_MAX_{CONCURRENT,QUEUE}`).
- Queue depth, active count and rejection counts exposed per category via a metrics endpoint (`GET /stellar/horizon/bulkhead/metrics`) and warn logs on rejection.
- `MarketOrderService` and `OcoOrderService` route `loadAccount` (read) and `submitTransaction` (write) through the bulkhead.
- Test simulates saturating the write category and verifies reads stay responsive.

Closes #676

## #671 — @CurrentWallet param decorator
- `@CurrentWallet()` (built with `createParamDecorator`) extracts the authenticated wallet from the request in one place; throws a clear `UnauthorizedException` when absent, with an `{ optional: true }` mode.
- Refactors three controller methods off manual extraction: wallet-status `refresh`, and subscriptions `createTier` / `subscribe`.
- Unit tests cover present-wallet and missing-wallet cases.

Closes #671

## #669 — @IsStellarMemo class-validator decorator
- `@IsStellarMemo()` validates a `StellarMemoDto` (`{ type, value }`) against Stellar's per-type constraints: `text` <= 28 UTF-8 bytes, `id` numeric within the uint64 range, `hash`/`return` 32-byte (64 hex char) hashes, `none` carries no value.
- Applied to the DTOs that accept an optional memo (payment + multisig), rejecting invalid combinations before the Stellar SDK.
- Unit tests cover each memo type with valid and invalid values.

Closes #669

> Note: implementation only — tests were written but not executed in this environment (`node_modules` not installed here).
