### PR TITLE
feat: add withdrawal OTP guard, audit diffing, token cleanup, and ver…

### DIFF
--- a/src/admin/admin-audit.controller.ts
+++ b/src/admin/admin-audit.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { PermissionAuditService, AuditAction } from '../auth/permission-audit.service';
+import { AdminRoleGuard } from './guards/admin-role.guard';
+
+@ApiTags('Admin Audit')
+@ApiBearerAuth()
+@UseGuards(AdminRoleGuard)
+@Controller('admin/audit/permissions')
+export class AdminAuditController {
+  constructor(private readonly permissionAuditService: PermissionAuditService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Query permission/role change audit history' })
+  @ApiQuery({ name: 'actorId', required: false })
+  @ApiQuery({ name: 'targetUserId', required: false })
+  @ApiQuery({ name: 'action', required: false, enum: AuditAction })
+  @ApiQuery({ name: 'from', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  async queryAuditLog(
+    @Query('actorId') actorId?: string,
+    @Query('targetUserId') targetUserId?: string,
+    @Query('action') action?: AuditAction,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.permissionAuditService.query({
+      actorId,
+      targetUserId,
+      action,
+      from: from ? new Date(from) : undefined,
+      to: to ? new Date(to) : undefined,
+      limit: limit ? parseInt(limit, 10) : 50,
+      offset: offset ? parseInt(offset, 10) : 0,
+    });
+  }
+
+  @Get('users/:userId')
+  @ApiOperation({ summary: 'Get full permission audit trail for a specific user' })
+  async getUserAuditTrail(@Param('userId') userId: string) {
+    return this.permissionAuditService.getTrailForUser(userId);
+  }
+
+  @Get('actors/:actorId')
+  @ApiOperation({ summary: 'Get all permission changes made by a specific admin' })
+  async getActorAuditTrail(@Param('actorId') actorId: string) {
+    return this.permissionAuditService.query({ actorId });
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -2,12 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminController } from './admin.controller';
 import { AdminManagementService } from './admin.service';
+import { AdminAuditController } from './admin-audit.controller';
 import { User } from '../users/entities/user.entity';
 import { Signal } from '../signals/entities/signal.entity';
 import { AuditLog } from '../audit-log/audit-log.entity';
 import { AdminAnalyticsModule } from './analytics/admin-analytics.module';
-// The auth modules normally needed to protect these routes
-// import { AuthModule } from '../auth/auth.module';
+import { PermissionAuditService, PermissionAuditLog } from '../auth/permission-audit.service';
 
 @Module({
     imports: [
@@ -15,12 +15,12 @@ import { AdminAnalyticsModule } from './analytics/admin-analytics.module';
             User,
             Signal,
             AuditLog,
+            PermissionAuditLog,
         ]),
         AdminAnalyticsModule,
-        // AuthModule
     ],
-    controllers: [AdminController],
-    providers: [AdminManagementService],
+    controllers: [AdminController, AdminAuditController],
+    providers: [AdminManagementService, PermissionAuditService],
     exports: [AdminManagementService],
 })
 export class AdminModule { }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -25,6 +25,8 @@ import { SessionFingerprintService } from './session/session-fingerprint.service
 import { LoginFingerprint } from './session/entities/login-fingerprint.entity';
 import { EmailModule } from '../email/email.module';
 import { AnomalousLoginListener } from './session/anomalous-login.listener';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { RefreshTokenCleanupService } from './refresh-token-cleanup.service';
 
 @Module({
   imports: [
@@ -41,7 +43,7 @@ import { AnomalousLoginListener } from './session/anomalous-login.listener';
     }),
     CacheModule,
     AuditModule,
-    TypeOrmModule.forFeature([User, SocialConnection, TwoFactor, LoginFingerprint]),
+    TypeOrmModule.forFeature([User, SocialConnection, TwoFactor, LoginFingerprint, RefreshToken]),
     UsersModule,
     EmailModule,
   ],
@@ -58,6 +60,7 @@ import { AnomalousLoginListener } from './session/anomalous-login.listener';
     SessionCleanupService,
     SessionFingerprintService,
     AnomalousLoginListener,
+    RefreshTokenCleanupService,
   ],
   exports: [
     AuthService,
@@ -68,6 +71,7 @@ import { AnomalousLoginListener } from './session/anomalous-login.listener';
     AuthAuditService,
     SessionManagerService,
     SessionFingerprintService,
+    RefreshTokenCleanupService,
   ],
 })
 export class AuthModule {}

--- a/src/auth/entities/refresh-token.entity.ts
+++ b/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('refresh_tokens')
+@Index(['userId'])
+@Index(['expiresAt'])
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'token_hash', type: 'varchar', length: 255, unique: true })
+  tokenHash: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'session_id', type: 'varchar', nullable: true })
+  sessionId: string | null;
+
+  @Column({ name: 'expires_at', type: 'timestamp' })
+  expiresAt: Date;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  isExpired(): boolean {
+    return new Date() > this.expiresAt;
+  }
+}

