### PR TITLE
Fix/four issues reputation ratelimit circuit deprecation

### DIFF
--- a/src/common/decorators/rate-limit.decorator.ts
+++ b/src/common/decorators/rate-limit.decorator.ts
@@ -18,6 +18,8 @@ export interface RateLimitConfig {
   keyBy?: string[];       // request body fields for per-account rate limiting
   accountLimit?: number;  // per-account limit (overrides tier default)
   accountWindow?: number; // per-account window in seconds (overrides tier default)
+  walletLimit?: number;   // per-wallet limit (overrides tier default)
+  walletWindow?: number;  // per-wallet window in seconds (overrides tier default)
 }
 
 export const RateLimit = (config: RateLimitConfig) =>

--- a/src/common/guards/rate-limit.guard.ts
+++ b/src/common/guards/rate-limit.guard.ts
@@ -42,6 +42,17 @@ const DEFAULT_ACCOUNT_TIER_LIMITS: Record<RateLimitTier, { limit: number; window
   [RateLimitTier.ADMIN]: { limit: 5000, window: 15 * 60 },
 };
 
+// Default per-wallet limit/window (seconds) per tier.
+// Override via RATE_LIMIT_<TIER>_WALLET_LIMIT / RATE_LIMIT_<TIER>_WALLET_WINDOW env vars.
+const DEFAULT_WALLET_TIER_LIMITS: Record<RateLimitTier, { limit: number; window: number }> = {
+  [RateLimitTier.PUBLIC]: { limit: 60, window: 15 * 60 },
+  [RateLimitTier.AUTH]: { limit: 8, window: 300 },
+  [RateLimitTier.AUTHENTICATED]: { limit: 600, window: 15 * 60 },
+  [RateLimitTier.TRADE]: { limit: 8, window: 60 },
+  [RateLimitTier.SIGNAL]: { limit: 8, window: 24 * 60 * 60 },
+  [RateLimitTier.ADMIN]: { limit: 6000, window: 15 * 60 },
+};
+
 // Violation count thresholds for abuse pattern escalation within a 1-hour window.
 const ABUSE_WARN_THRESHOLD = 3;
 const ABUSE_ERROR_THRESHOLD = 10;
