### PR TITLE
fix(common): typed exception + auth-guard-safe VerifiedEmailGuard (#822)

### DIFF
--- a/docs/verified-email-guard.md
+++ b/docs/verified-email-guard.md
@@ -1,0 +1,87 @@
+# Verified Email Guard
+
+## Overview
+
+Some sensitive actions — changing payout destinations, accessing certain reports, etc. —
+should only be available to accounts that have verified their email address.
+`@RequireVerifiedEmail()` (`src/common/decorators/require-verified-email.decorator.ts`) paired
+with `VerifiedEmailGuard` (`src/common/guards/verified-email.guard.ts`) provides an opt-in way
+to enforce that on any route, without affecting any endpoint that doesn't ask for it.
+
+## How it works
+
+- `@RequireVerifiedEmail()` sets a small piece of route metadata (`requireVerifiedEmail: true`)
+  using Nest's `SetMetadata`, and can be applied to a single handler or to an entire controller.
+- `VerifiedEmailGuard` reads that metadata via `Reflector#getAllAndOverride`. If it isn't set,
+  the guard is a no-op and returns `true` immediately — endpoints without the decorator are
+  completely unaffected.
+- When the metadata is set, the guard reads `request.user` (populated by the authentication
+  guard that ran before it) and checks `user.emailVerified`:
+  - Verified user → request proceeds.
+  - Unverified user → throws `EmailNotVerifiedException`
+    (`src/common/exceptions/email-not-verified.exception.ts`), an `HttpException` that resolves
+    to **HTTP 403** with a JSON body containing `code: "EMAIL_NOT_VERIFIED"` so clients can
+    distinguish this rejection from other 403s (permissions, KYC level, etc.).
+  - No `request.user` at all (e.g. the guard was accidentally used without an auth guard, or
+    is running in some other order) → the guard defers and returns `true`, leaving rejection of
+    unauthenticated requests to the authentication guard, consistent with how `KycGuard` and
+    `WalletAgeGuard` behave in this codebase.
+
+`VerifiedEmailGuard` only depends on Nest's `Reflector`, so it needs no module wiring — just add
+it to a route's `@UseGuards(...)` list.
+
+## Composing with authentication
+
+`VerifiedEmailGuard` **must** run after your authentication guard (`JwtAuthGuard`,
+`UnifiedAuthGuard`, etc.) so `request.user` is already populated. Guards passed to `@UseGuards()`
+run in array order, so list the auth guard first:
+
+```typescript
+import { UseGuards, Get } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { VerifiedEmailGuard } from '../common/guards/verified-email.guard';
+import { RequireVerifiedEmail } from '../common/decorators/require-verified-email.decorator';
+
+@Get('payout-settings')
+@UseGuards(JwtAuthGuard, VerifiedEmailGuard)
+@RequireVerifiedEmail()
+getPayoutSettings() { ... }
+```
+
+### Controller-level usage
+
+Apply it once at the class level to protect every route on the controller:
+
+```typescript
+@UseGuards(JwtAuthGuard, VerifiedEmailGuard)
+@RequireVerifiedEmail()
+@Controller('payouts')
+export class PayoutsController {
+  @Get('destination')
+  getDestination() { ... }
+
+  @Post('destination')
+  updateDestination(@Body() dto: UpdatePayoutDestinationDto) { ... }
+}
+```
+
+## Error response shape
+
+```json
+{
+  "statusCode": 403,
+  "message": "This action requires a verified email address.",
+  "error": "EmailNotVerified",
+  "code": "EMAIL_NOT_VERIFIED"
+}
+```
+
+## Testing
+
+See `src/common/guards/verified-email.guard.spec.ts` for unit tests covering:
+
+- A verified user is allowed through.
+- An unverified user is rejected with `EmailNotVerifiedException` (HTTP 403, `code:
+  "EMAIL_NOT_VERIFIED"`).
+- Routes without `@RequireVerifiedEmail()` are unaffected (opt-in only).
+- The guard defers to the auth guard rather than double-rejecting when `request.user` is absent.

--- a/src/common/decorators/require-verified-email.decorator.ts
+++ b/src/common/decorators/require-verified-email.decorator.ts
@@ -3,8 +3,15 @@ import { SetMetadata } from '@nestjs/common';
 export const REQUIRE_VERIFIED_EMAIL_KEY = 'requireVerifiedEmail';
 
 /**
- * Restricts an endpoint to users who have verified their email address.
- * Must be used alongside JwtAuthGuard (or equivalent) and VerifiedEmailGuard.
+ * Restricts an endpoint (or every endpoint on a controller) to users who have
+ * verified their email address. Opt-in only: routes without this decorator
+ * are completely unaffected.
+ *
+ * Apply `VerifiedEmailGuard` *after* your authentication guard so
+ * `req.user` is populated before the check runs. Unverified users receive an
+ * `EmailNotVerifiedException` (HTTP 403, `code: "EMAIL_NOT_VERIFIED"`).
+ *
+ * See `docs/verified-email-guard.md` for the full usage guide.
  *
  * @example
  * ```ts
@@ -12,6 +19,14 @@ export const REQUIRE_VERIFIED_EMAIL_KEY = 'requireVerifiedEmail';
  * @UseGuards(JwtAuthGuard, VerifiedEmailGuard)
  * @RequireVerifiedEmail()
  * getPayoutSettings() { ... }
+ * ```
+ *
+ * @example Controller-level (applies to every route in the controller)
+ * ```ts
+ * @UseGuards(JwtAuthGuard, VerifiedEmailGuard)
+ * @RequireVerifiedEmail()
+ * @Controller('payouts')
+ * export class PayoutsController { ... }
  * ```
  */
 export const RequireVerifiedEmail = () => SetMetadata(REQUIRE_VERIFIED_EMAIL_KEY, true);

--- a/src/common/exceptions/email-not-verified.exception.ts
+++ b/src/common/exceptions/email-not-verified.exception.ts
@@ -1,0 +1,26 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/** Stable error code returned in the response body for unverified-email rejections. */
+export const EMAIL_NOT_VERIFIED_ERROR_CODE = 'EMAIL_NOT_VERIFIED';
+
+/**
+ * Thrown by {@link VerifiedEmailGuard} when an authenticated user without a
+ * verified email address hits an endpoint annotated with `@RequireVerifiedEmail()`.
+ *
+ * Always resolves to HTTP 403 with a typed, machine-readable `code` so clients
+ * can distinguish this rejection from other 403s (e.g. permissions, KYC).
+ */
+export class EmailNotVerifiedException extends HttpException {
+  constructor(
+    message: string = 'This action requires a verified email address.',
+  ) {
+    super(
+      {
+        message,
+        error: 'EmailNotVerified',
+        code: EMAIL_NOT_VERIFIED_ERROR_CODE,
+      },
+      HttpStatus.FORBIDDEN,
+    );
+  }
+}

--- a/src/common/guards/verified-email.guard.spec.ts
+++ b/src/common/guards/verified-email.guard.spec.ts
@@ -1,9 +1,13 @@
 import { Reflector } from '@nestjs/core';
-import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ExecutionContext, HttpStatus } from '@nestjs/common';
 import { VerifiedEmailGuard } from './verified-email.guard';
 import { REQUIRE_VERIFIED_EMAIL_KEY } from '../decorators/require-verified-email.decorator';
