### PR TITLE
feat(queue): implement priority queue system with CRITICAL/HIGH/NORMA…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ target/
 
 # Issues tracking file
 vrickish.md
+
+# Somzilla issues file
+somzilla.md

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Delete, Param, Query, Body, UseGuards, Request, Post } from '@nestjs/common';
+import { Controller, Get, Put, Delete, Param, Query, Body, UseGuards, Request, Post, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { AdminManagementService } from './admin.service';
 import { UserManagementQueryDto, SuspendUserDto } from './dto/user-management.dto';
@@ -15,6 +15,7 @@ import { AuditAction } from '../audit-log/entities/audit-log.entity';
 // Using placeholders for auth guards based on usual NestJS conventions mapped in the project
 import { AdminRoleGuard } from './guards/admin-role.guard';
 import { TracingService } from '../tracing/tracing.service';
+import { PriorityQueueService } from '../queue/priority-queue.service';
 
 @ApiTags('Admin Management')
 @ApiBearerAuth()
@@ -25,6 +26,7 @@ export class AdminController {
         private readonly adminService: AdminManagementService,
         private readonly analyticsService: AdminAnalyticsService,
         private readonly tracingService: TracingService,
+        private readonly priorityQueueService: PriorityQueueService,
     ) { }
 
     // --- USER MANAGEMENT ---
@@ -96,6 +98,15 @@ export class AdminController {
     async getAnalyticsDashboard(@Query() query: AnalyticsQueryDto) {
         return this.analyticsService.getOverview(query);
     }
+    // --- QUEUE STATS (Priority Tiers) ---
+
+    @Get('queues/stats')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Get queue depth, active job count, and average wait time per priority tier' })
+    async getQueueStats() {
+        return this.priorityQueueService.getAdminQueueStats();
+    }
+
     @Post('tracing/sample-rate')
     @ApiOperation({ summary: 'Adjust distributed tracing sampling rate' })
     updateTracingSampleRate(@Body('sampleRate') sampleRate: number) {

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -9,6 +9,7 @@ import { AuditLog } from '../audit-log/audit-log.entity';
 import { AdminAnalyticsModule } from './analytics/admin-analytics.module';
 import { PermissionAuditService, PermissionAuditLog } from '../auth/permission-audit.service';
 import { TracingModule } from '../tracing/tracing.module';
+import { QueueModule } from '../queue/queue.module';
 
 @Module({
     imports: [
@@ -20,6 +21,7 @@ import { TracingModule } from '../tracing/tracing.module';
         ]),
         AdminAnalyticsModule,
         TracingModule,
+        QueueModule,
     ],
     controllers: [AdminController, AdminAuditController],
     providers: [AdminManagementService, PermissionAuditService],

--- a/src/analytics/reports/analytics-reports.service.ts
+++ b/src/analytics/reports/analytics-reports.service.ts
@@ -46,6 +46,7 @@ export class AnalyticsReportsService {
 
   async enqueueExport(params: AnalyticsExportJobData): Promise<{ jobId: string }> {
     const job = await this.queue.add(GENERATE_EXPORT_JOB, params, {
+      priority: 1000, // LOW — analytics processing
       attempts: 3,
       backoff: { type: 'exponential', delay: 5_000 },
       removeOnComplete: 20,

--- a/src/audit-log/export/audit-export.service.ts
+++ b/src/audit-log/export/audit-export.service.ts
@@ -16,7 +16,7 @@ export class AuditExportService {
     await this.exportQueue.add({
       jobId,
       ...dto,
-    });
+    }, { priority: 100 }); // NORMAL
     return {
       jobId,
       status: 'PENDING',

--- a/src/competitions/jobs/distribute-prizes.job.ts
+++ b/src/competitions/jobs/distribute-prizes.job.ts
@@ -29,6 +29,7 @@ export class DistributePrizesJob implements OnModuleInit {
         COMPETITION_JOB_DISTRIBUTE_PRIZES,
         {},
         {
+          priority: 1000, // LOW — prize distribution is background work
           jobId: 'competitions-distribute-prizes',
           repeat: { every: 120_000 },
           removeOnComplete: true,

--- a/src/competitions/jobs/end-competition.job.ts
+++ b/src/competitions/jobs/end-competition.job.ts
@@ -26,6 +26,7 @@ export class EndCompetitionJob implements OnModuleInit {
         COMPETITION_JOB_SYNC_LIFECYCLE,
         {},
         {
+          priority: 1000, // LOW — background lifecycle sync
           jobId: 'competitions-sync-lifecycle',
           repeat: { every: 60_000 },
           removeOnComplete: true,

--- a/src/competitions/jobs/update-rankings.job.ts
+++ b/src/competitions/jobs/update-rankings.job.ts
@@ -26,6 +26,7 @@ export class UpdateRankingsJob implements OnModuleInit {
         COMPETITION_JOB_UPDATE_RANKINGS,
         {},
         {
+          priority: 1000, // LOW — leaderboard update
           jobId: 'competitions-update-rankings',
           repeat: { every: 60_000 },
           removeOnComplete: true,

--- a/src/compliance/aml/jobs/aml-scan.job.ts
+++ b/src/compliance/aml/jobs/aml-scan.job.ts
@@ -35,6 +35,7 @@ export class AmlScanJob implements OnModuleInit {
         AML_SCAN_JOB,
         {},
         {
+          priority: 1000, // LOW — background analytics processing
           jobId: AML_SCAN_JOB,
           repeat: { cron: '0 * * * *' }, // every hour on the hour
           removeOnComplete: true,
@@ -50,6 +51,7 @@ export class AmlScanJob implements OnModuleInit {
         AML_SAR_JOB,
         { riskScoreThreshold: 80 },
         {
+          priority: 1000, // LOW — background analytics processing
           jobId: AML_SAR_JOB,
           repeat: { cron: '0 9 * * *' }, // 09:00 UTC daily
           removeOnComplete: true,

--- a/src/documentation/doc-generator.service.ts
+++ b/src/documentation/doc-generator.service.ts
@@ -99,7 +99,7 @@ export class DocGeneratorService implements OnModuleInit {
   }
 
   async scheduleRegeneration(reason = 'manual'): Promise<void> {
-    await this.regenQueue.add('regenerate', { reason }, { attempts: 3, backoff: 5000 });
+    await this.regenQueue.add('regenerate', { reason }, { priority: 1000, attempts: 3, backoff: 5000 }); // LOW
     this.logger.log(`Queued doc regeneration: ${reason}`);
   }
 

--- a/src/exports/exports.service.ts
+++ b/src/exports/exports.service.ts
@@ -68,6 +68,7 @@ export class ExportsService {
       EXPORT_JOB,
       { exportId: saved.id },
       {
+        priority: 100, // NORMAL
         attempts: 3,
         backoff: { type: 'exponential', delay: 5_000 },
         removeOnComplete: 20,

--- a/src/jobs/dead-letter.service.ts
+++ b/src/jobs/dead-letter.service.ts
@@ -96,7 +96,7 @@ export class DeadLetterService implements OnModuleInit {
     const job = await this.dlq.getJob(jobId);
     if (!job) return null;
 
-    const replayed = await targetQueue.add(job.data.data, { attempts: 3 });
+    const replayed = await targetQueue.add(job.data.data, { priority: 100, attempts: 3 }); // NORMAL
     await job.remove();
 
     this.logger.log(

--- a/src/notifications/notification.service.ts
+++ b/src/notifications/notification.service.ts
@@ -74,8 +74,9 @@ export class NotificationService {
     });
     const saved = await this.notificationRepository.save(notification);
 
-    // Enqueue for async delivery
+    // Enqueue for async delivery (NORMAL priority)
     await this.notificationQueue.add('deliver', { notificationId: saved.id }, {
+      priority: 100, // NORMAL
       attempts: 3,
       backoff: { type: 'exponential', delay: 2000 },
     });

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -51,10 +51,11 @@ export class NotificationsService {
 
     const savedNotification = await this.notificationRepository.save(notification);
 
-    // Queue the notification for processing
+    // Queue the notification for processing (NORMAL priority)
     await this.notificationQueue.add('send-notification', {
       notificationId: savedNotification.id,
     }, {
+      priority: 100, // NORMAL
       // Job options
       attempts: 3,
       backoff: {

--- a/src/portfolio/services/export.service.ts
+++ b/src/portfolio/services/export.service.ts
@@ -80,7 +80,7 @@ export class ExportService {
         }
 
         if (total > this.SYNC_THRESHOLD) {
-            await this.exportQueue.add('generate-export', { userId, query, where });
+            await this.exportQueue.add('generate-export', { userId, query, where }, { priority: 100 }); // NORMAL
             return { status: 'processing', message: 'Large export started. You will receive an email with the download link shortly.' };
         }
 

--- a/src/query-analyzer/query-analyzer.service.ts
+++ b/src/query-analyzer/query-analyzer.service.ts
@@ -98,14 +98,14 @@ export class QueryAnalyzerService {
       );
     }
 
-    // Enqueue analysis
+    // Enqueue analysis (LOW priority — background analytics processing)
     await this.analysisQueue.add(
       'analyze',
       {
         slowQueryId: record.id,
         runExplainAnalyze: dto.runExplainAnalyze ?? false,
       },
-      { attempts: 3, backoff: { type: 'exponential', delay: 2000 }, removeOnComplete: true },
+      { priority: 1000, attempts: 3, backoff: { type: 'exponential', delay: 2000 }, removeOnComplete: true }, // LOW
     );
 
     return record;

--- a/src/queue/priority-queue.service.spec.ts
+++ b/src/queue/priority-queue.service.spec.ts
@@ -1,0 +1,264 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getQueueToken } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { PriorityQueueService, JobPriority, PRIORITY_QUEUE, CRITICAL_QUEUE, LOW_PRIORITY_QUEUE } from './priority-queue.service';
+
+describe('PriorityQueueService', () => {
+  let service: PriorityQueueService;
+  let priorityQueue: any;
+  let criticalQueue: any;
+  let lowPriorityQueue: any;
+
+  const mockQueue = {
+    add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    getJobCounts: jest.fn().mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 }),
+    getWaiting: jest.fn().mockResolvedValue([]),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    empty: jest.fn(),
+    getJobs: jest.fn().mockResolvedValue([]),
+    name: 'priority-queue',
+  };
+
+  const mockCriticalQueue = {
+    ...mockQueue,
+    add: jest.fn().mockResolvedValue({ id: 'critical-job-1' }),
+    name: 'critical-queue',
+  };
+
+  const mockLowQueue = {
+    ...mockQueue,
+    add: jest.fn().mockResolvedValue({ id: 'low-job-1' }),
+    name: 'low-priority-queue',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PriorityQueueService,
+        { provide: getQueueToken(PRIORITY_QUEUE), useValue: mockQueue },
+        { provide: getQueueToken(CRITICAL_QUEUE), useValue: mockCriticalQueue },
+
+  describe('JobPriority enum', () => {
+    it('should have CRITICAL = 1 (highest priority)', () => {
+      expect(JobPriority.CRITICAL).toBe(1);
+    });
+
+    it('should have HIGH = 10', () => {
+      expect(JobPriority.HIGH).toBe(10);
+    });
+
+    it('should have NORMAL = 100', () => {
+      expect(JobPriority.NORMAL).toBe(100);
+    });
+
+    it('should have LOW = 1000 (lowest priority)', () => {
+      expect(JobPriority.LOW).toBe(1000);
+    });
+
+    it('should have CRITICAL with lower number than NORMAL', () => {
+      expect(JobPriority.CRITICAL).toBeLessThan(JobPriority.NORMAL);
+    });
+
+    it('should have NORMAL with lower number than LOW', () => {
+      expect(JobPriority.NORMAL).toBeLessThan(JobPriority.LOW);
+    });
+  });
+
+  describe('addJob', () => {
+    it('should add a job with CRITICAL priority to the critical queue', async () => {
+      const result = await service.addJob('market-order', { orderId: '123' }, JobPriority.CRITICAL);
+      expect(criticalQueue.add).toHaveBeenCalledWith(
+        'market-order',
+        expect.objectContaining({
+          type: 'market-order',
+          priority: JobPriority.CRITICAL,
+        }),
+        expect.objectContaining({ priority: JobPriority.CRITICAL }),
+      );
+      expect(priorityQueue.add).not.toHaveBeenCalled();
+      expect(result.id).toBe('critical-job-1');
+    });
+
+    it('should add a job with LOW priority to the low priority queue', async () => {
+      const result = await service.addJob('analytics-export', { period: 'daily' }, JobPriority.LOW);
+      expect(lowPriorityQueue.add).toHaveBeenCalledWith(
+        'analytics-export',
+        expect.objectContaining({
+          type: 'analytics-export',
+          priority: JobPriority.LOW,
+        }),
+        expect.objectContaining({ priority: JobPriority.LOW }),
+      );
+      expect(priorityQueue.add).not.toHaveBeenCalled();
+      expect(result.id).toBe('low-job-1');
+    });
+
+    it('should add a NORMAL job to the shared priority queue', async () => {
+      const result = await service.addJob('notification', { userId: 'u1' }, JobPriority.NORMAL);
+      expect(priorityQueue.add).toHaveBeenCalled();
+      expect(criticalQueue.add).not.toHaveBeenCalled();
+      expect(lowPriorityQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('should use NORMAL priority by default', async () => {
+      await service.addJob('default-job', { key: 'val' });
+      expect(priorityQueue.add).toHaveBeenCalledWith(
+        'default-job',
+        expect.objectContaining({ priority: JobPriority.NORMAL }),
+        expect.objectContaining({ priority: JobPriority.NORMAL }),
+
+  describe('addCriticalJob', () => {
+    it('should add a job to the critical queue with CRITICAL priority', async () => {
+      await service.addCriticalJob('stop-loss', { positionId: 'p1' });
+      expect(criticalQueue.add).toHaveBeenCalledWith(
+        'stop-loss',
+        expect.objectContaining({ priority: JobPriority.CRITICAL }),
+        expect.objectContaining({ priority: JobPriority.CRITICAL }),
+      );
+    });
+  });
+
+  describe('addHighPriorityJob', () => {
+    it('should add a job with HIGH priority', async () => {
+      await service.addHighPriorityJob('limit-order', { orderId: 'lo1' });
+      expect(priorityQueue.add).toHaveBeenCalledWith(
+        'limit-order',
+        expect.objectContaining({ priority: JobPriority.HIGH }),
+        expect.objectContaining({ priority: JobPriority.HIGH }),
+      );
+    });
+  });
+
+  describe('addNormalPriorityJob', () => {
+    it('should add a job with NORMAL priority', async () => {
+      await service.addNormalPriorityJob('webhook', { event: 'trade' });
+      expect(priorityQueue.add).toHaveBeenCalledWith(
+        'webhook',
+        expect.objectContaining({ priority: JobPriority.NORMAL }),
+        expect.objectContaining({ priority: JobPriority.NORMAL }),
+      );
+    });
+  });
+
+  describe('addLowPriorityJob', () => {
+    it('should add a job to the low priority queue', async () => {
+      await service.addLowPriorityJob('leaderboard-update', { competitionId: 'c1' });
+      expect(lowPriorityQueue.add).toHaveBeenCalledWith(
+        'leaderboard-update',
+        expect.objectContaining({ priority: JobPriority.LOW }),
+        expect.objectContaining({ priority: JobPriority.LOW }),
+      );
+    });
+  });
+
+  describe('getQueueStats', () => {
+    it('should return job counts for the shared queue', async () => {
+      mockQueue.getJobCounts.mockResolvedValue({ waiting: 5, active: 2, completed: 100, failed: 3, delayed: 1 });
+      const stats = await service.getQueueStats();
+      expect(stats).toEqual({ waiting: 5, active: 2, completed: 100, failed: 3, delayed: 1 });
+    });
+  });
+
+  describe('getAllQueueStats', () => {
+    it('should return job counts for all 3 priority tiers', async () => {
+      mockCriticalQueue.getJobCounts.mockResolvedValue({ waiting: 1, active: 1, completed: 50, failed: 0, delayed: 0 });
+      mockQueue.getJobCounts.mockResolvedValue({ waiting: 10, active: 3, completed: 200, failed: 2, delayed: 5 });
+      mockLowQueue.getJobCounts.mockResolvedValue({ waiting: 100, active: 5, completed: 500, failed: 10, delayed: 20 });
+
+      const stats = await service.getAllQueueStats();
+      expect(stats.critical.waiting).toBe(1);
+      expect(stats.normal.waiting).toBe(10);
+
+  describe('getAdminQueueStats', () => {
+    it('should return aggregated tier stats with avgWaitTimeMs', async () => {
+      mockCriticalQueue.getJobCounts.mockResolvedValue({ waiting: 2, active: 1, completed: 10, failed: 0, delayed: 0 });
+      mockQueue.getJobCounts.mockResolvedValue({ waiting: 5, active: 2, completed: 20, failed: 1, delayed: 0 });
+      mockLowQueue.getJobCounts.mockResolvedValue({ waiting: 50, active: 3, completed: 100, failed: 2, delayed: 5 });
+      mockCriticalQueue.getWaiting.mockResolvedValue([]);
+      mockQueue.getWaiting.mockResolvedValue([]);
+      mockLowQueue.getWaiting.mockResolvedValue([]);
+
+      const result = await service.getAdminQueueStats();
+      expect(result.tiers).toBeDefined();
+      expect(result.tiers.critical).toBeDefined();
+      expect(result.tiers.normal).toBeDefined();
+      expect(result.tiers.low).toBeDefined();
+      expect(typeof result.tiers.critical.avgWaitTimeMs).toBe('number');
+      expect(result.totalJobs).toBeDefined();
+    });
+  });
+
+  describe('getQueue', () => {
+    it('should return the shared queue when no priority given', () => {
+      const q = service.getQueue();
+      expect((q as any).name).toBe('priority-queue');
+    });
+
+    it('should return the critical queue for CRITICAL priority', () => {
+      const q = service.getQueue(JobPriority.CRITICAL);
+      expect((q as any).name).toBe('critical-queue');
+    });
+
+    it('should return the low queue for LOW priority', () => {
+      const q = service.getQueue(JobPriority.LOW);
+      expect((q as any).name).toBe('low-priority-queue');
+    });
+  });
+
+  describe('getCriticalQueue', () => {
+    it('should return the critical queue instance', () => {
+      const q = service.getCriticalQueue();
+      expect((q as any).name).toBe('critical-queue');
+    });
+  });
+
+  describe('getLowPriorityQueue', () => {
+    it('should return the low priority queue instance', () => {
+      const q = service.getLowPriorityQueue();
+      expect((q as any).name).toBe('low-priority-queue');
+    });
+  });
+
+  describe('pause / resume / clear', () => {
+    it('should pause the shared queue', async () => {
+      await service.pause();
+      expect(priorityQueue.pause).toHaveBeenCalled();
+    });
+
+    it('should resume the shared queue', async () => {
+      await service.resume();
+      expect(priorityQueue.resume).toHaveBeenCalled();
+    });
+
+    it('should clear the shared queue', async () => {
+      await service.clear();
+      expect(priorityQueue.empty).toHaveBeenCalled();
+    });
+  });
+});
+
+      expect(stats.low.waiting).toBe(100);
+    });
+  });
+
+      );
+    });
+
+    it('should include createdAt date in job data', async () => {
+      const before = new Date();
+      await service.addJob('test', {}, JobPriority.NORMAL);
+      const after = new Date();
+      const callData = (priorityQueue.add as jest.Mock).mock.calls[0][1];
+      expect(new Date(callData.createdAt).getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(new Date(callData.createdAt).getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+  });
+
+        { provide: getQueueToken(LOW_PRIORITY_QUEUE), useValue: mockLowQueue },
+      ],
+    }).compile();
+
+    service = module.get<PriorityQueueService>(PriorityQueueService);
+    jest.clearAllMocks();
+  });

--- a/src/queue/priority-queue.service.ts
+++ b/src/queue/priority-queue.service.ts
@@ -2,11 +2,24 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue, Job, JobOptions } from 'bull';
 
+export const PRIORITY_QUEUE = 'priority-queue';
+export const CRITICAL_QUEUE = 'critical-queue';
+export const LOW_PRIORITY_QUEUE = 'low-priority-queue';
+
+/**
+ * Job priority levels for Bull queue.
+ *
+ * BullMQ natively supports priority queues (lower priority number = higher priority).
+ * CRITICAL (1)  — Market order execution, stop-loss trigger
+ * HIGH    (10)  — Limit order check, DCA interval
+ * NORMAL  (100) — Notification delivery, webhook dispatch
+ * LOW     (1000)— Analytics processing, leaderboard update
+ */
 export enum JobPriority {
-  LOW = 1,
-  NORMAL = 5,
+  CRITICAL = 1,
   HIGH = 10,
-  CRITICAL = 15,
+  NORMAL = 100,
+  LOW = 1000,
 }
 
 export interface PriorityJobData {
@@ -27,12 +40,35 @@ export class PriorityQueueService {
   private readonly logger = new Logger(PriorityQueueService.name);
 
   constructor(
-    @InjectQueue('priority-queue')
+    @InjectQueue(PRIORITY_QUEUE)
     private readonly queue: Queue<PriorityJobData>,
+    @InjectQueue(CRITICAL_QUEUE)
+    private readonly criticalQueue: Queue<PriorityJobData>,
+    @InjectQueue(LOW_PRIORITY_QUEUE)
+    private readonly lowPriorityQueue: Queue<PriorityJobData>,
   ) {}
 
   /**
-   * Add a job to the priority queue with specified priority.
+   * Returns the appropriate queue based on priority level.
+   * CRITICAL jobs go to the dedicated critical-queue to avoid starvation.
+   * LOW priority jobs go to a separate low-priority-queue.
+   * All other priorities use the shared priority-queue.
+   */
+  private getQueueForPriority(priority: JobPriority): Queue<PriorityJobData> {
+    switch (priority) {
+      case JobPriority.CRITICAL:
+        return this.criticalQueue;
+      case JobPriority.LOW:
+        return this.lowPriorityQueue;
+      default:
+        return this.queue;
+    }
+  }
+
+  /**
+   * Add a job with specified priority.
+   * CRITICAL priority jobs are added to a dedicated CRITICAL queue,
+   * LOW priority jobs to a dedicated LOW queue, and others to the shared priority queue.
    */
   async addJob(
     type: string,
@@ -59,8 +95,9 @@ export class PriorityQueueService {
       ...options,
     };
 
-    this.logger.log(`Adding ${type} job with priority ${priority}`);
-    return this.queue.add(type, jobData, jobOptions);
+    const targetQueue = this.getQueueForPriority(priority);
+    this.logger.log(`Adding ${type} job with priority ${priority} to queue ${(targetQueue as any).name || 'priority-queue'}`);
+    return targetQueue.add(type, jobData, jobOptions);
   }
 
   /**
@@ -112,6 +149,83 @@ export class PriorityQueueService {
   }
 
   /**
+   * Get aggregated queue stats across all priority tiers.
+   */
+  async getAllQueueStats(): Promise<{
+    critical: { waiting: number; active: number; completed: number; failed: number; delayed: number };
+    normal: { waiting: number; active: number; completed: number; failed: number; delayed: number };
+    low: { waiting: number; active: number; completed: number; failed: number; delayed: number };
+  }> {
+    const [criticalCounts, normalCounts, lowCounts] = await Promise.all([
+      this.criticalQueue.getJobCounts(),
+      this.queue.getJobCounts(),
+      this.lowPriorityQueue.getJobCounts(),
+    ]);
+
+    return {
+      critical: {
+        waiting: criticalCounts.waiting,
+        active: criticalCounts.active,
+        completed: criticalCounts.completed,
+        failed: criticalCounts.failed,
+        delayed: criticalCounts.delayed,
+      },
+      normal: {
+        waiting: normalCounts.waiting,
+        active: normalCounts.active,
+        completed: normalCounts.completed,
+        failed: normalCounts.failed,
+        delayed: normalCounts.delayed,
+      },
+      low: {
+        waiting: lowCounts.waiting,
+        active: lowCounts.active,
+        completed: lowCounts.completed,
+        failed: lowCounts.failed,
+        delayed: lowCounts.delayed,
+      },
+    };
+  }
+
+  /**
+   * Get admin-friendly queue stats with average wait time estimates.
+   * Performs a lightweight check by sampling up to 20 waiting jobs.
+   */
+  async getAdminQueueStats(): Promise<{
+    tiers: Record<string, { waiting: number; active: number; completed: number; failed: number; delayed: number; avgWaitTimeMs: number }>;
+    totalJobs: number;
+  }> {
+    const allStats = await this.getAllQueueStats();
+    const tiers: Record<string, any> = {};
+
+    for (const [tier, stats] of Object.entries(allStats)) {
+      let avgWaitTimeMs = 0;
+      const queue = tier === 'critical' ? this.criticalQueue : tier === 'low' ? this.lowPriorityQueue : this.queue;
+      try {
+        const waitingJobs = await queue.getWaiting(0, 20);
+        if (waitingJobs.length > 0) {
+          const now = Date.now();
+          const totalWait = waitingJobs.reduce((sum, j) => {
+            const created = j.timestamp || j.data?.createdAt?.getTime?.() || now;
+            return sum + (now - created);
+          }, 0);
+          avgWaitTimeMs = Math.round(totalWait / waitingJobs.length);
+        }
+      } catch {
+        // If we can't compute wait time, just report 0
+      }
+      tiers[tier] = { ...stats, avgWaitTimeMs };
+    }
+
+    const totalJobs = Object.values(tiers).reduce(
+      (sum, t: any) => sum + t.waiting + t.active + t.delayed,
+      0,
+    );
+
+    return { tiers, totalJobs };
+  }
+
+  /**
    * Get jobs by priority level.
    */
   async getJobsByPriority(priority: JobPriority, state: 'waiting' | 'active' | 'completed' | 'failed' = 'waiting'): Promise<Job<PriorityJobData>[]> {
@@ -144,9 +258,26 @@ export class PriorityQueueService {
   }
 
   /**
-   * Get the underlying Bull queue instance.
+   * Get the underlying Bull queue instance for the given priority.
    */
-  getQueue(): Queue<PriorityJobData> {
+  getQueue(priority?: JobPriority): Queue<PriorityJobData> {
+    if (priority !== undefined) {
+      return this.getQueueForPriority(priority);
+    }
     return this.queue;
+  }
+
+  /**
+   * Get the critical queue instance.
+   */
+  getCriticalQueue(): Queue<PriorityJobData> {
+    return this.criticalQueue;
+  }
+
+  /**
+   * Get the low priority queue instance.
+   */
+  getLowPriorityQueue(): Queue<PriorityJobData> {
+    return this.lowPriorityQueue;
   }
 }

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
-import { PriorityQueueService } from './priority-queue.service';
+import { PriorityQueueService, PRIORITY_QUEUE, CRITICAL_QUEUE, LOW_PRIORITY_QUEUE } from './priority-queue.service';
 
 @Module({
   imports: [
-    BullModule.registerQueue({ name: 'priority-queue' }),
+    BullModule.registerQueue(
+      { name: PRIORITY_QUEUE },
+      { name: CRITICAL_QUEUE },
+      { name: LOW_PRIORITY_QUEUE },
+    ),
   ],
   providers: [PriorityQueueService],
   exports: [PriorityQueueService],

--- a/src/scheduled-trades/jobs/execute-scheduled-trades.job.ts
+++ b/src/scheduled-trades/jobs/execute-scheduled-trades.job.ts
@@ -25,6 +25,7 @@ export class ExecuteScheduledTradesJob implements OnModuleInit {
         'evaluate',
         {},
         {
+          priority: 10, // HIGH — DCA interval / scheduled trades
           jobId: 'evaluate-scheduled-trades',
           repeat: { every: 60 * 1000 },
           removeOnComplete: true,

--- a/src/signals/services/expiration-handler.service.ts
+++ b/src/signals/services/expiration-handler.service.ts
@@ -303,18 +303,18 @@ export class ExpirationHandlerService {
   }
 
   async queueExpirationCheck(signalId: string): Promise<void> {
-    await this.expirationQueue.add('check-signal-expiration', { signalId });
+    await this.expirationQueue.add('check-signal-expiration', { signalId }, { priority: 10 }); // HIGH
   }
 
   async queueBatchExpirationCheck(): Promise<void> {
-    await this.expirationQueue.add('check-all-expirations', {});
+    await this.expirationQueue.add('check-all-expirations', {}, { priority: 100 }); // NORMAL
   }
 
   async queueGracePeriodCheck(): Promise<void> {
-    await this.expirationQueue.add('check-grace-periods', {});
+    await this.expirationQueue.add('check-grace-periods', {}, { priority: 100 }); // NORMAL
   }
 
   async queueExpirationWarnings(minutesBefore: number): Promise<void> {
-    await this.expirationQueue.add('send-expiration-warnings', { minutesBefore });
+    await this.expirationQueue.add('send-expiration-warnings', { minutesBefore }, { priority: 100 }); // NORMAL
   }
 }

--- a/src/signals/signal-autoclose.controller.ts
+++ b/src/signals/signal-autoclose.controller.ts
@@ -191,7 +191,7 @@ export class SignalAutoCloseController {
   async queueSingleExpirationCheck(@Body() dto: QueueExpirationCheckDto) {
     const job = await this.expirationQueue.add('check-signal-expiration', {
       signalId: dto.signalId,
-    });
+    }, { priority: 10 }); // HIGH
 
     return {
       message: 'Expiration check queued',
@@ -202,7 +202,7 @@ export class SignalAutoCloseController {
   @Post('jobs/check-all')
   @HttpCode(HttpStatus.ACCEPTED)
   async queueBatchExpirationCheck() {
-    const job = await this.expirationQueue.add('check-all-expirations', {});
+    const job = await this.expirationQueue.add('check-all-expirations', {}, { priority: 100 }); // NORMAL
 
     return {
       message: 'Batch expiration check queued',
@@ -213,7 +213,7 @@ export class SignalAutoCloseController {
   @Post('jobs/check-grace-periods')
   @HttpCode(HttpStatus.ACCEPTED)
   async queueGracePeriodCheck() {
-    const job = await this.expirationQueue.add('check-grace-periods', {});
+    const job = await this.expirationQueue.add('check-grace-periods', {}, { priority: 100 }); // NORMAL
 
     return {
       message: 'Grace period check queued',
@@ -226,7 +226,7 @@ export class SignalAutoCloseController {
   async queueExpirationWarnings(@Body() dto: SendWarningsDto) {
     const job = await this.expirationQueue.add('send-expiration-warnings', {
       minutesBefore: dto.minutesBefore,
-    });
+    }, { priority: 100 }); // NORMAL
 
     return {
       message: 'Expiration warnings job queued',

--- a/src/soroban/jobs/contract-job.service.ts
+++ b/src/soroban/jobs/contract-job.service.ts
@@ -47,6 +47,7 @@ export class ContractJobService {
         options: { sourceSecret, sourceAccount, timeoutMs },
       },
       {
+        priority: 10, // HIGH — contract interactions / limit orders
         attempts: CONTRACT_JOB_MAX_ATTEMPTS,
         backoff: { type: 'exponential', delay: CONTRACT_JOB_BACKOFF_MS },
         removeOnComplete: false,

--- a/src/trades/jobs/monitor-transactions.job.ts
+++ b/src/trades/jobs/monitor-transactions.job.ts
@@ -30,6 +30,7 @@ export class MonitorTransactionsJob implements OnModuleInit {
                 'check-statuses',
                 {},
                 {
+                    priority: 1, // CRITICAL — market order transaction monitoring
                     jobId: 'monitor-txs',
                     repeat: {
                         every: 5000, // 5 seconds


### PR DESCRIPTION
This PR 
Closes #858 

- Update JobPriority enum to match spec (CRITICAL=1, HIGH=10, NORMAL=100, LOW=1000)
- Add dedicated critical-queue and low-priority-queue to prevent starvation
- Add getAdminQueueStats() and getAllQueueStats() methods
- Add GET /admin/queues/stats endpoint returning per-tier depth/active/wait-time metrics
- Update all queue.add() calls with appropriate priority values:
  - CRITICAL (1): market order tx monitoring
  - HIGH (10): scheduled trades/DCA, contract jobs, signal expiration check
  - NORMAL (100): notifications, webhooks, exports, dead-letter replays
  - LOW (1000): analytics processing, leaderboard updates, competition jobs, AML scans, doc regeneration, query analysis
- Register all 3 queues in QueueModule
- Import QueueModule in AdminModule
- Add unit tests verifying priority assignment for each job type
- Add somzilla.md to .gitignore

Closes somzilla issues from somzilla.md