@@ -52,6 +63,7 @@ export class RateLimitGuard implements CanActivate {
   private readonly logger = new Logger(RateLimitGuard.name);
   private readonly limits: Record<RateLimitTier, { limit: number; window: number }>;
   private readonly accountLimits: Record<RateLimitTier, { limit: number; window: number }>;
+  private readonly walletLimits: Record<RateLimitTier, { limit: number; window: number }>;
 
   constructor(
     private reflector: Reflector,
@@ -61,6 +73,7 @@ export class RateLimitGuard implements CanActivate {
   ) {
     this.limits = this.buildTierLimits();
     this.accountLimits = this.buildAccountTierLimits();
+    this.walletLimits = this.buildWalletTierLimits();
   }
 
   private buildTierLimits(): Record<RateLimitTier, { limit: number; window: number }> {
@@ -89,6 +102,19 @@ export class RateLimitGuard implements CanActivate {
     }, {} as Record<RateLimitTier, { limit: number; window: number }>);
   }
 
+  private buildWalletTierLimits(): Record<RateLimitTier, { limit: number; window: number }> {
+    const tiers = Object.values(RateLimitTier) as RateLimitTier[];
+    return tiers.reduce((acc, tier) => {
+      const envPrefix = `RATE_LIMIT_${tier.toUpperCase()}_WALLET`;
+      const defaults = DEFAULT_WALLET_TIER_LIMITS[tier];
+      acc[tier] = {
+        limit: this.getEnvNumber(`${envPrefix}_LIMIT`, defaults.limit),
+        window: this.getEnvNumber(`${envPrefix}_WINDOW`, defaults.window),
+      };
+      return acc;
+    }, {} as Record<RateLimitTier, { limit: number; window: number }>);
+  }
+
   private getEnvNumber(key: string, fallback: number): number {
     const raw = this.configService?.get<string | number>(key);
     const parsed = Number(raw);
@@ -106,6 +132,18 @@ export class RateLimitGuard implements CanActivate {
 
     // Per-IP check
     await this.checkRateLimit(context, effectiveTier, config?.limit, config?.window);
+
+    // Per-wallet check when the request has an authenticated wallet address
+    const walletAddress = this.extractWalletAddress(context);
+    if (walletAddress) {
+      await this.checkWalletLimit(
+        context,
+        effectiveTier,
+        walletAddress,
+        config?.walletLimit,
+        config?.walletWindow,
+      );
+    }
 
     // Per-account check when keyBy is specified
     if (config?.keyBy?.length) {
@@ -260,6 +298,62 @@ export class RateLimitGuard implements CanActivate {
     response.setHeader('X-RateLimit-Limit', finalLimit);
     response.setHeader('X-RateLimit-Remaining', finalLimit - info.count);
     response.setHeader('X-RateLimit-Reset', info.resetTime);
+  }
+
+  private extractWalletAddress(context: ExecutionContext): string | null {
+    const request = context.switchToHttp().getRequest();
+    const wallet = request.user?.walletAddress ?? request.user?.wallet ?? null;
+    return typeof wallet === 'string' && wallet.length > 0 ? wallet.toLowerCase() : null;
+  }
+
+  private async checkWalletLimit(
+    context: ExecutionContext,
+    tier: RateLimitTier,
+    walletAddress: string,
+    customLimit?: number,
+    customWindow?: number,
+  ): Promise<void> {
+    const response = context.switchToHttp().getResponse();
+    const { limit: defaultLimit, window: defaultWindow } = this.walletLimits[tier];
+    const finalLimit = customLimit ?? defaultLimit;
+    const finalWindow = customWindow ?? defaultWindow;
+
+    const key = `rate_limit:wallet:${tier}:${walletAddress}`;
+    const info = await this.getRateLimitInfo(key);
+
+    const now = Date.now();
+    const windowMs = finalWindow * 1000;
+
+    if (info.resetTime <= now) {
+      info.count = 0;
+      info.resetTime = now + windowMs;
+    }
+
+    info.count++;
+
+    if (info.count > finalLimit) {
+      const retryAfter = Math.ceil((info.resetTime - now) / 1000);
+
+      response.setHeader('X-RateLimit-Limit', finalLimit);
+      response.setHeader('X-RateLimit-Remaining', 0);
+      response.setHeader('X-RateLimit-Reset', info.resetTime);
+      response.setHeader('Retry-After', retryAfter);
+
+      this.logViolation(`wallet:${walletAddress}`, tier, finalLimit);
+
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          message: 'Too many requests',
+          error: 'Too Many Requests',
+          retryAfter,
+          guidance: `Wallet rate limit of ${finalLimit} requests per ${finalWindow}s exceeded. Retry after ${retryAfter}s.`,
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    await this.setRateLimitInfo(key, info, finalWindow);
   }
 
   private extractAccountIdentifier(request: any, keyBy: string[]): string | null {

--- a/src/http/circuit-breaker.controller.ts
+++ b/src/http/circuit-breaker.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { CircuitBreakerService, CircuitState } from './circuit-breaker.service';
+import { AdminRoleGuard } from '../admin/guards/admin-role.guard';
+
+export interface CircuitStatusDto {
+  name: string;
+  state: CircuitState;
+  failureCount: number;
+  successCount: number;
+  lastFailureAt: string | null;
+  lastStateChangeAt: string | null;
+}
+
+@ApiTags('Operations')
+@ApiBearerAuth()
+@UseGuards(AdminRoleGuard)
+@Controller('admin/circuits')
+export class CircuitBreakerController {
+  constructor(private readonly circuitBreakerService: CircuitBreakerService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all circuit breaker states (admin only)' })
+  getCircuitStatuses(): CircuitStatusDto[] {
+    const allStats = this.circuitBreakerService.getAllStats();
+    return Object.entries(allStats).map(([name, stats]) => ({
+      name,
+      state: stats.state,
+      failureCount: stats.failures,
+      successCount: stats.successes,
+      lastFailureAt: stats.lastFailureAt?.toISOString() ?? null,
+      lastStateChangeAt: stats.openedAt?.toISOString() ?? null,
+    }));
+  }
+}

--- a/src/reputation-scoring/provider-reputation.service.ts
+++ b/src/reputation-scoring/provider-reputation.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ReputationScore } from './reputation-score.entity';
-import { ReputationScoringService, ProviderMetrics } from './reputation-scoring.service';
+import { ReputationScoringService } from './reputation-scoring.service';
 
 export type SignalOutcomeType = 'success' | 'failure' | 'invalidated';
 
@@ -56,13 +56,29 @@ export class ProviderReputationService {
       return { providerId: event.providerId, previousScore, newScore: previousScore, delta: 0, isBlacklisted: true };
     }
 
+    const delta = this.getOutcomeDelta(event);
     this.applyOutcomeToRecord(record, event);
     this.checkAndApplyBlacklist(record);
 
-    const metrics = this.buildMetrics(record, event.copierCount);
-    const breakdown = this.scoringService.calculateScore(metrics);
+    const breakdown = this.scoringService.calculateIncrementalScore(
+      {
+        score: previousScore,
+        smoothedScore: Number(record.smoothedScore ?? previousScore),
+        totalSignals: record.totalSignals - delta.signalsDelta,
+        winningSignals: record.winningSignals - delta.winsDelta,
+        totalCopiers: record.totalCopiers,
+        activeCopiers: record.activeCopiers,
+        stakeAmount: Number(record.stakeAmount),
+        avgRating: Number(record.avgRating),
+        ratingCount: record.ratingCount ?? 0,
+        activeDays: record.activeDays ?? 30,
+        activeDaysLast30: 20,
+      },
+      { ...delta, newCopierCount: event.copierCount },
+    );
 
     record.score = breakdown.smoothedScore;
+    record.smoothedScore = breakdown.smoothedScore;
     record.winRate = breakdown.winRate;
     record.consistencyScore = breakdown.consistencyScore;
     record.retentionRate = breakdown.retentionRate;
@@ -150,18 +166,14 @@ export class ProviderReputationService {
     }
   }
 
-  private buildMetrics(record: ReputationScore, copierCount: number): ProviderMetrics {
-    return {
-      providerId: record.providerId,
-      totalSignals: record.totalSignals,
-      winningSignals: record.winningSignals,
-      totalCopiers: record.totalCopiers,
-      activeCopiers: copierCount,
-      stakeAmount: Number(record.stakeAmount),
-      avgRating: Number(record.avgRating),
-      ratingCount: 0,
-      activeDays: 30,
-      activeDaysLast30: 20,
-    };
+  private getOutcomeDelta(event: SignalOutcomeEvent): { signalsDelta: number; winsDelta: number } {
+    switch (event.outcome) {
+      case 'success':
+        return { signalsDelta: 1, winsDelta: 1 };
+      case 'failure':
+        return { signalsDelta: 1, winsDelta: 0 };
+      case 'invalidated':
+        return { signalsDelta: -1, winsDelta: 0 };
+    }
   }
 }

--- a/src/reputation-scoring/reputation-scoring.service.ts
+++ b/src/reputation-scoring/reputation-scoring.service.ts
@@ -137,6 +137,48 @@ export class ReputationScoringService {
   }
 
   /**
+   * Compute an incremental score update from a previous score record and a
+   * single new signal outcome, avoiding a full history recompute.
+   */
+  calculateIncrementalScore(
+    previous: {
+      score: number;
+      smoothedScore: number;
+      totalSignals: number;
+      winningSignals: number;
+      totalCopiers: number;
+      activeCopiers: number;
+      stakeAmount: number;
+      avgRating: number;
+      ratingCount: number;
+      activeDays: number;
+      activeDaysLast30: number;
+    },
+    delta: { signalsDelta: number; winsDelta: number; newCopierCount: number },
+  ): ScoreBreakdown {
+    const updatedMetrics: ProviderMetrics = {
+      providerId: '',
+      totalSignals: previous.totalSignals + delta.signalsDelta,
+      winningSignals: previous.winningSignals + delta.winsDelta,
+      totalCopiers: Math.max(previous.totalCopiers, delta.newCopierCount),
+      activeCopiers: delta.newCopierCount,
+      stakeAmount: previous.stakeAmount,
+      avgRating: previous.avgRating,
+      ratingCount: previous.ratingCount,
+      activeDays: previous.activeDays,
+      activeDaysLast30: previous.activeDaysLast30,
+    };
+
+    const breakdown = this.calculateScore(updatedMetrics);
+    const smoothedScore = this.applyEMA(previous.smoothedScore, breakdown.score);
+
+    return {
+      ...breakdown,
+      smoothedScore: parseFloat(smoothedScore.toFixed(2)),
+    };
+  }
+
+  /**
    * Bulk update scores for all providers — used by the daily cron job.
    */
   async updateAllProviderScores(allMetrics: ProviderMetrics[]): Promise<void> {
@@ -154,6 +196,14 @@ export class ReputationScoringService {
     this.logger.log(
       `Reputation update complete: ${results.length - failed} succeeded, ${failed} failed`,
     );
+  }
+
+  /**
+   * Full recompute for a single provider — used as a correctness safeguard
+   * against incremental drift. Returns the freshly computed score.
+   */
+  async fullRecompute(metrics: ProviderMetrics): Promise<ReputationScore> {
+    return this.updateProviderScore(metrics);
   }
 
   /**

--- a/src/reputation-scoring/update-reputation-scores.job.ts
+++ b/src/reputation-scoring/update-reputation-scores.job.ts
@@ -79,6 +79,43 @@ export class UpdateReputationScoresJob {
   }
 
   /**
+   * Weekly full-recompute safeguard against incremental drift.
+   * Runs every Sunday at 03:00 UTC.
+   */
+  @Cron('0 3 * * 0', { name: 'full-recompute-reputation-scores', timeZone: 'UTC' })
+  async handleFullRecompute(): Promise<void> {
+    const { ran } = await this.distributedLock.withLock(
+      `${LOCK_KEY}:full-recompute`,
+      LOCK_TTL_MS,
+      () => this.runFullRecompute(),
+    );
+    if (!ran) {
+      this.logger.log('Skipping full recompute — another replica is running it');
+    }
+  }
+
+  private async runFullRecompute(): Promise<void> {
+    this.logger.log('Starting weekly full reputation recompute (drift safeguard)');
+    const startTime = Date.now();
+    const metrics = await this.fetchAllProviderMetrics();
+
+    if (metrics.length === 0) {
+      this.logger.warn('No provider metrics found — skipping full recompute');
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      metrics.map((m) => this.reputationScoringService.fullRecompute(m)),
+    );
+
+    const failed = results.filter((r) => r.status === 'rejected').length;
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    this.logger.log(
+      `Full recompute finished in ${elapsed}s: ${metrics.length - failed} succeeded, ${failed} failed`,
+    );
+  }
+
+  /**
    * Allows manual triggering outside of the cron schedule
    * (e.g. via an admin endpoint or for backfilling).
    */

--- a/src/versioning/interceptors/deprecation.interceptor.spec.ts
+++ b/src/versioning/interceptors/deprecation.interceptor.spec.ts
@@ -8,11 +8,22 @@ import { DEPRECATED_KEY, DEPRECATION_METADATA_KEY } from '../decorators/deprecat
 // Helpers
 // ---------------------------------------------------------------------------
 
-function buildContext(isDeprecated: boolean, options?: any): ExecutionContext {
+function buildContext(
+  isDeprecated: boolean,
+  options?: any,
+  user?: { id?: string; walletAddress?: string },
+): ExecutionContext {
   const headers: Record<string, string> = {};
   const res = {
     setHeader: jest.fn((k: string, v: string) => { headers[k] = v; }),
     _headers: headers,
+  };
+  const req = {
+    method: 'GET',
+    url: '/api/v1/signals',
+    originalUrl: '/api/v1/signals',
+    ip: '10.0.0.1',
+    user: user ?? undefined,
   };
 
   const reflector = new Reflector();
@@ -26,6 +37,7 @@ function buildContext(isDeprecated: boolean, options?: any): ExecutionContext {
     getHandler: jest.fn(),
     getClass: jest.fn(),
     switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue(req),
       getResponse: jest.fn().mockReturnValue(res),
     }),
   } as unknown as ExecutionContext;
@@ -137,6 +149,49 @@ describe('DeprecationInterceptor', () => {
         (c: any[]) => c[0] === 'Sunset',
       );
       expect(sunsetCall).toBeUndefined();
+      done();
+    });
+  });
+
+  it('logs deprecated endpoint usage with caller identity', (done) => {
+    const warnSpy = jest.spyOn((interceptor as any).logger, 'warn').mockImplementation(() => {});
+    const ctx = buildContext(
+      true,
+      { sunsetDate: '2025-12-31' },
+      { id: 'user-42' },
+    );
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('caller=user-42'),
+        expect.objectContaining({ type: 'deprecated_endpoint_usage', caller: 'user-42' }),
+      );
+      done();
+    });
+  });
+
+  it('does NOT log when endpoint is not deprecated', (done) => {
+    const warnSpy = jest.spyOn((interceptor as any).logger, 'warn').mockImplementation(() => {});
+    const ctx = buildContext(false);
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      expect(warnSpy).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('falls back to IP when no user identity is present', (done) => {
+    const warnSpy = jest.spyOn((interceptor as any).logger, 'warn').mockImplementation(() => {});
+    const ctx = buildContext(true, { sunsetDate: '2025-12-31' });
+    const handler = buildHandler();
+
+    interceptor.intercept(ctx, handler).subscribe(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('caller=10.0.0.1'),
+        expect.objectContaining({ type: 'deprecated_endpoint_usage' }),
+      );
       done();
     });
   });