+import {
+  EMAIL_NOT_VERIFIED_ERROR_CODE,
+  EmailNotVerifiedException,
+} from '../exceptions/email-not-verified.exception';
 
-function makeContext(user: any, handlerMeta: boolean | undefined): ExecutionContext {
+function makeContext(user: unknown): ExecutionContext {
   return {
     getHandler: () => ({}),
     getClass: () => ({}),
@@ -22,37 +26,52 @@ describe('VerifiedEmailGuard', () => {
     guard = new VerifiedEmailGuard(reflector);
   });
 
-  it('allows the request when the decorator is not present', () => {
+  it('allows the request when @RequireVerifiedEmail() is not present (opt-in behavior)', () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
-    const ctx = makeContext({ emailVerified: false }, undefined);
+    const ctx = makeContext({ id: 'u1', emailVerified: false });
     expect(guard.canActivate(ctx)).toBe(true);
   });
 
   it('allows a verified user when the decorator is present', () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
-    const ctx = makeContext({ id: 'u1', emailVerified: true }, true);
+    const ctx = makeContext({ id: 'u1', emailVerified: true });
     expect(guard.canActivate(ctx)).toBe(true);
   });
 
-  it('rejects an unverified user with ForbiddenException', () => {
+  it('rejects an unverified user with a typed EmailNotVerifiedException (HTTP 403 + error code)', () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
-    const ctx = makeContext({ id: 'u1', emailVerified: false }, true);
-    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
-  });
+    const ctx = makeContext({ id: 'u1', emailVerified: false });
 
-  it('rejects when user is absent (guard composed without auth guard)', () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
-    const ctx = makeContext(undefined, true);
-    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
-  });
+    expect(() => guard.canActivate(ctx)).toThrow(EmailNotVerifiedException);
 
-  it('error message contains EMAIL_NOT_VERIFIED code for unverified user', () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
-    const ctx = makeContext({ id: 'u1', emailVerified: false }, true);
     try {
       guard.canActivate(ctx);
+      fail('expected canActivate to throw');
     } catch (err) {
-      expect((err as ForbiddenException).message).toContain('EMAIL_NOT_VERIFIED');
+      const exception = err as EmailNotVerifiedException;
+      expect(exception.getStatus()).toBe(HttpStatus.FORBIDDEN);
+      const response = exception.getResponse() as Record<string, unknown>;
+      expect(response.code).toBe(EMAIL_NOT_VERIFIED_ERROR_CODE);
     }
+  });
+
+  it('defers to the authentication guard when req.user is absent, instead of duplicating its rejection', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const ctx = makeContext(undefined);
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('reads metadata from both the handler and the class so controller-level usage works', () => {
+    const spy = jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue(true);
+    const ctx = makeContext({ id: 'u1', emailVerified: true });
+
+    guard.canActivate(ctx);
+
+    expect(spy).toHaveBeenCalledWith(REQUIRE_VERIFIED_EMAIL_KEY, [
+      ctx.getHandler(),
+      ctx.getClass(),
+    ]);
   });
 });

--- a/src/common/guards/verified-email.guard.ts
+++ b/src/common/guards/verified-email.guard.ts
@@ -1,16 +1,15 @@
-import {
-  Injectable,
-  CanActivate,
-  ExecutionContext,
-  ForbiddenException,
-} from '@nestjs/common';
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { REQUIRE_VERIFIED_EMAIL_KEY } from '../decorators/require-verified-email.decorator';
+import { EmailNotVerifiedException } from '../exceptions/email-not-verified.exception';
 
 /**
- * Guard that enforces email verification on endpoints decorated with @RequireVerifiedEmail().
- * Must be composed after an authentication guard so req.user is populated.
- * Endpoints without @RequireVerifiedEmail() are completely unaffected.
+ * Guard that enforces email verification on endpoints decorated with
+ * `@RequireVerifiedEmail()`.
+ *
+ * Must be composed AFTER an authentication guard (e.g. `JwtAuthGuard`) so
+ * `req.user` is already populated — see `@RequireVerifiedEmail()` for a usage
+ * example. Endpoints without the decorator are completely unaffected.
  */
 @Injectable()
 export class VerifiedEmailGuard implements CanActivate {
@@ -22,6 +21,7 @@ export class VerifiedEmailGuard implements CanActivate {
       [context.getHandler(), context.getClass()],
     );
 
+    // Opt-in: routes without @RequireVerifiedEmail() are untouched.
     if (!required) {
       return true;
     }
@@ -29,14 +29,14 @@ export class VerifiedEmailGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const user = request.user;
 
+    // No authenticated user on the request: defer to the auth guard that
+    // should run before this one rather than duplicating its rejection.
     if (!user) {
-      throw new ForbiddenException('Authentication required.');
+      return true;
     }
 
     if (!user.emailVerified) {
-      throw new ForbiddenException(
-        'EMAIL_NOT_VERIFIED: This action requires a verified email address.',
-      );
+      throw new EmailNotVerifiedException();
     }
 
     return true;


### PR DESCRIPTION
## Summary

A `@RequireVerifiedEmail()` decorator and `VerifiedEmailGuard` already existed on `main` from an earlier, unmerged commit, but they didn't fully satisfy the issue's acceptance criteria: unverified-email rejections used a generic `ForbiddenException` with a string-prefixed message rather than a typed exception with a distinct error code, and the guard threw when `req.user` was missing instead of deferring to the authentication guard (inconsistent with `KycGuard`/`WalletAgeGuard` elsewhere in this repo). This PR closes those gaps and hardens the test coverage.

## Context / before-after behavior

- **Before**: `VerifiedEmailGuard` threw `new ForbiddenException('EMAIL_NOT_VERIFIED: ...')` — a plain string message, not a structured/typed error — and also threw when `req.user` was absent, duplicating the authentication guard's job.
- **After**: unverified users get `EmailNotVerifiedException` (`src/common/exceptions/email-not-verified.exception.ts`), an `HttpException` resolving to HTTP 403 with a JSON body `{ message, error: "EmailNotVerified", code: "EMAIL_NOT_VERIFIED" }`, so clients can distinguish this 403 from permission/KYC 403s. When `req.user` is absent, the guard now returns `true` and defers to the auth guard that should run first, matching the pattern already used by `KycGuard` and `WalletAgeGuard`.
- Behavior is still fully opt-in: `@RequireVerifiedEmail()` sets route metadata via `SetMetadata`/`Reflector`, and any route without it is completely unaffected. It composes after auth guards, e.g. `@UseGuards(JwtAuthGuard, VerifiedEmailGuard)`.

## Testing

- Rewrote `src/common/guards/verified-email.guard.spec.ts` to cover:
  - Verified user is allowed through.
  - Unverified user is rejected, asserting both the exception type (`EmailNotVerifiedException`) and the `code: "EMAIL_NOT_VERIFIED"` in the response body.
  - No `@RequireVerifiedEmail()` metadata → guard is a no-op (opt-in confirmed).
  - `req.user` absent → guard defers (returns `true`) instead of throwing.
  - Metadata is read from both handler and class so controller-level decoration works.
- **Dependencies were not installed in this environment (per task constraints), so the test suite was not executed — only written.** Reviewers should run `npm test -- verified-email.guard` (or the full suite) before merging.

## Usage notes for other developers

Apply the guard **after** your auth guard, then opt in per-route or per-controller:

```typescript
@Get('payout-settings')
@UseGuards(JwtAuthGuard, VerifiedEmailGuard)
@RequireVerifiedEmail()
getPayoutSettings() { ... }
```

Full guide with the controller-level example and the exact error response shape is in `docs/verified-email-guard.md`.

Closes #822