--- a/src/auth/permission-audit.service.spec.ts
+++ b/src/auth/permission-audit.service.spec.ts
@@ -5,7 +5,41 @@ import {
   PermissionAuditService,
   PermissionAuditLog,
   AuditAction,
+  diffObjects,
 } from './permission-audit.service';
+
+describe('diffObjects', () => {
+  it('returns null when objects are identical (no-op update)', () => {
+    expect(diffObjects({ name: 'admin', isActive: true }, { name: 'admin', isActive: true })).toBeNull();
+  });
+
+  it('captures a single changed field', () => {
+    const diff = diffObjects({ name: 'admin' }, { name: 'super-admin' });
+    expect(diff).not.toBeNull();
+    expect(diff!.before).toEqual({ name: 'admin' });
+    expect(diff!.after).toEqual({ name: 'super-admin' });
+  });
+
+  it('captures multiple changed fields and ignores unchanged ones', () => {
+    const diff = diffObjects(
+      { name: 'admin', isActive: true, priority: 1 },
+      { name: 'super-admin', isActive: false, priority: 1 },
+    );
+    expect(Object.keys(diff!.before)).toHaveLength(2);
+    expect(diff!.before).not.toHaveProperty('priority');
+  });
+
+  it('captures fields added in after state', () => {
+    const diff = diffObjects({ name: 'admin' }, { name: 'admin', extra: 'value' });
+    expect(diff!.after).toHaveProperty('extra', 'value');
+    expect(diff!.before).toHaveProperty('extra', undefined);
+  });
+
+  it('captures fields removed in after state', () => {
+    const diff = diffObjects({ name: 'admin', extra: 'x' }, { name: 'admin' });
+    expect(diff!.before).toHaveProperty('extra', 'x');
+  });
+});
 
 describe('PermissionAuditService', () => {
   let service: PermissionAuditService;
@@ -62,6 +96,8 @@ describe('PermissionAuditService', () => {
         targetUserId: dto.targetUserId,
         action: dto.action,
         resourceName: dto.resourceName,
+        beforeState: null,
+        afterState: null,
         metadata: dto.metadata,
       });
       expect(mockRepository.save).toHaveBeenCalledWith(mockEntry);
@@ -83,6 +119,26 @@ describe('PermissionAuditService', () => {
 
       expect(mockRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({ targetUserId: 'actor-1' }),
+      );
+    });
+
+    it('should persist beforeState and afterState when provided', async () => {
+      const dto = {
+        actorId: 'admin-1',
+        targetUserId: 'user-1',
+        action: AuditAction.ROLE_UPDATED,
+        resourceName: 'editor',
+        beforeState: { name: 'editor' },
+        afterState: { name: 'super-editor' },
+      };
+      const mockEntry = { id: 'log-x', ...dto, createdAt: new Date() };
+      mockRepository.create.mockReturnValue(mockEntry);
+      mockRepository.save.mockResolvedValue(mockEntry);
+
+      await service.log(dto);
+
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ beforeState: { name: 'editor' }, afterState: { name: 'super-editor' } }),
       );
     });
 