--- a/src/versioning/interceptors/deprecation.interceptor.ts
+++ b/src/versioning/interceptors/deprecation.interceptor.ts
@@ -1,12 +1,13 @@
 import {
   Injectable,
+  Logger,
   NestInterceptor,
   ExecutionContext,
   CallHandler,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import {
   DEPRECATED_KEY,
   DEPRECATION_METADATA_KEY,
@@ -30,6 +31,8 @@ import {
  */
 @Injectable()
 export class DeprecationInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(DeprecationInterceptor.name);
+
   constructor(private readonly reflector: Reflector) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
@@ -65,6 +68,14 @@ export class DeprecationInterceptor implements NestInterceptor {
         parts.push(`Please migrate to v${options.successorVersion}.`);
 
       res.setHeader('X-Deprecation-Notice', parts.join(' '));
+
+      const req: Request = context.switchToHttp().getRequest();
+      const caller = (req as any).user?.id ?? (req as any).user?.walletAddress ?? req.ip ?? 'anonymous';
+      const route = `${req.method} ${req.originalUrl ?? req.url}`;
+      this.logger.warn(
+        `Deprecated endpoint called: route=${route} caller=${caller} sunset=${options?.sunsetDate ?? 'unset'}`,
+        { type: 'deprecated_endpoint_usage', route, caller, sunsetDate: options?.sunsetDate },
+      );
     }
 
     return next.handle();

--- a/test/circuit-breaker-status.spec.ts
+++ b/test/circuit-breaker-status.spec.ts
@@ -1,0 +1,98 @@
+import { CircuitBreakerService, CircuitState } from '../src/http/circuit-breaker.service';
+import { CircuitBreakerController } from '../src/http/circuit-breaker.controller';
+
+describe('CircuitBreakerController', () => {
+  let controller: CircuitBreakerController;
+  let service: CircuitBreakerService;
+
+  beforeEach(() => {
+    service = new CircuitBreakerService();
+    controller = new CircuitBreakerController(service);
+    jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+    jest.spyOn((service as any).logger, 'log').mockImplementation(() => {});
+  });
+
+  it('returns empty array when no circuits exist', () => {
+    const result = controller.getCircuitStatuses();
+    expect(result).toEqual([]);
+  });
+
+  it('lists all registered circuits with their current state', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    await service.execute('stellar-horizon', fn);
+    await service.execute('price-oracle', fn);
+
+    const result = controller.getCircuitStatuses();
+
+    expect(result).toHaveLength(2);
+    const names = result.map((c) => c.name);
+    expect(names).toContain('stellar-horizon');
+    expect(names).toContain('price-oracle');
+    expect(result[0].state).toBe(CircuitState.CLOSED);
+  });
+
+  it('reflects OPEN state and failure count after failures', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('timeout'));
+    const opts = { failureThreshold: 3, recoveryTimeMs: 60_000 };
+
+    for (let i = 0; i < 3; i++) {
+      await service.execute('stellar-horizon', fn, opts).catch(() => {});
+    }
+
+    const result = controller.getCircuitStatuses();
+    const horizon = result.find((c) => c.name === 'stellar-horizon');
+
+    expect(horizon).toBeDefined();
+    expect(horizon!.state).toBe(CircuitState.OPEN);
+    expect(horizon!.failureCount).toBeGreaterThanOrEqual(3);
+    expect(horizon!.lastFailureAt).not.toBeNull();
+    expect(horizon!.lastStateChangeAt).not.toBeNull();
+  });
+
+  it('reflects HALF_OPEN state after recovery timeout', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('fail'));
+    const opts = { failureThreshold: 2, recoveryTimeMs: 0, successThreshold: 2 };
+
+    for (let i = 0; i < 2; i++) {
+      await service.execute('svc', fn, opts).catch(() => {});
+    }
+
+    fn.mockResolvedValueOnce('ok');
+    await service.execute('svc', fn, opts);
+
+    const result = controller.getCircuitStatuses();
+    const svc = result.find((c) => c.name === 'svc');
+
+    expect(svc).toBeDefined();
+    expect(svc!.state).toBe(CircuitState.HALF_OPEN);
+  });
+
+  it('reflects state change back to CLOSED after recovery', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('fail'));
+    const opts = { failureThreshold: 2, recoveryTimeMs: 0, successThreshold: 1 };
+
+    for (let i = 0; i < 2; i++) {
+      await service.execute('svc', fn, opts).catch(() => {});
+    }
+
+    fn.mockResolvedValue('ok');
+    await service.execute('svc', fn, opts);
+
+    const result = controller.getCircuitStatuses();
+    const svc = result.find((c) => c.name === 'svc');
+
+    expect(svc!.state).toBe(CircuitState.CLOSED);
+    expect(svc!.failureCount).toBe(0);
+  });
+
+  it('includes null timestamps for circuits that have never failed', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    await service.execute('healthy-svc', fn);
+
+    const result = controller.getCircuitStatuses();
+    const svc = result.find((c) => c.name === 'healthy-svc');
+
+    expect(svc!.lastFailureAt).toBeNull();
+    expect(svc!.lastStateChangeAt).toBeNull();
+  });
+});

