### PR TITLE
feat(authorization): diff role-set changes on user role assign/revoke

### DIFF
--- a/src/authorization/rbac.service.spec.ts
+++ b/src/authorization/rbac.service.spec.ts
@@ -190,6 +190,10 @@ describe('RbacService', () => {
       mockRoleRepository.findOne.mockResolvedValue(mockRole);
       mockUserRoleRepository.create.mockReturnValue(mockUserRole);
       mockUserRoleRepository.save.mockResolvedValue(mockUserRole);
+      // No active roles before, one active role (this assignment) after.
+      mockUserRoleRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ roleId }]);
 
       const result = await service.assignRoleToUser(userId, roleId, assignedBy);
 
@@ -216,6 +220,81 @@ describe('RbacService', () => {
       await expect(service.assignRoleToUser(userId, roleId, assignedBy)).rejects.toThrow(
         'Role not found'
       );
+    });
+
+    it('should write an audit entry with a before/after diff when a single role is added (issue #820)', async () => {
+      const userId = 'user1';
+      const roleId = 'role2';
+      const assignedBy = 'admin1';
+      const mockRole = { id: roleId, name: 'Editor' };
+      const mockUserRole = { id: 'userRole2', userId, roleId, assignedBy, status: 'active' };
+
+      mockRoleRepository.findOne.mockResolvedValue(mockRole);
+      mockUserRoleRepository.create.mockReturnValue(mockUserRole);
+      mockUserRoleRepository.save.mockResolvedValue(mockUserRole);
+      // Before: user already holds 'role1'. After: user holds 'role1' and the newly assigned 'role2'.
+      mockUserRoleRepository.find
+        .mockResolvedValueOnce([{ roleId: 'role1' }])
+        .mockResolvedValueOnce([{ roleId: 'role1' }, { roleId }]);
+
+      await service.assignRoleToUser(userId, roleId, assignedBy);
+
+      expect(mockPermissionAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: assignedBy,
+          targetUserId: userId,
+          action: 'role_assigned',
+          beforeState: { roleIds: ['role1'] },
+          afterState: { roleIds: ['role1', roleId] },
+        }),
+      );
+    });
+  });
+
+  describe('revokeRoleFromUser', () => {
+    it('should write an audit entry with a before/after diff when a single role is revoked (issue #820)', async () => {
+      const userId = 'user1';
+      const roleId = 'role1';
+      const revokedBy = 'admin1';
+      const mockUserRole = { id: 'userRole1', userId, roleId, status: 'active' };
+      const mockRole = { id: roleId, name: 'Editor' };
+
+      mockUserRoleRepository.findOne.mockResolvedValue(mockUserRole);
+      mockUserRoleRepository.save.mockResolvedValue({ ...mockUserRole, status: 'revoked' });
+      mockRoleRepository.findOne.mockResolvedValue(mockRole);
+      // Before: role is active. After: revocation removes it from the active set.
+      mockUserRoleRepository.find
+        .mockResolvedValueOnce([{ roleId }])
+        .mockResolvedValueOnce([]);
+
+      await service.revokeRoleFromUser(userId, roleId, revokedBy);
+
+      expect(mockPermissionAuditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: revokedBy,
+          targetUserId: userId,
+          action: 'role_revoked',
+          beforeState: { roleIds: [roleId] },
+          afterState: { roleIds: [] },
+        }),
+      );
+    });
+
+    it('should not write an audit entry when revoking a role the user does not hold (no-op, issue #820)', async () => {
+      const userId = 'user1';
+      const roleId = 'role-not-held';
+      const revokedBy = 'admin1';
+
+      mockUserRoleRepository.findOne.mockResolvedValue(null);
+      // Clear call history accumulated by earlier tests in this suite (no global
+      // mock-reset config) so this assertion reflects only this scenario.
+      mockPermissionAuditService.log.mockClear();
+
+      await expect(
+        service.revokeRoleFromUser(userId, roleId, revokedBy),
+      ).rejects.toThrow('Role assignment not found');
+
+      expect(mockPermissionAuditService.log).not.toHaveBeenCalled();
     });
   });
 

--- a/src/authorization/rbac.service.ts
+++ b/src/authorization/rbac.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { Role } from './entities/role.entity';
 import { Permission } from './entities/permission.entity';
-import { UserRole } from './entities/user-role.entity';
+import { UserRole, AssignmentStatus } from './entities/user-role.entity';
 import { ApprovalWorkflow, ApprovalRequest, ApprovalAction, WorkflowType, ApprovalStatus } from './entities/approval-workflow.entity';
 import { PermissionChecker } from './utils/permission-checker';
 import { PolicyEvaluator } from './utils/policy-evaluator';
@@ -237,6 +237,9 @@ export class RbacService {
       throw new NotFoundException('Role not found');
     }
 
