### PR TITLE
fix(database): disable schema auto-sync outside test env and run migrations in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,14 @@ COPY --from=dependencies --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=build --chown=nestjs:nodejs /app/dist ./dist
 COPY --chown=nestjs:nodejs package.json ./
 
+# The migration CLI (`npm run migration:run`) executes TypeORM's DataSource
+# config via ts-node rather than the compiled dist output, so the runtime
+# image needs the migration sources plus a minimal ts-node toolchain.
+COPY --chown=nestjs:nodejs tsconfig.json ./
+COPY --chown=nestjs:nodejs src/config/typeorm.config.ts ./src/config/typeorm.config.ts
+COPY --chown=nestjs:nodejs src/database/migrations ./src/database/migrations
+RUN npm install --no-save ts-node@^10.9.2 typescript@^5.3.3 tsconfig-paths@^4.2.0
+
 USER nestjs
 
 EXPOSE 3000
@@ -29,4 +37,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/api/v1/health', (r) => { if (r.statusCode !== 200) throw new Error(r.statusCode) })"
 
-CMD ["node", "dist/main.js"]
+CMD ["sh", "-c", "npm run migration:run && node dist/main.js"]

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -9,10 +9,9 @@ export const databaseConfig = registerAs(
     username: process.env.DATABASE_USER || 'postgres',
     password: process.env.DATABASE_PASSWORD || 'password',
     database: process.env.DATABASE_NAME || 'stellarswipe',
-    synchronize:
-      process.env.NODE_ENV !== 'production' &&
-      process.env.NODE_ENV !== 'mainnet' &&
-      process.env.NODE_ENV !== 'public',
+    // Never auto-sync the schema outside of the test environment — all
+    // schema changes must go through versioned migrations.
+    synchronize: process.env.NODE_ENV === 'test',
     logging: process.env.DATABASE_LOGGING === 'true',
     // TypeORM specific properties
     type: 'postgres',


### PR DESCRIPTION
## Summary

Closes #856

This repo already has a mature TypeORM migration workflow in place (`src/database/migrations/**`, `src/config/typeorm.config.ts` as the CLI DataSource, `migration:generate` / `migration:run` / `migration:revert` scripts, and a CI job that applies + reverts migrations before running tests). The two gaps against the issue's acceptance criteria were:

1. **`synchronize` was not `false` in all non-test environments.** `src/config/database.config.ts` computed `synchronize` as `true` for any `NODE_ENV` other than `production`/`mainnet`/`public` — meaning `development`, `staging`, and any other non-test environment still auto-synced the schema from entity changes. Changed it to `synchronize: process.env.NODE_ENV === 'test'`, so only the test environment (used by `test/setup.ts` for the Jest suite) gets auto-sync; every other environment must go through migrations.
2. **The Dockerfile never ran migrations before starting the app.** Updated the production stage to copy the migration sources (`src/database/migrations`, `src/config/typeorm.config.ts`) and a minimal `ts-node`/`typescript`/`tsconfig-paths` toolchain (matching the versions already pinned in `devDependencies`) into the image, and changed the `CMD` to `npm run migration:run && node dist/main.js`, so the container fails fast if migrations don't apply cleanly instead of silently booting on a stale schema.

## Changes

- `src/config/database.config.ts` — `synchronize` now only true when `NODE_ENV === 'test'`.
- `Dockerfile` — production stage copies migration sources + minimal ts-node toolchain, and `CMD` runs `migration:run` before starting the app.

## Testing / Validation

- Manually reviewed all call sites of `databaseConfig`/`synchronize` (`src/app.module.ts`, `src/cli/cli.ts`, test helpers under `test/helpers/*`) — none rely on the previous non-test auto-sync behavior; test helpers set their own `synchronize: true` independently of this config.
- Confirmed no `.spec.ts` files assert on the old `synchronize` boolean expression.
- Confirmed `.eslintrc.json` already exempts `src/config/**/*.ts` from the `no-restricted-syntax` (`process.env`) rule, so no lint changes needed there.
- Confirmed `.dockerignore` does not exclude `src/`, so the new `COPY --from=build` steps have the files available.
- Existing `ci.yml` already runs `migration:run` → `seed` → `migration:revert` → `migration:run` → `npm test` against a Postgres service container before the unit test suite, satisfying the "CI runs migrations before tests" criterion untouched by this PR.
- Was unable to run `npm run build` / `npm test` / `npm run lint` locally in this environment (no `node_modules` installed and installing new dependencies was out of scope for this change); relying on the repo's CI workflow (`ci.yml`) to validate build/lint/test on this PR.

## Risks / Follow-ups

- The Docker image now installs `ts-node`, `typescript`, and `tsconfig-paths` (already pinned as `devDependencies` in `package.json`) into the production stage to run the migration CLI — this is a small addition to the production image's dependency surface; worth keeping an eye on the Docker Security Scan (Trivy) workflow results on this PR.
- Pre-existing, out-of-scope observation (not changed here): `src/config/typeorm.config.ts`'s `migrations` glob only points at `src/database/migrations`, so per-module migration folders (e.g. `src/watchlist/migrations`, `src/kyc/migrations`) aren't picked up by the `migration:*` CLI scripts. This predates this PR and CI already only exercises `src/database/migrations`, so this PR preserves that existing behavior rather than expanding scope.