--- a/test/incremental-reputation.spec.ts
+++ b/test/incremental-reputation.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import {
+  ReputationScoringService,
+  ProviderMetrics,
+} from '../src/reputation-scoring/reputation-scoring.service';
+import { ReputationScore } from '../src/reputation-scoring/reputation-score.entity';
+
+const buildMetrics = (overrides: Partial<ProviderMetrics> = {}): ProviderMetrics => ({
+  providerId: 'provider-1',
+  totalSignals: 50,
+  winningSignals: 35,
+  totalCopiers: 100,
+  activeCopiers: 80,
+  stakeAmount: 5000,
+  avgRating: 4.2,
+  ratingCount: 20,
+  activeDays: 90,
+  activeDaysLast30: 25,
+  ...overrides,
+});
+
+describe('Incremental vs Full Recompute Equivalence', () => {
+  let service: ReputationScoringService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReputationScoringService,
+        {
+          provide: getRepositoryToken(ReputationScore),
+          useValue: { findOne: jest.fn(), find: jest.fn(), create: jest.fn(), save: jest.fn() },
+        },
+        {
+          provide: DataSource,
+          useValue: { createQueryBuilder: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ReputationScoringService);
+  });
+
+  it('incremental update matches full recompute for a success outcome', () => {
+    const base = buildMetrics({ totalSignals: 50, winningSignals: 35 });
+    const baseBreakdown = service.calculateScore(base);
+
+    const afterFull = service.calculateScore(
+      buildMetrics({ totalSignals: 51, winningSignals: 36 }),
+    );
+
+    const afterIncremental = service.calculateIncrementalScore(
+      {
+        score: baseBreakdown.score,
+        smoothedScore: baseBreakdown.score,
+        totalSignals: 50,
+        winningSignals: 35,
+        totalCopiers: 100,
+        activeCopiers: 80,
+        stakeAmount: 5000,
+        avgRating: 4.2,
+        ratingCount: 20,
+        activeDays: 90,
+        activeDaysLast30: 25,
+      },
+      { signalsDelta: 1, winsDelta: 1, newCopierCount: 80 },
+    );
+
+    expect(afterIncremental.score).toBe(afterFull.score);
+    expect(afterIncremental.winRate).toBe(afterFull.winRate);
+    expect(afterIncremental.consistencyScore).toBe(afterFull.consistencyScore);
+  });
+
+  it('incremental update matches full recompute for a failure outcome', () => {
+    const afterFull = service.calculateScore(
+      buildMetrics({ totalSignals: 51, winningSignals: 35 }),
+    );
+
+    const baseBreakdown = service.calculateScore(buildMetrics());
+
+    const afterIncremental = service.calculateIncrementalScore(
+      {
+        score: baseBreakdown.score,
+        smoothedScore: baseBreakdown.score,
+        totalSignals: 50,
+        winningSignals: 35,
+        totalCopiers: 100,
+        activeCopiers: 80,
+        stakeAmount: 5000,
+        avgRating: 4.2,
+        ratingCount: 20,
+        activeDays: 90,
+        activeDaysLast30: 25,
+      },
+      { signalsDelta: 1, winsDelta: 0, newCopierCount: 80 },
+    );
+
+    expect(afterIncremental.score).toBe(afterFull.score);
+    expect(afterIncremental.winRate).toBe(afterFull.winRate);
+  });
+
+  it('incremental update matches full recompute for an invalidated outcome', () => {
+    const afterFull = service.calculateScore(
+      buildMetrics({ totalSignals: 49, winningSignals: 35 }),
+    );
+
+    const baseBreakdown = service.calculateScore(buildMetrics());
+
+    const afterIncremental = service.calculateIncrementalScore(
+      {
+        score: baseBreakdown.score,
+        smoothedScore: baseBreakdown.score,
+        totalSignals: 50,
+        winningSignals: 35,
+        totalCopiers: 100,
+        activeCopiers: 80,
+        stakeAmount: 5000,
+        avgRating: 4.2,
+        ratingCount: 20,
+        activeDays: 90,
+        activeDaysLast30: 25,
+      },
+      { signalsDelta: -1, winsDelta: 0, newCopierCount: 80 },
+    );
+
+    expect(afterIncremental.score).toBe(afterFull.score);
+    expect(afterIncremental.winRate).toBe(afterFull.winRate);
+  });
+
+  it('produces equivalent scores across a sequence of incremental updates', () => {
+    const outcomes: Array<{ signalsDelta: number; winsDelta: number }> = [
+      { signalsDelta: 1, winsDelta: 1 },
+      { signalsDelta: 1, winsDelta: 0 },
+      { signalsDelta: 1, winsDelta: 1 },
+      { signalsDelta: -1, winsDelta: 0 },
+      { signalsDelta: 1, winsDelta: 1 },
+    ];
+
+    let totalSignals = 50;
+    let winningSignals = 35;
+    let prevScore = service.calculateScore(buildMetrics()).score;
+
+    for (const delta of outcomes) {
+      totalSignals += delta.signalsDelta;
+      winningSignals += delta.winsDelta;
+
+      const fullResult = service.calculateScore(
+        buildMetrics({ totalSignals, winningSignals }),
+      );
+
+      const incrResult = service.calculateIncrementalScore(
+        {
+          score: prevScore,
+          smoothedScore: prevScore,
+          totalSignals: totalSignals - delta.signalsDelta,
+          winningSignals: winningSignals - delta.winsDelta,
+          totalCopiers: 100,
+          activeCopiers: 80,
+          stakeAmount: 5000,
+          avgRating: 4.2,
+          ratingCount: 20,
+          activeDays: 90,
+          activeDaysLast30: 25,
+        },
+        { ...delta, newCopierCount: 80 },
+      );
+
+      expect(incrResult.score).toBe(fullResult.score);
+      prevScore = fullResult.score;
+    }
+  });
+
+  it('incremental smoothedScore applies EMA correctly', () => {
+    const baseBreakdown = service.calculateScore(buildMetrics());
+
+    const result = service.calculateIncrementalScore(
+      {
+        score: baseBreakdown.score,
+        smoothedScore: 60,
+        totalSignals: 50,
+        winningSignals: 35,
+        totalCopiers: 100,
+        activeCopiers: 80,
+        stakeAmount: 5000,
+        avgRating: 4.2,
+        ratingCount: 20,
+        activeDays: 90,
+        activeDaysLast30: 25,
+      },
+      { signalsDelta: 1, winsDelta: 1, newCopierCount: 80 },
+    );
+
+    const expectedSmoothed = 0.3 * result.score + 0.7 * 60;
+    expect(result.smoothedScore).toBeCloseTo(expectedSmoothed, 1);
+  });
+});