--- a/src/auth/permission-audit.service.ts
+++ b/src/auth/permission-audit.service.ts
@@ -47,6 +47,14 @@ export class PermissionAuditLog {
   @Column({ type: 'varchar', length: 255 })
   resourceName: string;
 
+  /** Snapshot of the role/permission state before the change (only changed fields) */
+  @Column({ name: 'before_state', type: 'jsonb', nullable: true })
+  beforeState: Record<string, unknown> | null;
+
+  /** Snapshot of the role/permission state after the change (only changed fields) */
+  @Column({ name: 'after_state', type: 'jsonb', nullable: true })
+  afterState: Record<string, unknown> | null;
+
   /** Optional free-form context (role id, permission ids, reason, etc.) */
   @Column({ type: 'jsonb', nullable: true })
   metadata: Record<string, unknown>;
@@ -64,7 +72,33 @@ export interface LogPermissionChangeDto {
   targetUserId?: string;
   action: AuditAction;
   resourceName: string;
+  /** State before the change — only include fields that changed */
+  beforeState?: Record<string, unknown>;
+  /** State after the change — only include fields that changed */
+  afterState?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
+}
+
+/** Computes a diff between two plain objects, returning only keys that differ. */
+export function diffObjects(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): { before: Record<string, unknown>; after: Record<string, unknown> } | null {
+  const changedBefore: Record<string, unknown> = {};
+  const changedAfter: Record<string, unknown> = {};
+
+  const allKeys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of allKeys) {
+    const bVal = JSON.stringify(before[key]);
+    const aVal = JSON.stringify(after[key]);
+    if (bVal !== aVal) {
+      changedBefore[key] = before[key];
+      changedAfter[key] = after[key];
+    }
+  }
+
+  if (Object.keys(changedBefore).length === 0) return null; // no-op
+  return { before: changedBefore, after: changedAfter };
 }
 
 export interface AuditQueryDto {
@@ -91,7 +125,7 @@ export class PermissionAuditService {
   ) {}
 
   /**
-   * Record a single RBAC / permission change event.
+   * Record a single RBAC / permission change event with optional before/after diff.
    */
   async log(dto: LogPermissionChangeDto): Promise<PermissionAuditLog> {
     const entry = this.auditRepository.create({
@@ -99,6 +133,8 @@ export class PermissionAuditService {
       targetUserId: dto.targetUserId ?? dto.actorId,
       action: dto.action,
       resourceName: dto.resourceName,
+      beforeState: dto.beforeState ?? null,
+      afterState: dto.afterState ?? null,
       metadata: dto.metadata ?? {},
     });
 

--- a/src/auth/refresh-token-cleanup.service.spec.ts
+++ b/src/auth/refresh-token-cleanup.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { RefreshTokenCleanupService } from './refresh-token-cleanup.service';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+function makeDeleteQb(affected: number) {
+  const qb: any = {
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected }),
+  };
+  return qb;
+}
+
+describe('RefreshTokenCleanupService', () => {
+  let service: RefreshTokenCleanupService;
+  let qbFactory: jest.Mock;
+  let countMock: jest.Mock;
+
+  beforeEach(async () => {
+    qbFactory = jest.fn();
+    countMock = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RefreshTokenCleanupService,
+        {
+          provide: getRepositoryToken(RefreshToken),
+          useValue: {
+            createQueryBuilder: qbFactory,
+            count: countMock,
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, def?: any) =>
+              key === 'REFRESH_TOKEN_CLEANUP_BATCH_SIZE' ? 500 : def,
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(RefreshTokenCleanupService);
+  });
+
+  describe('deleteExpiredTokens', () => {
+    it('deletes expired tokens in a single batch when fewer than batch size', async () => {
+      const qb = makeDeleteQb(10);
+      qbFactory.mockReturnValueOnce(qb).mockReturnValueOnce(makeDeleteQb(0));
+
+      await service.deleteExpiredTokens();
+
+      expect(qb.execute).toHaveBeenCalled();
+    });
+
+    it('loops until batch returns 0 rows (batch boundary)', async () => {
+      const fullBatch = makeDeleteQb(500);
+      const partialBatch = makeDeleteQb(200);
+      const emptyBatch = makeDeleteQb(0);
+
+      qbFactory
+        .mockReturnValueOnce(fullBatch)
+        .mockReturnValueOnce(partialBatch)
+        .mockReturnValueOnce(emptyBatch);
+
+      await service.deleteExpiredTokens();
+
+      expect(fullBatch.execute).toHaveBeenCalledTimes(1);
+      expect(partialBatch.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when repository throws — logs the error', async () => {
+      qbFactory.mockReturnValueOnce({
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockRejectedValue(new Error('DB error')),
+      });
+
+      await expect(service.deleteExpiredTokens()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('countExpired / countActive', () => {
+    it('countExpired queries tokens with expiresAt < now', async () => {
+      countMock.mockResolvedValue(3);
+      const result = await service.countExpired();
+      expect(result).toBe(3);
+      expect(countMock).toHaveBeenCalledWith({ where: { expiresAt: expect.anything() } });
+    });
+
+    it('countActive uses a query builder to count non-expired tokens', async () => {
+      const qb: any = {
+        where: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(7),
+      };
+      qbFactory.mockReturnValue(qb);
+      const result = await service.countActive();
+      expect(result).toBe(7);
+    });
+  });
+});

--- a/src/auth/refresh-token-cleanup.service.ts
+++ b/src/auth/refresh-token-cleanup.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+const DEFAULT_BATCH_SIZE = 500;
+
+@Injectable()
+export class RefreshTokenCleanupService {
+  private readonly logger = new Logger(RefreshTokenCleanupService.name);
+  private readonly batchSize: number;
+
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepository: Repository<RefreshToken>,
+    private readonly configService: ConfigService,
+  ) {
+    this.batchSize = this.configService.get<number>(
+      'REFRESH_TOKEN_CLEANUP_BATCH_SIZE',
+      DEFAULT_BATCH_SIZE,
+    );
+  }
+
+  /**
+   * Scheduled cleanup of expired refresh tokens.
+   * Runs at 3 AM daily. Processes in batches to avoid long-running locks.
+   * Safe to run concurrently across replicas — DELETE WHERE expiresAt < now is idempotent.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async deleteExpiredTokens(): Promise<void> {
+    this.logger.log('Starting expired refresh token cleanup');
+    const now = new Date();
+    let totalDeleted = 0;
+
+    try {
+      let batchDeleted: number;
+      do {
+        const result = await this.refreshTokenRepository
+          .createQueryBuilder()
+          .delete()
+          .from(RefreshToken)
+          .where('expires_at < :now', { now })
+          .limit(this.batchSize)
+          .execute();
+
+        batchDeleted = result.affected ?? 0;
+        totalDeleted += batchDeleted;
+
+        if (batchDeleted > 0) {
+          this.logger.log(`Deleted batch of ${batchDeleted} expired refresh tokens`);
+        }
+      } while (batchDeleted === this.batchSize);
+
+      this.logger.log(`Refresh token cleanup complete. Total deleted: ${totalDeleted}`);
+    } catch (error) {
+      this.logger.error(
+        `Refresh token cleanup failed after deleting ${totalDeleted} rows`,
+        (error as Error).message,
+      );
+    }
+  }
+
+  /**
+   * Exposed for use in integration tests and manual triggers.
+   */
+  async countExpired(): Promise<number> {
+    return this.refreshTokenRepository.count({
+      where: { expiresAt: LessThan(new Date()) },
+    });
+  }
+
+  async countActive(): Promise<number> {
+    return this.refreshTokenRepository
+      .createQueryBuilder('rt')
+      .where('rt.expires_at >= :now', { now: new Date() })
+      .getCount();
+  }
+}

--- a/src/authorization/rbac.service.ts
+++ b/src/authorization/rbac.service.ts
@@ -12,7 +12,7 @@ import { AssignPermissionDto, CheckPermissionDto } from './dto/assign-permission
 import { CreateWorkflowDto, UpdateWorkflowDto } from './dto/workflow-config.dto';
 import { CreateAccessRequestDto, ApproveRequestDto, RejectRequestDto } from './dto/access-request.dto';
 import { IPermissionContext } from './interfaces/permission.interface';
-import { PermissionAuditService, AuditAction } from '../auth/permission-audit.service';
+import { PermissionAuditService, AuditAction, diffObjects } from '../auth/permission-audit.service';
 
 @Injectable()
 export class RbacService {
@@ -67,6 +67,17 @@ export class RbacService {
       throw new NotFoundException('Role not found');
     }
 
+    // Capture before state for diffing
+    const beforeSnapshot: Record<string, unknown> = {
+      name: role.name,
+      description: role.description,
+      type: role.type,
+      scope: role.scope,
+      isActive: role.isActive,
+      priority: role.priority,
+      permissionIds: role.permissions?.map((p) => p.id) ?? [],
+    };
+
     Object.assign(role, dto);
 
     if (dto.permissionIds) {
@@ -75,13 +86,29 @@ export class RbacService {
     }
 
     const saved = await this.roleRepository.save(role);
+
     if (updatedBy) {
-      await this.permissionAuditService.log({
-        actorId: updatedBy,
-        action: AuditAction.ROLE_UPDATED,
-        resourceName: saved.name,
-        metadata: { roleId: id, changes: dto },
-      });
+      const afterSnapshot: Record<string, unknown> = {
+        name: saved.name,
+        description: saved.description,
+        type: saved.type,
+        scope: saved.scope,
+        isActive: saved.isActive,
+        priority: saved.priority,
+        permissionIds: saved.permissions?.map((p) => p.id) ?? [],
+      };
+
+      const diff = diffObjects(beforeSnapshot, afterSnapshot);
+      if (diff) {
+        await this.permissionAuditService.log({
+          actorId: updatedBy,
+          action: AuditAction.ROLE_UPDATED,
+          resourceName: saved.name,
+          beforeState: diff.before,
+          afterState: diff.after,
+          metadata: { roleId: id },
+        });
+      }
     }
     return saved;
   }
@@ -161,17 +188,28 @@ export class RbacService {
       throw new NotFoundException('Role not found');
     }
 
+    const previousPermissionIds = role.permissions?.map((p) => p.id) ?? [];
+
     const permissions = await this.permissionRepository.findByIds(dto.permissionIds);
     role.permissions = permissions;
 
     const saved = await this.roleRepository.save(role);
+
     if (actorId) {
-      await this.permissionAuditService.log({
-        actorId,
-        action: AuditAction.PERMISSION_GRANTED,
-        resourceName: role.name,
-        metadata: { roleId: dto.roleId, permissionIds: dto.permissionIds },
-      });
+      const diff = diffObjects(
+        { permissionIds: previousPermissionIds },
+        { permissionIds: dto.permissionIds },
+      );
+      if (diff) {
+        await this.permissionAuditService.log({
+          actorId,
+          action: AuditAction.PERMISSION_GRANTED,
+          resourceName: role.name,
+          beforeState: diff.before,
+          afterState: diff.after,
+          metadata: { roleId: dto.roleId },
+        });
+      }
     }
     return saved;
   }

--- a/src/common/decorators/require-verified-email.decorator.ts
+++ b/src/common/decorators/require-verified-email.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const REQUIRE_VERIFIED_EMAIL_KEY = 'requireVerifiedEmail';
+
+/**
+ * Restricts an endpoint to users who have verified their email address.
+ * Must be used alongside JwtAuthGuard (or equivalent) and VerifiedEmailGuard.
+ *
+ * @example
+ * ```ts
+ * @Get('payout-settings')
+ * @UseGuards(JwtAuthGuard, VerifiedEmailGuard)
+ * @RequireVerifiedEmail()
+ * getPayoutSettings() { ... }
+ * ```
+ */
+export const RequireVerifiedEmail = () => SetMetadata(REQUIRE_VERIFIED_EMAIL_KEY, true);

--- a/src/common/guards/verified-email.guard.spec.ts
+++ b/src/common/guards/verified-email.guard.spec.ts
@@ -1,0 +1,58 @@
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { VerifiedEmailGuard } from './verified-email.guard';
+import { REQUIRE_VERIFIED_EMAIL_KEY } from '../decorators/require-verified-email.decorator';
+
+function makeContext(user: any, handlerMeta: boolean | undefined): ExecutionContext {
+  return {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('VerifiedEmailGuard', () => {
+  let guard: VerifiedEmailGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new VerifiedEmailGuard(reflector);
+  });
+
+  it('allows the request when the decorator is not present', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    const ctx = makeContext({ emailVerified: false }, undefined);
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('allows a verified user when the decorator is present', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const ctx = makeContext({ id: 'u1', emailVerified: true }, true);
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('rejects an unverified user with ForbiddenException', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const ctx = makeContext({ id: 'u1', emailVerified: false }, true);
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('rejects when user is absent (guard composed without auth guard)', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const ctx = makeContext(undefined, true);
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('error message contains EMAIL_NOT_VERIFIED code for unverified user', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const ctx = makeContext({ id: 'u1', emailVerified: false }, true);
+    try {
+      guard.canActivate(ctx);
+    } catch (err) {
+      expect((err as ForbiddenException).message).toContain('EMAIL_NOT_VERIFIED');
+    }
+  });
+});

--- a/src/common/guards/verified-email.guard.ts
+++ b/src/common/guards/verified-email.guard.ts
@@ -1,0 +1,44 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { REQUIRE_VERIFIED_EMAIL_KEY } from '../decorators/require-verified-email.decorator';
+
+/**
+ * Guard that enforces email verification on endpoints decorated with @RequireVerifiedEmail().
+ * Must be composed after an authentication guard so req.user is populated.
+ * Endpoints without @RequireVerifiedEmail() are completely unaffected.
+ */
+@Injectable()
+export class VerifiedEmailGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const required = this.reflector.getAllAndOverride<boolean>(
+      REQUIRE_VERIFIED_EMAIL_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!required) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user) {
+      throw new ForbiddenException('Authentication required.');
+    }
+
+    if (!user.emailVerified) {
+      throw new ForbiddenException(
+        'EMAIL_NOT_VERIFIED: This action requires a verified email address.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/payments/withdrawal-otp/dto/withdrawal-otp.dto.ts
+++ b/src/payments/withdrawal-otp/dto/withdrawal-otp.dto.ts
@@ -1,0 +1,19 @@
+import { IsUUID, IsString, Length } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RequestWithdrawalOtpDto {
+  @ApiProperty({ description: 'The withdrawal request ID requiring OTP confirmation' })
+  @IsUUID()
+  withdrawalRequestId: string;
+}
+
+export class VerifyWithdrawalOtpDto {
+  @ApiProperty({ description: 'The withdrawal request ID' })
+  @IsUUID()
+  withdrawalRequestId: string;
+
+  @ApiProperty({ description: 'The 6-digit OTP code' })
+  @IsString()
+  @Length(6, 6)
+  otp: string;
+}

--- a/src/payments/withdrawal-otp/entities/withdrawal-otp.entity.ts
+++ b/src/payments/withdrawal-otp/entities/withdrawal-otp.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('withdrawal_otps')
+@Index(['userId', 'withdrawalRequestId'])
+export class WithdrawalOtp {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'withdrawal_request_id', type: 'uuid' })
+  withdrawalRequestId: string;
+
+  @Column({ name: 'otp_hash', type: 'varchar', length: 255 })
+  otpHash: string;
+
+  @Column({ name: 'expires_at', type: 'timestamp' })
+  expiresAt: Date;
+
+  @Column({ name: 'used_at', type: 'timestamp', nullable: true })
+  usedAt: Date | null;
+
+  @Column({ name: 'attempt_count', type: 'int', default: 0 })
+  attemptCount: number;
+
+  @Column({ name: 'locked_until', type: 'timestamp', nullable: true })
+  lockedUntil: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  isExpired(): boolean {
+    return new Date() > this.expiresAt;
+  }
+
+  isUsed(): boolean {
+    return this.usedAt !== null;
+  }
+
+  isLocked(): boolean {
+    return this.lockedUntil !== null && new Date() < this.lockedUntil;
+  }
+}

--- a/src/payments/withdrawal-otp/guards/withdrawal-otp.guard.ts
+++ b/src/payments/withdrawal-otp/guards/withdrawal-otp.guard.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { WithdrawalOtpService } from '../withdrawal-otp.service';
+
+/**
+ * Validates a withdrawal OTP before allowing the request to proceed.
+ *
+ * Expects the request body or headers to contain:
+ *   - `withdrawalRequestId`: UUID of the pending withdrawal
+ *   - `x-withdrawal-otp` header OR `otp` field in the body
+ *
+ * Must be composed after JwtAuthGuard so `req.user` is populated.
+ */
+@Injectable()
+export class WithdrawalOtpGuard implements CanActivate {
+  constructor(private readonly withdrawalOtpService: WithdrawalOtpService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId: string | undefined = request.user?.id;
+
+    if (!userId) {
+      throw new ForbiddenException('Authentication required.');
+    }
+
+    const withdrawalRequestId: string =
+      request.body?.withdrawalRequestId ?? request.params?.withdrawalRequestId;
+
+    if (!withdrawalRequestId) {
+      throw new BadRequestException('withdrawalRequestId is required.');
+    }
+
+    const otp: string =
+      request.headers?.['x-withdrawal-otp'] ?? request.body?.otp;
+
+    if (!otp) {
+      throw new BadRequestException(
+        'OTP is required. Provide it via x-withdrawal-otp header or otp body field.',
+      );
+    }
+
+    await this.withdrawalOtpService.verifyOtp(userId, withdrawalRequestId, otp);
+
+    return true;
+  }
+}

--- a/src/payments/withdrawal-otp/withdrawal-otp.controller.ts
+++ b/src/payments/withdrawal-otp/withdrawal-otp.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { WithdrawalOtpService } from './withdrawal-otp.service';
+import { RequestWithdrawalOtpDto } from './dto/withdrawal-otp.dto';
+
+@ApiTags('Withdrawal OTP')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('withdrawals/otp')
+export class WithdrawalOtpController {
+  constructor(private readonly withdrawalOtpService: WithdrawalOtpService) {}
+
+  @Post('request')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Request a one-time OTP for a pending withdrawal' })
+  @ApiResponse({ status: 200, description: 'OTP sent to the user verified email/phone' })
+  async requestOtp(
+    @Request() req: any,
+    @Body() dto: RequestWithdrawalOtpDto,
+  ): Promise<{ message: string }> {
+    const userId: string = req.user.id;
+    const userEmail: string = req.user.email;
+
+    await this.withdrawalOtpService.requestOtp(
+      userId,
+      dto.withdrawalRequestId,
+      userEmail,
+    );
+
+    return { message: 'OTP sent to your verified email address.' };
+  }
+}

--- a/src/payments/withdrawal-otp/withdrawal-otp.module.ts
+++ b/src/payments/withdrawal-otp/withdrawal-otp.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { WithdrawalOtp } from './entities/withdrawal-otp.entity';
+import { WithdrawalOtpService } from './withdrawal-otp.service';
+import { WithdrawalOtpController } from './withdrawal-otp.controller';
+import { WithdrawalOtpGuard } from './guards/withdrawal-otp.guard';
+import { AuthModule } from '../../auth/auth.module';
+import { EmailModule } from '../../email/email.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([WithdrawalOtp]),
+    ConfigModule,
+    AuthModule,
+    EmailModule,
+  ],
+  controllers: [WithdrawalOtpController],
+  providers: [WithdrawalOtpService, WithdrawalOtpGuard],
+  exports: [WithdrawalOtpService, WithdrawalOtpGuard],
+})
+export class WithdrawalOtpModule {}

--- a/src/payments/withdrawal-otp/withdrawal-otp.service.spec.ts
+++ b/src/payments/withdrawal-otp/withdrawal-otp.service.spec.ts
@@ -1,0 +1,141 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { WithdrawalOtpService } from './withdrawal-otp.service';
+import { WithdrawalOtp } from './entities/withdrawal-otp.entity';
+import { EmailService } from '../../email/email.service';
+import * as bcrypt from 'bcrypt';
+
+const USER_ID = 'user-uuid-1';
+const WITHDRAWAL_ID = 'withdrawal-uuid-1';
+const PLAIN_OTP = '123456';
+
+function makeOtpRecord(overrides: Partial<WithdrawalOtp> = {}): WithdrawalOtp {
+  const record = new WithdrawalOtp();
+  record.id = 'otp-uuid-1';
+  record.userId = USER_ID;
+  record.withdrawalRequestId = WITHDRAWAL_ID;
+  record.otpHash = 'hash';
+  record.expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+  record.usedAt = null;
+  record.attemptCount = 0;
+  record.lockedUntil = null;
+  record.createdAt = new Date();
+  return Object.assign(record, overrides);
+}
+
+describe('WithdrawalOtpService', () => {
+  let service: WithdrawalOtpService;
+  let otpRepo: jest.Mocked<Repository<WithdrawalOtp>>;
+  let emailService: jest.Mocked<EmailService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WithdrawalOtpService,
+        {
+          provide: getRepositoryToken(WithdrawalOtp),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+            createQueryBuilder: jest.fn().mockReturnValue({
+              update: jest.fn().mockReturnThis(),
+              set: jest.fn().mockReturnThis(),
+              where: jest.fn().mockReturnThis(),
+              execute: jest.fn().mockResolvedValue({ affected: 0 }),
+            }),
+          },
+        },
+        {
+          provide: EmailService,
+          useValue: { sendEmail: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultVal?: any) => {
+              if (key === 'WITHDRAWAL_OTP_MAX_ATTEMPTS') return 5;
+              if (key === 'WITHDRAWAL_OTP_LOCKOUT_MS') return 15 * 60 * 1000;
+              return defaultVal;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(WithdrawalOtpService);
+    otpRepo = module.get(getRepositoryToken(WithdrawalOtp));
+    emailService = module.get(EmailService);
+  });
+
+  describe('requestOtp', () => {
+    it('sends an OTP email and persists the hashed OTP', async () => {
+      otpRepo.create.mockReturnValue(makeOtpRecord());
+      otpRepo.save.mockResolvedValue(makeOtpRecord());
+
+      await service.requestOtp(USER_ID, WITHDRAWAL_ID, 'user@example.com');
+
+      expect(otpRepo.save).toHaveBeenCalledTimes(1);
+      expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+      expect(emailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'user@example.com' }),
+      );
+    });
+  });
+
+  describe('verifyOtp', () => {
+    it('marks the OTP as used on successful verification', async () => {
+      const record = makeOtpRecord({ otpHash: await bcrypt.hash(PLAIN_OTP, 10) });
+      record.isUsed = () => false;
+      record.isExpired = () => false;
+      record.isLocked = () => false;
+      otpRepo.findOne.mockResolvedValue(record);
+      otpRepo.save.mockResolvedValue({ ...record, usedAt: new Date() });
+
+      await expect(service.verifyOtp(USER_ID, WITHDRAWAL_ID, PLAIN_OTP)).resolves.toBeUndefined();
+      expect(otpRepo.save).toHaveBeenCalledWith(expect.objectContaining({ usedAt: expect.any(Date) }));
+    });
+
+    it('throws NotFoundException when no active OTP exists', async () => {
+      otpRepo.findOne.mockResolvedValue(null);
+      await expect(service.verifyOtp(USER_ID, WITHDRAWAL_ID, PLAIN_OTP)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when OTP is expired', async () => {
+      const record = makeOtpRecord({ expiresAt: new Date(Date.now() - 1000) });
+      record.isUsed = () => false;
+      record.isExpired = () => true;
+      record.isLocked = () => false;
+      otpRepo.findOne.mockResolvedValue(record);
+      await expect(service.verifyOtp(USER_ID, WITHDRAWAL_ID, PLAIN_OTP)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws ForbiddenException and locks after exceeding max attempts', async () => {
+      const record = makeOtpRecord({
+        otpHash: await bcrypt.hash('999999', 10),
+        attemptCount: 4,
+      });
+      record.isUsed = () => false;
+      record.isExpired = () => false;
+      record.isLocked = () => false;
+      otpRepo.findOne.mockResolvedValue(record);
+      otpRepo.save.mockResolvedValue({ ...record, lockedUntil: new Date(Date.now() + 15 * 60 * 1000) });
+
+      await expect(service.verifyOtp(USER_ID, WITHDRAWAL_ID, PLAIN_OTP)).rejects.toThrow(ForbiddenException);
+      expect(otpRepo.save).toHaveBeenCalledWith(expect.objectContaining({ lockedUntil: expect.any(Date) }));
+    });
+
+    it('throws ForbiddenException when OTP is locked', async () => {
+      const record = makeOtpRecord({ lockedUntil: new Date(Date.now() + 60_000) });
+      record.isUsed = () => false;
+      record.isExpired = () => false;
+      record.isLocked = () => true;
+      otpRepo.findOne.mockResolvedValue(record);
+      await expect(service.verifyOtp(USER_ID, WITHDRAWAL_ID, PLAIN_OTP)).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/payments/withdrawal-otp/withdrawal-otp.service.ts
+++ b/src/payments/withdrawal-otp/withdrawal-otp.service.ts
@@ -1,0 +1,140 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, IsNull, LessThan } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
+import { WithdrawalOtp } from './entities/withdrawal-otp.entity';
+import { EmailService } from '../../email/email.service';
+
+const OTP_LENGTH = 6;
+const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const BCRYPT_ROUNDS = 10;
+
+@Injectable()
+export class WithdrawalOtpService {
+  private readonly logger = new Logger(WithdrawalOtpService.name);
+  private readonly maxAttempts: number;
+  private readonly lockoutDurationMs: number;
+
+  constructor(
+    @InjectRepository(WithdrawalOtp)
+    private readonly otpRepository: Repository<WithdrawalOtp>,
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
+  ) {
+    this.maxAttempts = this.configService.get<number>('WITHDRAWAL_OTP_MAX_ATTEMPTS', 5);
+    this.lockoutDurationMs = this.configService.get<number>('WITHDRAWAL_OTP_LOCKOUT_MS', 15 * 60 * 1000);
+  }
+
+  async requestOtp(
+    userId: string,
+    withdrawalRequestId: string,
+    userEmail: string,
+  ): Promise<void> {
+    // Invalidate any existing unused OTP for this withdrawal
+    await this.otpRepository
+      .createQueryBuilder()
+      .update(WithdrawalOtp)
+      .set({ usedAt: new Date() })
+      .where('userId = :userId AND withdrawalRequestId = :withdrawalRequestId AND usedAt IS NULL', {
+        userId,
+        withdrawalRequestId,
+      })
+      .execute();
+
+    const plainOtp = this.generateOtp();
+    const otpHash = await bcrypt.hash(plainOtp, BCRYPT_ROUNDS);
+
+    const record = this.otpRepository.create({
+      userId,
+      withdrawalRequestId,
+      otpHash,
+      expiresAt: new Date(Date.now() + OTP_TTL_MS),
+      usedAt: null,
+      attemptCount: 0,
+      lockedUntil: null,
+    });
+
+    await this.otpRepository.save(record);
+
+    await this.emailService.sendEmail({
+      to: userEmail,
+      subject: 'Withdrawal Confirmation OTP',
+      template: 'security-alert',
+      variables: {
+        name: 'User',
+        message: `Your withdrawal confirmation code is: ${plainOtp}. It expires in 10 minutes. Do not share this code.`,
+      },
+    });
+
+    this.logger.log(`Withdrawal OTP issued for user ${userId}, request ${withdrawalRequestId}`);
+  }
+
+  async verifyOtp(
+    userId: string,
+    withdrawalRequestId: string,
+    plainOtp: string,
+  ): Promise<void> {
+    const record = await this.otpRepository.findOne({
+      where: { userId, withdrawalRequestId, usedAt: IsNull() },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (!record || record.isUsed()) {
+      throw new NotFoundException('No active OTP found for this withdrawal request.');
+    }
+
+    if (record.isExpired()) {
+      throw new ForbiddenException('OTP has expired. Please request a new one.');
+    }
+
+    if (record.isLocked()) {
+      throw new ForbiddenException(
+        'Too many invalid OTP attempts. Please wait before retrying.',
+      );
+    }
+
+    const isMatch = await bcrypt.compare(plainOtp, record.otpHash);
+
+    if (!isMatch) {
+      record.attemptCount += 1;
+      if (record.attemptCount >= this.maxAttempts) {
+        record.lockedUntil = new Date(Date.now() + this.lockoutDurationMs);
+        this.logger.warn(
+          `Withdrawal OTP locked for user ${userId}, request ${withdrawalRequestId} after ${record.attemptCount} failed attempts`,
+        );
+      }
+      await this.otpRepository.save(record);
+      const remaining = this.maxAttempts - record.attemptCount;
+      throw new ForbiddenException(
+        remaining > 0
+          ? `Invalid OTP. ${remaining} attempt(s) remaining.`
+          : 'OTP locked due to too many failed attempts.',
+      );
+    }
+
+    record.usedAt = new Date();
+    await this.otpRepository.save(record);
+
+    this.logger.log(`Withdrawal OTP verified for user ${userId}, request ${withdrawalRequestId}`);
+  }
+
+  async cleanupExpired(): Promise<number> {
+    const result = await this.otpRepository.delete({
+      expiresAt: LessThan(new Date()),
+    });
+    return result.affected ?? 0;
+  }
+
+  private generateOtp(): string {
+    const bytes = crypto.randomBytes(4);
+    const num = bytes.readUInt32BE(0) % Math.pow(10, OTP_LENGTH);
+    return num.toString().padStart(OTP_LENGTH, '0');
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -58,6 +58,9 @@ export class User {
   @Column({ default: true })
   isActive!: boolean;
 
+  @Column({ name: 'email_verified', default: false })
+  emailVerified!: boolean;
+
   @Column({
     type: 'enum',
     enum: UserTier,


### PR DESCRIPTION
…ified-email decorator (#819-822)

- #819: Add WithdrawalOtpGuard with time-limited, single-use OTPs sent via email; lockout after configurable failed attempts; POST /withdrawals/otp/request endpoint

- #820: Extend PermissionAuditLog with beforeState/afterState columns; add diffObjects() helper to capture only changed fields; wire into updateRole and assignPermissionsToRole; add read-only admin endpoints at GET /admin/audit/permissions

- #821: Add RefreshToken entity and RefreshTokenCleanupService with a nightly @Cron job that deletes expired rows in batches (default 500) — idempotent across replicas

#822: Add @RequireVerifiedEmail() decorator and VerifiedEmailGuard; opt-in per endpoint,
  composes after JwtAuthGuard; add emailVerified column to User entity

closes
#819 

#820 

#821 

#822 