+    // Capture the user's active role set before the change for diffing (issue #820)
+    const beforeRoleIds = await this.getActiveRoleIds(userId);
+
     const userRole = this.userRoleRepository.create({
       userId,
       roleId,
@@ -247,13 +250,20 @@ export class RbacService {
     });
 
     const saved = await this.userRoleRepository.save(userRole);
-    await this.permissionAuditService.log({
-      actorId: assignedBy,
-      targetUserId: userId,
-      action: AuditAction.ROLE_ASSIGNED,
-      resourceName: role.name,
-      metadata: { roleId, teamId: options?.teamId, organizationId: options?.organizationId },
-    });
+
+    const afterRoleIds = await this.getActiveRoleIds(userId);
+    const diff = diffObjects({ roleIds: beforeRoleIds }, { roleIds: afterRoleIds });
+    if (diff) {
+      await this.permissionAuditService.log({
+        actorId: assignedBy,
+        targetUserId: userId,
+        action: AuditAction.ROLE_ASSIGNED,
+        resourceName: role.name,
+        beforeState: diff.before,
+        afterState: diff.after,
+        metadata: { roleId, teamId: options?.teamId, organizationId: options?.organizationId },
+      });
+    }
     return saved;
   }
 
@@ -266,17 +276,38 @@ export class RbacService {
       throw new NotFoundException('Role assignment not found');
     }
 
+    // Capture the user's active role set before the change for diffing (issue #820)
+    const beforeRoleIds = await this.getActiveRoleIds(userId);
+
     userRole.status = 'revoked' as any;
     await this.userRoleRepository.save(userRole);
 
+    const afterRoleIds = await this.getActiveRoleIds(userId);
     const role = await this.roleRepository.findOne({ where: { id: roleId } });
-    await this.permissionAuditService.log({
-      actorId: revokedBy ?? 'system',
-      targetUserId: userId,
-      action: AuditAction.ROLE_REVOKED,
-      resourceName: role?.name ?? roleId,
-      metadata: { roleId },
+
+    const diff = diffObjects({ roleIds: beforeRoleIds }, { roleIds: afterRoleIds });
+    if (diff) {
+      await this.permissionAuditService.log({
+        actorId: revokedBy ?? 'system',
+        targetUserId: userId,
+        action: AuditAction.ROLE_REVOKED,
+        resourceName: role?.name ?? roleId,
+        beforeState: diff.before,
+        afterState: diff.after,
+        metadata: { roleId },
+      });
+    }
+  }
+
+  /**
+   * Returns the sorted list of role IDs currently active for a user.
+   * Used to diff role-set changes for audit logging (issue #820).
+   */
+  private async getActiveRoleIds(userId: string): Promise<string[]> {
+    const activeAssignments = await this.userRoleRepository.find({
+      where: { userId, status: AssignmentStatus.ACTIVE },
     });
+    return activeAssignments.map((ur) => ur.roleId).sort();
   }
 
   async getUserRoles(userId: string): Promise<UserRole[]> {


### PR DESCRIPTION
## Summary
PR #831 added before/after audit diffing for role/permission *definition* edits (`updateRole`, `assignPermissionsToRole`) via `PermissionAuditService`/`diffObjects`, but the direct user-role assignment path — `assignRoleToUser` and `revokeRoleFromUser` in `rbac.service.ts`, i.e. an admin actually granting/removing a role from another user — never captured a diff. This PR fills that gap using the exact same diffing pattern already established in the codebase.

## Context / before-after
**Before:** `assignRoleToUser` and `revokeRoleFromUser` always wrote a `PermissionAuditLog` row with only `metadata: { roleId, ... }` — no before/after state, and an entry was written unconditionally even when nothing meaningfully changed.

**After:** both methods snapshot the target user's active role IDs (sorted) before and after the operation, diff them with the existing `diffObjects()` helper, and only call `permissionAuditService.log(...)` — populating `beforeState`/`afterState` — when the active role set actually changed. This mirrors `updateRole`/`assignPermissionsToRole` exactly. Audit rows continue to flow through the same immutable `PermissionAuditLog` entity and the existing read-only `GET /admin/audit/permissions`, `GET /admin/audit/permissions/users/:userId`, and `GET /admin/audit/permissions/actors/:actorId` endpoints — no new endpoints, no update/delete surface added.

Revoking a role the user doesn't hold still throws `NotFoundException` before any audit write, so it produces no audit entry, satisfying the no-op requirement.

## Testing
Added unit tests in `src/authorization/rbac.service.spec.ts` (mocked repositories, no DB):
- Single role added → audit entry with `beforeState`/`afterState` diff reflecting the added role ID.
- Single role revoked → audit entry with `beforeState`/`afterState` diff reflecting the removed role ID.
- Revoke of a role the user doesn't hold → no audit entry written (asserted via `not.toHaveBeenCalled()`).

Dependencies were not installed in this environment (per task constraints), so these tests were **written but not executed** — no `npm install`, no test runner was run. Existing `assignRoleToUser` test was updated to stub the new `find()` calls used for the before/after snapshot so it stays internally consistent with the new logic.

Closes #820