--- a/test/wallet-rate-limit.spec.ts
+++ b/test/wallet-rate-limit.spec.ts
@@ -1,0 +1,158 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { RateLimitGuard } from '../src/common/guards/rate-limit.guard';
+import { RateLimitTier, RATE_LIMIT_KEY } from '../src/common/decorators/rate-limit.decorator';
+
+const mockCacheManager = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+
+const mockReflector = {
+  get: jest.fn(),
+};
+
+function buildContext(
+  user?: { id: string; walletAddress?: string },
+  ip = '127.0.0.1',
+): ExecutionContext {
+  const response = { setHeader: jest.fn() };
+  return {
+    getHandler: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => ({
+        user,
+        headers: {},
+        socket: { remoteAddress: ip },
+        body: {},
+      }),
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('Wallet-based Rate Limiting', () => {
+  let guard: RateLimitGuard;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateLimitGuard,
+        { provide: Reflector, useValue: mockReflector },
+        { provide: CACHE_MANAGER, useValue: mockCacheManager },
+      ],
+    }).compile();
+
+    guard = module.get(RateLimitGuard);
+  });
+
+  it('should throttle a single wallet across different IPs', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.AUTHENTICATED });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    const walletAddress = 'GABCDEF1234567890';
+    let walletCallCount = 0;
+
+    mockCacheManager.get.mockImplementation((key: string) => {
+      if (key.includes('wallet:')) {
+        walletCallCount++;
+        if (walletCallCount > 600) {
+          return Promise.resolve({ count: 600, resetTime: Date.now() + 60_000 });
+        }
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    });
+
+    const ctx1 = buildContext({ id: 'user-1', walletAddress }, '10.0.0.1');
+    await expect(guard.canActivate(ctx1)).resolves.toBe(true);
+
+    const ctx2 = buildContext({ id: 'user-1', walletAddress }, '10.0.0.2');
+    await expect(guard.canActivate(ctx2)).resolves.toBe(true);
+
+    expect(mockCacheManager.set).toHaveBeenCalledWith(
+      expect.stringContaining('wallet:'),
+      expect.any(Object),
+      expect.any(Number),
+    );
+  });
+
+  it('should apply wallet limit in addition to IP limit', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.AUTHENTICATED });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    mockCacheManager.get.mockImplementation((key: string) => {
+      if (key.includes('wallet:')) {
+        return Promise.resolve({ count: 700, resetTime: Date.now() + 60_000 });
+      }
+      return Promise.resolve(null);
+    });
+
+    const ctx = buildContext(
+      { id: 'user-1', walletAddress: 'GABCDEF1234567890' },
+      '10.0.0.1',
+    );
+
+    await expect(guard.canActivate(ctx)).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+    });
+  });
+
+  it('should not apply wallet limit when no wallet address is present', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.PUBLIC });
+    mockCacheManager.get.mockResolvedValue(null);
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    const ctx = buildContext(undefined, '10.0.0.1');
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+
+    const walletSetCalls = mockCacheManager.set.mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('wallet:'),
+    );
+    expect(walletSetCalls).toHaveLength(0);
+  });
+
+  it('should use wallet-specific cache key distinct from IP key', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.AUTHENTICATED });
+    mockCacheManager.get.mockResolvedValue(null);
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    const ctx = buildContext(
+      { id: 'user-1', walletAddress: 'GXYZ9876' },
+      '10.0.0.1',
+    );
+    await guard.canActivate(ctx);
+
+    const keys = mockCacheManager.set.mock.calls.map((c: any[]) => c[0]);
+    const ipKey = keys.find((k: string) => k.startsWith('rate_limit:authenticated:'));
+    const walletKey = keys.find((k: string) => k.startsWith('rate_limit:wallet:'));
+
+    expect(ipKey).toBeDefined();
+    expect(walletKey).toBeDefined();
+    expect(walletKey).toContain('gxyz9876');
+    expect(ipKey).not.toEqual(walletKey);
+  });
+
+  it('should reject same wallet from different IPs when wallet limit exceeded', async () => {
+    mockReflector.get.mockReturnValue({ tier: RateLimitTier.TRADE });
+    mockCacheManager.set.mockResolvedValue(undefined);
+
+    mockCacheManager.get.mockImplementation((key: string) => {
+      if (key.includes('wallet:')) {
+        return Promise.resolve({ count: 100, resetTime: Date.now() + 60_000 });
+      }
+      return Promise.resolve(null);
+    });
+
+    const wallet = 'GSAMEWALLET';
+
+    const ctx1 = buildContext({ id: 'user-1', walletAddress: wallet }, '192.168.1.1');
+    await expect(guard.canActivate(ctx1)).rejects.toThrow(HttpException);
+
+    const ctx2 = buildContext({ id: 'user-1', walletAddress: wallet }, '192.168.1.2');
+    await expect(guard.canActivate(ctx2)).rejects.toThrow(HttpException);
+  });
+});


### PR DESCRIPTION
closes #781 
closes #782
closes #783
closes #784 

API versioning and deprecation notices exist at a route level, but there is no standardized HTTP header signal (e.g. a Deprecation/Sunset header) attached automatically to responses from endpoints marked for retirement, leaving clients to discover deprecation only through documentation.
Signal provider reputation scoring is implemented, but appears to recompute a provider's full score from scratch on each trigger, which becomes increasingly expensive as a provider accumulates a long history of signals and trades.

