### PR TITLE
Fix/forgot password timing enumeration

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -7,6 +7,9 @@ import { Keypair } from '@stellar/stellar-sdk';
 import { UnauthorizedException, NotFoundException } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { EmailService } from '../email/email.service';
+import { AuthAuditService } from './auth-audit.service';
+import { SessionManagerService } from './session/session-manager.service';
+import { SessionFingerprintService } from './session/session-fingerprint.service';
 
 describe('AuthService', () => {
     let service: AuthService;
@@ -14,6 +17,9 @@ describe('AuthService', () => {
     let jwtServiceSpec: any;
     let usersServiceSpec: any;
     let emailServiceSpec: any;
+    let authAuditServiceSpec: any;
+    let sessionManagerSpec: any;
+    let sessionFingerprintServiceSpec: any;
 
     const mockCacheStore = new Map();
 
@@ -46,6 +52,23 @@ describe('AuthService', () => {
             sendEmail: jest.fn().mockResolvedValue(undefined),
         };
 
+        authAuditServiceSpec = {
+            logLoginFailed: jest.fn().mockResolvedValue(undefined),
+            logLogin: jest.fn().mockResolvedValue(undefined),
+        };
+
+        sessionManagerSpec = {
+            issueTokens: jest.fn().mockResolvedValue({
+                accessToken: 'mock-jwt-token',
+                refreshToken: 'mock-refresh-token',
+                expiresIn: 3600,
+            }),
+        };
+
+        sessionFingerprintServiceSpec = {
+            checkAndRecord: jest.fn().mockResolvedValue(undefined),
+        };
+
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 AuthService,
@@ -64,6 +87,18 @@ describe('AuthService', () => {
                 {
                     provide: EmailService,
                     useValue: emailServiceSpec,
+                },
+                {
+                    provide: AuthAuditService,
+                    useValue: authAuditServiceSpec,
+                },
+                {
+                    provide: SessionManagerService,
+                    useValue: sessionManagerSpec,
+                },
+                {
+                    provide: SessionFingerprintService,
+                    useValue: sessionFingerprintServiceSpec,
                 },
             ],
         }).compile();
@@ -111,13 +146,15 @@ describe('AuthService', () => {
     });
 
     describe('forgotPassword', () => {
+        const GENERIC_MESSAGE = 'If this email is registered, you will receive a reset link.';
+
         it('should send a reset email if user exists', async () => {
             const user = { id: 'user-uuid', email: 'test@example.com', username: 'testuser' };
             usersServiceSpec.findByEmail.mockResolvedValue(user);
 
             const result = await service.forgotPassword({ email: 'test@example.com' });
 
-            expect(result.message).toContain('password reset link has been sent');
+            expect(result.message).toBe(GENERIC_MESSAGE);
             expect(cacheManagerSpec.set).toHaveBeenCalled();
             expect(emailServiceSpec.sendEmail).toHaveBeenCalledWith(expect.objectContaining({
                 template: 'password-reset',
@@ -129,8 +166,36 @@ describe('AuthService', () => {
 
             const result = await service.forgotPassword({ email: 'nonexistent@example.com' });
 
-            expect(result.message).toContain('password reset link has been sent');
+            expect(result.message).toBe(GENERIC_MESSAGE);
             expect(emailServiceSpec.sendEmail).not.toHaveBeenCalled();
+        });
+
+        it('should return identical response shape for existing and non-existing email', async () => {
+            usersServiceSpec.findByEmail.mockResolvedValueOnce({ id: 'user-uuid', username: 'testuser' });
+            const existingResult = await service.forgotPassword({ email: 'test@example.com' });
+
+            usersServiceSpec.findByEmail.mockRejectedValueOnce(new NotFoundException());
+            const nonExistingResult = await service.forgotPassword({ email: 'nonexistent@example.com' });
+
+            expect(Object.keys(existingResult)).toEqual(Object.keys(nonExistingResult));
+            expect(existingResult).toEqual(nonExistingResult);
+        });
+
+        it('should keep response time for a non-existent email within 100ms of an existing email', async () => {
+            usersServiceSpec.findByEmail.mockResolvedValueOnce({ id: 'user-uuid', username: 'testuser' });
+            emailServiceSpec.sendEmail.mockImplementationOnce(
+                () => new Promise((resolve) => setTimeout(resolve, 20)),
+            );
+            const existingStart = Date.now();
+            await service.forgotPassword({ email: 'test@example.com' });
+            const existingDuration = Date.now() - existingStart;
+
+            usersServiceSpec.findByEmail.mockRejectedValueOnce(new NotFoundException());
+            const nonExistingStart = Date.now();
+            await service.forgotPassword({ email: 'nonexistent@example.com' });
+            const nonExistingDuration = Date.now() - nonExistingStart;
+
+            expect(Math.abs(existingDuration - nonExistingDuration)).toBeLessThan(100);
         });
     });
 
@@ -182,7 +247,7 @@ describe('AuthService', () => {
             });
 
             expect(result.accessToken).toBe('mock-jwt-token');
-            expect(jwtServiceSpec.sign).toHaveBeenCalledWith({ sub: 'user-uuid' });
+            expect(sessionManagerSpec.issueTokens).toHaveBeenCalledWith('user-uuid', kp.publicKey(), expect.any(Object));
             expect(cacheManagerSpec.del).toHaveBeenCalledWith(`auth_challenge:${kp.publicKey()}`);
         });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,9 @@
-
-import { Injectable, Inject, UnauthorizedException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  Inject,
+  UnauthorizedException,
+  NotFoundException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -19,211 +23,244 @@ import { Request } from 'express';
 
 @Injectable()
 export class AuthService {
-    // Approximate P50 latency of a real forgotPassword lookup + email dispatch.
-    // Non-existent-user requests are padded up to this floor so response timing
-    // cannot be used to enumerate registered emails.
-    private static readonly FORGOT_PASSWORD_RESPONSE_FLOOR_MS = 150;
+  // Approximate P50 latency of a real forgotPassword lookup + email dispatch.
+  // Non-existent-user requests are padded up to this floor so response timing
+  // cannot be used to enumerate registered emails.
+  private static readonly FORGOT_PASSWORD_RESPONSE_FLOOR_MS = 150;
 
-    constructor(
-        private jwtService: JwtService,
-        private usersService: UsersService,
-        private authAuditService: AuthAuditService,
-        private sessionManager: SessionManagerService,
-        private sessionFingerprintService: SessionFingerprintService,
-        private emailService: EmailService,
-        @Inject(CACHE_MANAGER) private cacheManager: Cache,
-    ) { }
+  constructor(
+    private jwtService: JwtService,
+    private usersService: UsersService,
+    private authAuditService: AuthAuditService,
+    private sessionManager: SessionManagerService,
+    private sessionFingerprintService: SessionFingerprintService,
+    private emailService: EmailService,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+  ) {}
 
-    async generateChallenge(publicKey: string): Promise<{ message: string }> {
-        const nonce = crypto.randomBytes(32).toString('hex');
-        const message = `Sign this message to authenticate with StellarSwipe: ${nonce}`;
+  async generateChallenge(publicKey: string): Promise<{ message: string }> {
+    const nonce = crypto.randomBytes(32).toString('hex');
+    const message = `Sign this message to authenticate with StellarSwipe: ${nonce}`;
 
-        // Store challenge in Redis with 5 min TTL
-        await this.cacheManager.set(`auth_challenge:${publicKey}`, message, 300000); // 300s = 5m. Check if cache manager expects ms or s.
+    // Store challenge in Redis with 5 min TTL
+    await this.cacheManager.set(`auth_challenge:${publicKey}`, message, 300000); // 300s = 5m. Check if cache manager expects ms or s.
 
-        return { message };
+    return { message };
+  }
+
+  async verifySignature(
+    dto: VerifySignatureDto,
+    req?: Request,
+  ): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
+    const { publicKey, signature, message } = dto;
+
+    // 1. Retrieve challenge from Redis
+    const storedMessage = await this.cacheManager.get<string>(
+      `auth_challenge:${publicKey}`,
+    );
+
+    if (!storedMessage) {
+      if (req)
+        await this.authAuditService.logLoginFailed(
+          req,
+          'Challenge expired or not found',
+        );
+      throw new UnauthorizedException(
+        'Challenge expired or not found. Please request a new challenge.',
+      );
     }
 
-    async verifySignature(dto: VerifySignatureDto, req?: Request): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
-        const { publicKey, signature, message } = dto;
-
-        // 1. Retrieve challenge from Redis
-        const storedMessage = await this.cacheManager.get<string>(`auth_challenge:${publicKey}`);
-
-        if (!storedMessage) {
-            if (req) await this.authAuditService.logLoginFailed(req, 'Challenge expired or not found');
-            throw new UnauthorizedException('Challenge expired or not found. Please request a new challenge.');
-        }
-
-        if (storedMessage !== message) {
-            if (req) await this.authAuditService.logLoginFailed(req, 'Message mismatch');
-            throw new UnauthorizedException('Message mismatch. Please sign the correct challenge.');
-        }
-
-        // 2. Verify signature
-        try {
-            const keypair = Keypair.fromPublicKey(publicKey);
-            const isValid = keypair.verify(Buffer.from(message), Buffer.from(signature, 'base64'));
-
-            if (!isValid) {
-                if (req) await this.authAuditService.logLoginFailed(req, 'Invalid signature');
-                throw new UnauthorizedException('Invalid signature');
-            }
-        } catch (error) {
-            if (req) await this.authAuditService.logLoginFailed(req, 'Signature verification failed');
-            throw new UnauthorizedException('Signature verification failed');
-        }
-
-        // 3. Clear challenge after successful verification (prevent replay)
-        await this.cacheManager.del(`auth_challenge:${publicKey}`);
-
-        // 4. Find or create user
-        const user = await this.usersService.findOrCreateByWalletAddress(publicKey);
-
-        // 5. Issue secure token pair with session tracking
-        const tokens = await this.sessionManager.issueTokens(user.id, publicKey, {
-            ip: req?.ip,
-            userAgent: req?.headers?.['user-agent'],
-        });
-
-        if (req) await this.authAuditService.logLogin(user.id, req);
-
-        // 6. Fingerprint this login (IP + user-agent + accept-language) and
-        // flag/log if it doesn't match the user's recent login history.
-        await this.sessionFingerprintService.checkAndRecord(user.id, {
-            ipAddress: req?.ip,
-            userAgent: req?.headers?.['user-agent'] as string | undefined,
-            acceptLanguage: req?.headers?.['accept-language'] as string | undefined,
-        });
-
-        return tokens;
+    if (storedMessage !== message) {
+      if (req)
+        await this.authAuditService.logLoginFailed(req, 'Message mismatch');
+      throw new UnauthorizedException(
+        'Message mismatch. Please sign the correct challenge.',
+      );
     }
 
-    async register(dto: RegisterDto): Promise<{ user: any; accessToken: string }> {
-        const { email, password, displayName, username } = dto;
+    // 2. Verify signature
+    try {
+      const keypair = Keypair.fromPublicKey(publicKey);
+      const isValid = keypair.verify(
+        Buffer.from(message),
+        Buffer.from(signature, 'base64'),
+      );
 
-        // Check if user already exists
-        try {
-            const existingUser = await this.usersService.findByEmail(email);
-            if (existingUser) {
-                throw new UnauthorizedException('User with this email already exists');
-            }
-        } catch (error) {
-            if (!(error instanceof NotFoundException)) {
-                throw error;
-            }
-        }
-
-        // Hash password
-        const hashedPassword = await bcrypt.hash(password, 10);
-
-        // Create user
-        const user = await this.usersService.createUser({
-            email,
-            password: hashedPassword,
-            displayName: displayName || email.split('@')[0],
-            username: username || email.split('@')[0],
-        });
-
-        // Send welcome email
-        try {
-            await this.emailService.sendEmail({
-                to: email,
-                subject: 'Welcome to StellarSwipe',
-                template: 'welcome',
-                variables: {
-                    name: user.displayName || user.username,
-                    link: 'https://stellarswipe.com/dashboard',
-                },
-            });
-        } catch (emailError) {
-            // Log email error but don't fail registration
-            console.error('Failed to send welcome email:', emailError);
-        }
-
-        // Generate JWT
-        const payload: JwtPayload = { sub: user.id };
-        const accessToken = this.jwtService.sign(payload);
-
-        return {
-            user: {
-                id: user.id,
-                email: user.email,
-                username: user.username,
-                displayName: user.displayName,
-            },
-            accessToken,
-        };
+      if (!isValid) {
+        if (req)
+          await this.authAuditService.logLoginFailed(req, 'Invalid signature');
+        throw new UnauthorizedException('Invalid signature');
+      }
+    } catch (error) {
+      if (req)
+        await this.authAuditService.logLoginFailed(
+          req,
+          'Signature verification failed',
+        );
+      throw new UnauthorizedException('Signature verification failed');
     }
 
-    async forgotPassword(dto: ForgotPasswordDto): Promise<{ message: string }> {
-        const { email } = dto;
-        const startedAt = Date.now();
+    // 3. Clear challenge after successful verification (prevent replay)
+    await this.cacheManager.del(`auth_challenge:${publicKey}`);
 
-        let user: { id: string; displayName?: string; username?: string } | null = null;
-        try {
-            user = await this.usersService.findByEmail(email);
-        } catch (error) {
-            // We should not reveal if user exists or not for security reasons
-            if (!(error instanceof NotFoundException)) {
-                throw error;
-            }
-        }
+    // 4. Find or create user
+    const user = await this.usersService.findOrCreateByWalletAddress(publicKey);
 
-        if (user) {
-            // Generate secure token
-            const token = crypto.randomBytes(32).toString('hex');
+    // 5. Issue secure token pair with session tracking
+    const tokens = await this.sessionManager.issueTokens(user.id, publicKey, {
+      ip: req?.ip,
+      userAgent: req?.headers?.['user-agent'],
+    });
 
-            // Store token in cache with 1 hour TTL
-            await this.cacheManager.set(`pwd_reset:${token}`, user.id, 3600000); // 1h in ms
+    if (req) await this.authAuditService.logLogin(user.id, req);
 
-            // Send email
-            await this.emailService.sendEmail({
-                to: email,
-                subject: 'Password Reset Request',
-                template: 'password-reset',
-                variables: {
-                    name: user.displayName || user.username,
-                    link: `https://stellarswipe.com/reset-password?token=${token}`,
-                },
-            });
-        }
+    // 6. Fingerprint this login (IP + user-agent + accept-language) and
+    // flag/log if it doesn't match the user's recent login history.
+    await this.sessionFingerprintService.checkAndRecord(user.id, {
+      ipAddress: req?.ip,
+      userAgent: req?.headers?.['user-agent'] as string | undefined,
+      acceptLanguage: req?.headers?.['accept-language'] as string | undefined,
+    });
 
-        // Pad the response so a non-existent-user request takes as long as a
-        // real lookup + email dispatch, preventing enumeration via timing.
-        await this.padToMinimumDuration(startedAt, AuthService.FORGOT_PASSWORD_RESPONSE_FLOOR_MS);
+    return tokens;
+  }
 
-        // Always return the same message and shape regardless of whether the
-        // account exists, so the response body cannot be used to enumerate emails.
-        return { message: 'If this email is registered, you will receive a reset link.' };
+  async register(
+    dto: RegisterDto,
+  ): Promise<{ user: any; accessToken: string }> {
+    const { email, password, displayName, username } = dto;
+
+    // Check if user already exists
+    try {
+      const existingUser = await this.usersService.findByEmail(email);
+      if (existingUser) {
+        throw new UnauthorizedException('User with this email already exists');
+      }
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) {
+        throw error;
+      }
     }
 
-    private async padToMinimumDuration(startedAt: number, floorMs: number): Promise<void> {
-        const remaining = floorMs - (Date.now() - startedAt);
-        if (remaining > 0) {
-            await new Promise((resolve) => setTimeout(resolve, remaining));
-        }
+    // Hash password
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    // Create user
+    const user = await this.usersService.createUser({
+      email,
+      password: hashedPassword,
+      displayName: displayName || email.split('@')[0],
+      username: username || email.split('@')[0],
+    });
+
+    // Send welcome email
+    try {
+      await this.emailService.sendEmail({
+        to: email,
+        subject: 'Welcome to StellarSwipe',
+        template: 'welcome',
+        variables: {
+          name: user.displayName || user.username,
+          link: 'https://stellarswipe.com/dashboard',
+        },
+      });
+    } catch (emailError) {
+      // Log email error but don't fail registration
+      console.error('Failed to send welcome email:', emailError);
     }
 
-    async resetPassword(dto: ResetPasswordDto): Promise<{ message: string }> {
-        const { token, newPassword } = dto;
+    // Generate JWT
+    const payload: JwtPayload = { sub: user.id };
+    const accessToken = this.jwtService.sign(payload);
 
-        // 1. Retrieve user ID from cache
-        const userId = await this.cacheManager.get<string>(`pwd_reset:${token}`);
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        username: user.username,
+        displayName: user.displayName,
+      },
+      accessToken,
+    };
+  }
 
-        if (!userId) {
-            throw new UnauthorizedException('Invalid or expired reset token');
-        }
+  async forgotPassword(dto: ForgotPasswordDto): Promise<{ message: string }> {
+    const { email } = dto;
+    const startedAt = Date.now();
 
-        // 2. Hash new password
-        const hashedPassword = await bcrypt.hash(newPassword, 10);
-
-        // 3. Update password
-        await this.usersService.updatePassword(userId, hashedPassword);
-
-        // 4. Clear token from cache
-        await this.cacheManager.del(`pwd_reset:${token}`);
-
-        return { message: 'Password has been successfully reset' };
+    let user: { id: string; displayName?: string; username?: string } | null =
+      null;
+    try {
+      user = await this.usersService.findByEmail(email);
+    } catch (error) {
+      // We should not reveal if user exists or not for security reasons
+      if (!(error instanceof NotFoundException)) {
+        throw error;
+      }
     }
+
+    if (user) {
+      // Generate secure token
+      const token = crypto.randomBytes(32).toString('hex');
+
+      // Store token in cache with 1 hour TTL
+      await this.cacheManager.set(`pwd_reset:${token}`, user.id, 3600000); // 1h in ms
+
+      // Send email
+      await this.emailService.sendEmail({
+        to: email,
+        subject: 'Password Reset Request',
+        template: 'password-reset',
+        variables: {
+          name: user.displayName || user.username,
+          link: `https://stellarswipe.com/reset-password?token=${token}`,
+        },
+      });
+    }
+
+    // Pad the response so a non-existent-user request takes as long as a
+    // real lookup + email dispatch, preventing enumeration via timing.
+    await this.padToMinimumDuration(
+      startedAt,
+      AuthService.FORGOT_PASSWORD_RESPONSE_FLOOR_MS,
+    );
+
+    // Always return the same message and shape regardless of whether the
+    // account exists, so the response body cannot be used to enumerate emails.
+    return {
+      message: 'If this email is registered, you will receive a reset link.',
+    };
+  }
+
+  private async padToMinimumDuration(
+    startedAt: number,
+    floorMs: number,
+  ): Promise<void> {
+    const remaining = floorMs - (Date.now() - startedAt);
+    if (remaining > 0) {
+      await new Promise((resolve) => setTimeout(resolve, remaining));
+    }
+  }
+
+  async resetPassword(dto: ResetPasswordDto): Promise<{ message: string }> {
+    const { token, newPassword } = dto;
+
+    // 1. Retrieve user ID from cache
+    const userId = await this.cacheManager.get<string>(`pwd_reset:${token}`);
+
+    if (!userId) {
+      throw new UnauthorizedException('Invalid or expired reset token');
+    }
+
+    // 2. Hash new password
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+    // 3. Update password
+    await this.usersService.updatePassword(userId, hashedPassword);
+
+    // 4. Clear token from cache
+    await this.cacheManager.del(`pwd_reset:${token}`);
+
+    return { message: 'Password has been successfully reset' };
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -14,16 +14,23 @@ import { UsersService } from '../users/users.service';
 import { AuthAuditService } from './auth-audit.service';
 import { SessionManagerService } from './session/session-manager.service';
 import { SessionFingerprintService } from './session/session-fingerprint.service';
+import { EmailService } from '../email/email.service';
 import { Request } from 'express';
 
 @Injectable()
 export class AuthService {
+    // Approximate P50 latency of a real forgotPassword lookup + email dispatch.
+    // Non-existent-user requests are padded up to this floor so response timing
+    // cannot be used to enumerate registered emails.
+    private static readonly FORGOT_PASSWORD_RESPONSE_FLOOR_MS = 150;
+
     constructor(
         private jwtService: JwtService,
         private usersService: UsersService,
         private authAuditService: AuthAuditService,
         private sessionManager: SessionManagerService,
         private sessionFingerprintService: SessionFingerprintService,
+        private emailService: EmailService,
         @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) { }
 
@@ -151,10 +158,19 @@ export class AuthService {
 
     async forgotPassword(dto: ForgotPasswordDto): Promise<{ message: string }> {
         const { email } = dto;
+        const startedAt = Date.now();
 
+        let user: { id: string; displayName?: string; username?: string } | null = null;
         try {
-            const user = await this.usersService.findByEmail(email);
+            user = await this.usersService.findByEmail(email);
+        } catch (error) {
+            // We should not reveal if user exists or not for security reasons
+            if (!(error instanceof NotFoundException)) {
+                throw error;
+            }
+        }
 
+        if (user) {
             // Generate secure token
             const token = crypto.randomBytes(32).toString('hex');
 
@@ -171,14 +187,22 @@ export class AuthService {
                     link: `https://stellarswipe.com/reset-password?token=${token}`,
                 },
             });
-        } catch (error) {
-            // We should not reveal if user exists or not for security reasons
-            if (!(error instanceof NotFoundException)) {
-                throw error;
-            }
         }
 
-        return { message: 'If an account with that email exists, a password reset link has been sent.' };
+        // Pad the response so a non-existent-user request takes as long as a
+        // real lookup + email dispatch, preventing enumeration via timing.
+        await this.padToMinimumDuration(startedAt, AuthService.FORGOT_PASSWORD_RESPONSE_FLOOR_MS);
+
+        // Always return the same message and shape regardless of whether the
+        // account exists, so the response body cannot be used to enumerate emails.
+        return { message: 'If this email is registered, you will receive a reset link.' };
+    }
+
+    private async padToMinimumDuration(startedAt: number, floorMs: number): Promise<void> {
+        const remaining = floorMs - (Date.now() - startedAt);
+        if (remaining > 0) {
+            await new Promise((resolve) => setTimeout(resolve, remaining));
+        }
     }
 
     async resetPassword(dto: ResetPasswordDto): Promise<{ message: string }> {

--- a/src/cache/cache-invalidation.service.spec.ts
+++ b/src/cache/cache-invalidation.service.spec.ts
@@ -4,6 +4,8 @@ import {
   UserCacheKeys,
   SignalCacheKeys,
   LeaderboardCacheKeys,
+  AnalyticsCacheKeys,
+  MarketCacheKeys,
 } from './cache-invalidation.service';
 import { CacheService, CachePrefix } from './cache.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';

--- a/src/cache/cache-invalidation.service.ts
+++ b/src/cache/cache-invalidation.service.ts
@@ -11,17 +11,19 @@ export const UserCacheKeys = {
     tenantKey(CachePrefix.USER_PROFILE, tenantId, `${userId}:profile`),
   preferences: (userId: string, tenantId = 'default') =>
     tenantKey(CachePrefix.USER_PROFILE, tenantId, `${userId}:preferences`),
-  sessions: (userId: string) =>
-    `${USER_PREFIX}${userId}:sessions`,
+  sessions: (userId: string) => `${USER_PREFIX}${userId}:sessions`,
   portfolio: (userId: string) => `${CachePrefix.PORTFOLIO}${userId}`,
 };
 
 /** Signal and feed-related cache keys */
 export const SignalCacheKeys = {
   signal: (signalId: string) => `${CachePrefix.SIGNAL}${signalId}`,
-  feedPage: (page: number, sortBy?: string) => `${CachePrefix.SIGNAL}feed:${sortBy || 'ranked'}:${page}`,
-  feedAsset: (asset: string, page: number) => `${CachePrefix.SIGNAL}feed:${asset}:${page}`,
-  feedProvider: (providerId: string, page: number) => `${CachePrefix.SIGNAL}feed:provider:${providerId}:${page}`,
+  feedPage: (page: number, sortBy?: string) =>
+    `${CachePrefix.SIGNAL}feed:${sortBy || 'ranked'}:${page}`,
+  feedAsset: (asset: string, page: number) =>
+    `${CachePrefix.SIGNAL}feed:${asset}:${page}`,
+  feedProvider: (providerId: string, page: number) =>
+    `${CachePrefix.SIGNAL}feed:provider:${providerId}:${page}`,
   allFeed: () => `${CachePrefix.SIGNAL}feed`,
   userSignals: (userId: string) => `${CachePrefix.SIGNAL}user:${userId}`,
 };
@@ -45,7 +47,8 @@ export const MarketCacheKeys = {
 /** Leaderboard and portfolio cache keys */
 export const LeaderboardCacheKeys = {
   overall: (page: number) => `stellarswipe:leaderboard:overall:${page}`,
-  assetSpecific: (asset: string, page: number) => `stellarswipe:leaderboard:${asset}:${page}`,
+  assetSpecific: (asset: string, page: number) =>
+    `stellarswipe:leaderboard:${asset}:${page}`,
   userRank: (userId: string) => `stellarswipe:leaderboard:user:${userId}`,
   topPerformers: () => `stellarswipe:leaderboard:top-performers`,
 };
@@ -77,13 +80,19 @@ export class CacheInvalidationService {
   }
 
   /** Invalidate only the user's profile cache entry. */
-  async invalidateUserProfile(userId: string, tenantId = 'default'): Promise<void> {
+  async invalidateUserProfile(
+    userId: string,
+    tenantId = 'default',
+  ): Promise<void> {
     await this.cacheService.del(UserCacheKeys.profile(userId, tenantId));
     this.logger.log(`Profile cache invalidated for user ${userId}`);
   }
 
   /** Invalidate only the user's preferences cache entry. */
-  async invalidateUserPreferences(userId: string, tenantId = 'default'): Promise<void> {
+  async invalidateUserPreferences(
+    userId: string,
+    tenantId = 'default',
+  ): Promise<void> {
     await this.cacheService.del(UserCacheKeys.preferences(userId, tenantId));
     this.logger.log(`Preferences cache invalidated for user ${userId}`);
   }
@@ -95,28 +104,44 @@ export class CacheInvalidationService {
   }
 
   /** Invalidate cache for multiple users at once (e.g. bulk admin operations). */
-  async invalidateUsers(userIds: string[], tenantId = 'default'): Promise<void> {
+  async invalidateUsers(
+    userIds: string[],
+    tenantId = 'default',
+  ): Promise<void> {
     await Promise.all(userIds.map((id) => this.invalidateUser(id, tenantId)));
   }
 
   /** Invalidate analytics dashboard cache for a tenant+period. */
   async invalidateAnalytics(tenantId: string, period: string): Promise<void> {
     await this.cacheService.del(AnalyticsCacheKeys.dashboard(tenantId, period));
-    this.logger.log(`Analytics cache invalidated for tenant ${tenantId}, period ${period}`);
+    this.logger.log(
+      `Analytics cache invalidated for tenant ${tenantId}, period ${period}`,
+    );
   }
 
   /** Invalidate a single analytics snapshot. */
-  async invalidateAnalyticsSnapshot(tenantId: string, period: string, date: string): Promise<void> {
-    await this.cacheService.del(AnalyticsCacheKeys.snapshot(tenantId, period, date));
+  async invalidateAnalyticsSnapshot(
+    tenantId: string,
+    period: string,
+    date: string,
+  ): Promise<void> {
+    await this.cacheService.del(
+      AnalyticsCacheKeys.snapshot(tenantId, period, date),
+    );
   }
 
   /** Invalidate market data (price + history) for an asset pair. */
-  async invalidateMarketData(tenantId: string, assetPair: string): Promise<void> {
+  async invalidateMarketData(
+    tenantId: string,
+    assetPair: string,
+  ): Promise<void> {
     await Promise.all([
       this.cacheService.del(MarketCacheKeys.price(tenantId, assetPair)),
       this.cacheService.del(MarketCacheKeys.history(tenantId, assetPair)),
     ]);
-    this.logger.log(`Market cache invalidated for ${assetPair} (tenant: ${tenantId})`);
+    this.logger.log(
+      `Market cache invalidated for ${assetPair} (tenant: ${tenantId})`,
+    );
   }
 
   /**
@@ -190,7 +215,9 @@ export class CacheInvalidationService {
     // Invalidate asset-specific leaderboards if asset pair is provided
     if (assetPair) {
       for (let page = 1; page <= 10; page++) {
-        keysToInvalidate.push(LeaderboardCacheKeys.assetSpecific(assetPair, page));
+        keysToInvalidate.push(
+          LeaderboardCacheKeys.assetSpecific(assetPair, page),
+        );
       }
     }
 
@@ -243,7 +270,8 @@ export class CacheInvalidationService {
     eventNameList: string[];
   } {
     return {
-      listenersAttached: this.eventEmitter.listenerCount('cache.invalidated.signal') +
+      listenersAttached:
+        this.eventEmitter.listenerCount('cache.invalidated.signal') +
         this.eventEmitter.listenerCount('cache.invalidated.trade') +
         this.eventEmitter.listenerCount('cache.invalidated.user') +
         this.eventEmitter.listenerCount('cache.invalidated.dashboard'),

--- a/src/cache/cache-invalidation.service.ts
+++ b/src/cache/cache-invalidation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { CacheService, CachePrefix } from './cache.service';
+import { CacheService, CachePrefix, tenantKey } from './cache.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
 /** All user-data cache keys are namespaced under this prefix. */
@@ -24,6 +24,22 @@ export const SignalCacheKeys = {
   feedProvider: (providerId: string, page: number) => `${CachePrefix.SIGNAL}feed:provider:${providerId}:${page}`,
   allFeed: () => `${CachePrefix.SIGNAL}feed`,
   userSignals: (userId: string) => `${CachePrefix.SIGNAL}user:${userId}`,
+};
+
+/** Analytics dashboard cache keys */
+export const AnalyticsCacheKeys = {
+  dashboard: (tenantId: string, period: string) =>
+    tenantKey(CachePrefix.ANALYTICS, tenantId, `dashboard:${period}`),
+  snapshot: (tenantId: string, period: string, date: string) =>
+    tenantKey(CachePrefix.ANALYTICS, tenantId, `snapshot:${period}:${date}`),
+};
+
+/** Market data cache keys */
+export const MarketCacheKeys = {
+  price: (tenantId: string, assetPair: string) =>
+    tenantKey(CachePrefix.MARKET, tenantId, `price:${assetPair}`),
+  history: (tenantId: string, assetPair: string) =>
+    tenantKey(CachePrefix.MARKET, tenantId, `history:${assetPair}`),
 };
 
 /** Leaderboard and portfolio cache keys */


### PR DESCRIPTION
closes #853 
AuthService.forgotPassword() sends a password reset email if the user exists. If the user does not exist, it returns immediately without sending an email. Because the response time differs — a DB lookup + email send vs. an immediate return — an attacker can enumerate registered email addresses by measuring response latency. This is a classic user enumeration vulnerability.

Motivation
Email enumeration enables targeted phishing and credential stuffing against registered users.
OWASP Authentication Cheat Sheet explicitly recommends uniform response times for account-lookup endpoints regardless of whether the account exists.
The fix is low-effort (add a sleep or use a constant-time dummy operation) and high-impact for user privacy.
Proposed Implementation
In forgotPassword(), always return the same success response (200 OK with { message: "If this email is registered, you will receive a reset link." }) regardless of whether the user exists.
Add a fixed minimum response delay: if the user was not found, simulate the email-send latency by sleeping for the average duration of a real email-send operation (measure P50 latency of emailService.sendPasswordReset() and use that as the floor).
Alternatively, always call a hashEmail(email) operation of constant cost to equalize timing.
Move the email template to notification-template.service.ts so it is configurable without code changes.
