### PR TITLE
fix: make refresh token cleanup job safe, batched, and configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,10 @@ CRON_BACKUP_MONTHLY=0 2 1 * *
 CRON_BACKUP_CLEANUP=0 3 * * *
 CRON_POSITION_ARCHIVE=0 3 * * *
 
+# Expired refresh token cleanup job
+REFRESH_TOKEN_CLEANUP_CRON=0 3 * * *
+REFRESH_TOKEN_CLEANUP_BATCH_SIZE=500
+
 # Email
 EMAIL_PROVIDER=sendgrid
 SENDGRID_API_KEY=your_sendgrid_api_key

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -27,6 +27,7 @@ import { EmailModule } from '../email/email.module';
 import { AnomalousLoginListener } from './session/anomalous-login.listener';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { RefreshTokenCleanupService } from './refresh-token-cleanup.service';
+import { DistributedLockService } from '../common/services/distributed-lock.service';
 
 @Module({
   imports: [
@@ -61,6 +62,7 @@ import { RefreshTokenCleanupService } from './refresh-token-cleanup.service';
     SessionFingerprintService,
     AnomalousLoginListener,
     RefreshTokenCleanupService,
+    DistributedLockService,
   ],
   exports: [
     AuthService,

--- a/src/auth/refresh-token-cleanup.service.spec.ts
+++ b/src/auth/refresh-token-cleanup.service.spec.ts
@@ -3,13 +3,24 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { RefreshTokenCleanupService } from './refresh-token-cleanup.service';
 import { RefreshToken } from './entities/refresh-token.entity';
+import { DistributedLockService } from '../common/services/distributed-lock.service';
+
+function makeSelectQb(ids: string[]) {
+  const qb: any = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(ids.map((id) => ({ id }))),
+  };
+  return qb;
+}
 
 function makeDeleteQb(affected: number) {
   const qb: any = {
     delete: jest.fn().mockReturnThis(),
     from: jest.fn().mockReturnThis(),
-    where: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockReturnThis(),
+    whereInIds: jest.fn().mockReturnThis(),
     execute: jest.fn().mockResolvedValue({ affected }),
   };
   return qb;
@@ -19,6 +30,7 @@ describe('RefreshTokenCleanupService', () => {
   let service: RefreshTokenCleanupService;
   let qbFactory: jest.Mock;
   let countMock: jest.Mock;
+  let distributedLock: DistributedLockService;
 
   beforeEach(async () => {
     qbFactory = jest.fn();
@@ -38,52 +50,114 @@ describe('RefreshTokenCleanupService', () => {
           provide: ConfigService,
           useValue: {
             get: jest.fn((key: string, def?: any) =>
-              key === 'REFRESH_TOKEN_CLEANUP_BATCH_SIZE' ? 500 : def,
+              key === 'REFRESH_TOKEN_CLEANUP_BATCH_SIZE' ? 5 : def,
             ),
+          },
+        },
+        {
+          provide: DistributedLockService,
+          useValue: {
+            withLock: jest.fn(async (_key: string, _ttl: number, fn: () => Promise<any>) => ({
+              ran: true,
+              result: await fn(),
+            })),
           },
         },
       ],
     }).compile();
 
     service = module.get(RefreshTokenCleanupService);
+    distributedLock = module.get(DistributedLockService);
   });
 
   describe('deleteExpiredTokens', () => {
     it('deletes expired tokens in a single batch when fewer than batch size', async () => {
-      const qb = makeDeleteQb(10);
-      qbFactory.mockReturnValueOnce(qb).mockReturnValueOnce(makeDeleteQb(0));
+      const selectQb = makeSelectQb(['id-1', 'id-2']);
+      const deleteQb = makeDeleteQb(2);
+      qbFactory.mockReturnValueOnce(selectQb).mockReturnValueOnce(deleteQb);
 
-      await service.deleteExpiredTokens();
+      const total = await service.deleteExpiredTokens();
 
-      expect(qb.execute).toHaveBeenCalled();
+      expect(selectQb.getRawMany).toHaveBeenCalled();
+      expect(deleteQb.whereInIds).toHaveBeenCalledWith(['id-1', 'id-2']);
+      expect(deleteQb.execute).toHaveBeenCalled();
+      expect(total).toBe(2);
     });
 
-    it('loops until batch returns 0 rows (batch boundary)', async () => {
-      const fullBatch = makeDeleteQb(500);
-      const partialBatch = makeDeleteQb(200);
-      const emptyBatch = makeDeleteQb(0);
+    it('loops across batch boundaries until fewer ids than batch size are found', async () => {
+      // batch size is mocked to 5
+      const fullSelect = makeSelectQb(['a', 'b', 'c', 'd', 'e']);
+      const fullDelete = makeDeleteQb(5);
+      const partialSelect = makeSelectQb(['f', 'g']);
+      const partialDelete = makeDeleteQb(2);
 
       qbFactory
-        .mockReturnValueOnce(fullBatch)
-        .mockReturnValueOnce(partialBatch)
-        .mockReturnValueOnce(emptyBatch);
+        .mockReturnValueOnce(fullSelect)
+        .mockReturnValueOnce(fullDelete)
+        .mockReturnValueOnce(partialSelect)
+        .mockReturnValueOnce(partialDelete);
+
+      const total = await service.deleteExpiredTokens();
+
+      expect(fullDelete.execute).toHaveBeenCalledTimes(1);
+      expect(partialDelete.execute).toHaveBeenCalledTimes(1);
+      expect(total).toBe(7);
+    });
+
+    it('stops immediately and returns 0 when no expired tokens exist', async () => {
+      const emptySelect = makeSelectQb([]);
+      qbFactory.mockReturnValueOnce(emptySelect);
+
+      const total = await service.deleteExpiredTokens();
+
+      expect(total).toBe(0);
+      expect(qbFactory).toHaveBeenCalledTimes(1);
+    });
+
+    it('never selects or deletes rows that are not yet expired (only expiresAt < now is queried)', async () => {
+      const selectQb = makeSelectQb([]);
+      qbFactory.mockReturnValueOnce(selectQb);
 
       await service.deleteExpiredTokens();
 
-      expect(fullBatch.execute).toHaveBeenCalledTimes(1);
-      expect(partialBatch.execute).toHaveBeenCalledTimes(1);
+      expect(selectQb.where).toHaveBeenCalledWith('rt.expiresAt < :now', {
+        now: expect.any(Date),
+      });
     });
 
-    it('does not throw when repository throws — logs the error', async () => {
+    it('does not throw when the repository throws — logs and returns partial progress', async () => {
       qbFactory.mockReturnValueOnce({
-        delete: jest.fn().mockReturnThis(),
-        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
-        execute: jest.fn().mockRejectedValue(new Error('DB error')),
+        getRawMany: jest.fn().mockRejectedValue(new Error('DB error')),
       });
 
-      await expect(service.deleteExpiredTokens()).resolves.toBeUndefined();
+      await expect(service.deleteExpiredTokens()).resolves.toBe(0);
+    });
+  });
+
+  describe('handleCron', () => {
+    it('runs the cleanup under a distributed lock', async () => {
+      const emptySelect = makeSelectQb([]);
+      qbFactory.mockReturnValueOnce(emptySelect);
+
+      await service.handleCron();
+
+      expect(distributedLock.withLock).toHaveBeenCalledWith(
+        'refresh-token-cleanup',
+        expect.any(Number),
+        expect.any(Function),
+      );
+    });
+
+    it('skips cleanup entirely when another replica already holds the lock', async () => {
+      (distributedLock.withLock as jest.Mock).mockResolvedValueOnce({ ran: false });
+
+      await service.handleCron();
+
+      expect(qbFactory).not.toHaveBeenCalled();
     });
   });
 

--- a/src/auth/refresh-token-cleanup.service.ts
+++ b/src/auth/refresh-token-cleanup.service.ts
@@ -4,8 +4,11 @@ import { Repository, LessThan } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { RefreshToken } from './entities/refresh-token.entity';
+import { DistributedLockService } from '../common/services/distributed-lock.service';
 
 const DEFAULT_BATCH_SIZE = 500;
+const LOCK_KEY = 'refresh-token-cleanup';
+const LOCK_TTL_MS = 10 * 60 * 1000; // 10 min — generous ceiling for large batched deletes
 
 @Injectable()
 export class RefreshTokenCleanupService {
@@ -16,6 +19,7 @@ export class RefreshTokenCleanupService {
     @InjectRepository(RefreshToken)
     private readonly refreshTokenRepository: Repository<RefreshToken>,
     private readonly configService: ConfigService,
+    private readonly distributedLock: DistributedLockService,
   ) {
     this.batchSize = this.configService.get<number>(
       'REFRESH_TOKEN_CLEANUP_BATCH_SIZE',
@@ -24,41 +28,84 @@ export class RefreshTokenCleanupService {
   }
 
   /**
-   * Scheduled cleanup of expired refresh tokens.
-   * Runs at 3 AM daily. Processes in batches to avoid long-running locks.
-   * Safe to run concurrently across replicas — DELETE WHERE expiresAt < now is idempotent.
+   * Scheduled entry point. Interval is configurable via the
+   * REFRESH_TOKEN_CLEANUP_CRON env var (falls back to 3 AM daily) so ops can
+   * retune frequency without a code change/redeploy.
+   *
+   * A distributed lock ensures only one replica performs the sweep per tick.
+   * The delete itself is also idempotent (WHERE expires_at < now), so even if
+   * the lock is lost mid-run (e.g. TTL expiry) or skipped, concurrent
+   * execution cannot double-delete or error — it simply finds fewer/no rows.
    */
-  @Cron(CronExpression.EVERY_DAY_AT_3AM)
-  async deleteExpiredTokens(): Promise<void> {
+  @Cron(process.env.REFRESH_TOKEN_CLEANUP_CRON ?? CronExpression.EVERY_DAY_AT_3AM)
+  async handleCron(): Promise<void> {
+    const { ran } = await this.distributedLock.withLock(LOCK_KEY, LOCK_TTL_MS, () =>
+      this.deleteExpiredTokens(),
+    );
+    if (!ran) {
+      this.logger.debug('Skipping refresh token cleanup — another replica is running it');
+    }
+  }
+
+  /**
+   * Deletes expired refresh tokens in batches to avoid long-running locks on
+   * large tables. Never touches rows whose expiry is in the future.
+   *
+   * Public (not private) so tests and manual/admin triggers can invoke the
+   * deletion logic directly without going through the cron + lock wrapper.
+   */
+  async deleteExpiredTokens(): Promise<number> {
     this.logger.log('Starting expired refresh token cleanup');
     const now = new Date();
     let totalDeleted = 0;
 
     try {
-      let batchDeleted: number;
+      let fetchedCount: number;
+
       do {
+        // TypeORM's DELETE query builder does not support LIMIT/OFFSET on all
+        // drivers (notably Postgres, which this project uses), so a raw
+        // `.delete().limit()` chain would throw at runtime. Instead we page
+        // through expired ids with a SELECT ... LIMIT, then delete exactly
+        // that batch by id. This keeps each statement small and stays
+        // idempotent — a replica that loses the race simply finds nothing
+        // left to select for the ids it already deleted.
+        const expiredIds = await this.refreshTokenRepository
+          .createQueryBuilder('rt')
+          .select('rt.id', 'id')
+          .where('rt.expiresAt < :now', { now })
+          .orderBy('rt.expiresAt', 'ASC')
+          .limit(this.batchSize)
+          .getRawMany<{ id: string }>();
+
+        fetchedCount = expiredIds.length;
+        if (fetchedCount === 0) {
+          break;
+        }
+
         const result = await this.refreshTokenRepository
           .createQueryBuilder()
           .delete()
           .from(RefreshToken)
-          .where('expires_at < :now', { now })
-          .limit(this.batchSize)
+          .whereInIds(expiredIds.map((row) => row.id))
           .execute();
 
-        batchDeleted = result.affected ?? 0;
+        const batchDeleted = result.affected ?? 0;
         totalDeleted += batchDeleted;
 
         if (batchDeleted > 0) {
           this.logger.log(`Deleted batch of ${batchDeleted} expired refresh tokens`);
         }
-      } while (batchDeleted === this.batchSize);
+      } while (fetchedCount === this.batchSize);
 
       this.logger.log(`Refresh token cleanup complete. Total deleted: ${totalDeleted}`);
+      return totalDeleted;
     } catch (error) {
       this.logger.error(
         `Refresh token cleanup failed after deleting ${totalDeleted} rows`,
         (error as Error).message,
       );
+      return totalDeleted;
     }
   }
 
@@ -74,7 +121,7 @@ export class RefreshTokenCleanupService {
   async countActive(): Promise<number> {
     return this.refreshTokenRepository
       .createQueryBuilder('rt')
-      .where('rt.expires_at >= :now', { now: new Date() })
+      .where('rt.expiresAt >= :now', { now: new Date() })
       .getCount();
   }
 }

--- a/test/integration/refresh-token-cleanup.integration.spec.ts
+++ b/test/integration/refresh-token-cleanup.integration.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * RefreshTokenCleanupService integration test — Testcontainers edition.
+ *
+ * Spins up isolated Postgres and Redis containers (same helper used by the
+ * RiskGate integration suite) so the cleanup job is exercised against real
+ * infrastructure: a real `refresh_tokens` table and a real distributed lock
+ * backed by Redis.
+ *
+ * When Docker is unavailable (e.g. a sandboxed CI runner) every test returns
+ * early so the suite stays green without false positives.
+ *
+ * Issue #821 acceptance criteria addressed here:
+ *  - Expired refresh tokens are deleted.
+ *  - Active (non-expired) tokens are never touched.
+ *  - Deletions are batched (verified against a batch size smaller than the
+ *    seeded row count).
+ *  - Row-count is returned/logged for observability.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RefreshTokenCleanupService } from '../../src/auth/refresh-token-cleanup.service';
+import { RefreshToken } from '../../src/auth/entities/refresh-token.entity';
+import { DistributedLockService } from '../../src/common/services/distributed-lock.service';
+import {
+  startContainers,
+  stopContainers,
+  isDockerAvailable,
+  ContainerHandles,
+} from '../helpers/testcontainers';
+
+jest.setTimeout(120_000);
+
+describe('RefreshTokenCleanupService (Testcontainers integration)', () => {
+  let containers: Partial<ContainerHandles> | undefined;
+  let module: TestingModule | undefined;
+  let service: RefreshTokenCleanupService | undefined;
+  let repository: Repository<RefreshToken> | undefined;
+  let dockerAvailable = false;
+
+  beforeAll(async () => {
+    dockerAvailable = await isDockerAvailable();
+    if (!dockerAvailable) return;
+
+    containers = await startContainers();
+
+    // process.env.REFRESH_TOKEN_CLEANUP_BATCH_SIZE is read at construction
+    // time by the service; set it small so we can prove batching works
+    // against a handful of rows instead of needing thousands.
+    process.env.REFRESH_TOKEN_CLEANUP_BATCH_SIZE = '2';
+
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: process.env.TEST_DATABASE_HOST,
+          port: parseInt(process.env.TEST_DATABASE_PORT as string, 10),
+          username: process.env.TEST_DATABASE_USER,
+          password: process.env.TEST_DATABASE_PASSWORD,
+          database: process.env.TEST_DATABASE_NAME,
+          entities: [RefreshToken],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([RefreshToken]),
+      ],
+      providers: [RefreshTokenCleanupService, DistributedLockService],
+    }).compile();
+
+    service = module.get(RefreshTokenCleanupService);
+    repository = module.get(getRepositoryToken(RefreshToken));
+  });
+
+  afterAll(async () => {
+    delete process.env.REFRESH_TOKEN_CLEANUP_BATCH_SIZE;
+    await module?.close();
+    await stopContainers(containers);
+  });
+
+  afterEach(async () => {
+    if (!hasDocker()) return;
+    await repository!.clear();
+  });
+
+  function hasDocker(): boolean {
+    return dockerAvailable && !!service && !!repository;
+  }
+
+  function makeToken(overrides: Partial<RefreshToken> = {}): Partial<RefreshToken> {
+    return {
+      tokenHash: `hash-${Math.random().toString(36).slice(2)}`,
+      userId: '11111111-1111-1111-1111-111111111111',
+      sessionId: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000), // valid by default
+      ...overrides,
+    };
+  }
+
+  it('containers are reachable — Postgres is initialised', () => {
+    if (!hasDocker()) return;
+    expect((containers as ContainerHandles).dataSource.isInitialized).toBe(true);
+  });
+
+  it('deletes expired refresh tokens and retains active ones', async () => {
+    if (!hasDocker()) return;
+
+    const expired = await repository!.save(
+      repository!.create(
+        makeToken({ expiresAt: new Date(Date.now() - 60 * 60 * 1000) }),
+      ),
+    );
+    const active = await repository!.save(repository!.create(makeToken()));
+
+    const deletedCount = await service!.deleteExpiredTokens();
+
+    expect(deletedCount).toBe(1);
+    await expect(repository!.findOneBy({ id: expired.id })).resolves.toBeNull();
+    await expect(repository!.findOneBy({ id: active.id })).resolves.not.toBeNull();
+  });
+
+  it('never deletes a token whose expiry is in the future, even by a second', async () => {
+    if (!hasDocker()) return;
+
+    const almostExpired = await repository!.save(
+      repository!.create(makeToken({ expiresAt: new Date(Date.now() + 1000) })),
+    );
+
+    const deletedCount = await service!.deleteExpiredTokens();
+
+    expect(deletedCount).toBe(0);
+    await expect(repository!.findOneBy({ id: almostExpired.id })).resolves.not.toBeNull();
+  });
+
+  it('processes deletions in batches smaller than the total expired row count', async () => {
+    if (!hasDocker()) return;
+
+    // Batch size is configured to 2 (see beforeAll) — seed 5 expired rows to
+    // force multiple delete batches within a single invocation.
+    const expiredRows = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        repository!.save(
+          repository!.create(
+            makeToken({ expiresAt: new Date(Date.now() - 60 * 60 * 1000) }),
+          ),
+        ),
+      ),
+    );
+    const active = await repository!.save(repository!.create(makeToken()));
+
+    const deletedCount = await service!.deleteExpiredTokens();
+
+    expect(deletedCount).toBe(expiredRows.length);
+    const remaining = await repository!.count();
+    expect(remaining).toBe(1);
+    await expect(repository!.findOneBy({ id: active.id })).resolves.not.toBeNull();
+  });
+
+  it('is safe to run concurrently — two overlapping runs never error and never double-count beyond total rows', async () => {
+    if (!hasDocker()) return;
+
+    await Promise.all(
+      Array.from({ length: 4 }, () =>
+        repository!.save(
+          repository!.create(
+            makeToken({ expiresAt: new Date(Date.now() - 60 * 60 * 1000) }),
+          ),
+        ),
+      ),
+    );
+
+    const [firstRun, secondRun] = await Promise.all([
+      service!.deleteExpiredTokens(),
+      service!.deleteExpiredTokens(),
+    ]);
+
+    // Total rows actually deleted across both concurrent runs must equal
+    // exactly the number of expired rows seeded — no double-deletion, no
+    // errors thrown, no rows left behind.
+    expect(firstRun + secondRun).toBe(4);
+    await expect(repository!.count()).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
`RefreshTokenCleanupService` already existed on `main` but was broken: it called `.limit()` on a TypeORM DELETE query builder, which has no such method for the Postgres driver this project uses — the scheduled job would throw a `TypeError` on every tick instead of deleting anything. This PR reworks the batching to page through expired ids via `SELECT ... LIMIT` and delete each page by id, makes the cron interval configurable via env, and wraps execution in the repo's existing `DistributedLockService` so concurrent replicas don't race.

## Context / before-after behavior
- **Before**: `@Cron(CronExpression.EVERY_DAY_AT_3AM)` fired daily, but `deleteExpiredTokens()` would throw immediately (`.limit is not a function` on the delete query builder for Postgres), so expired refresh tokens never actually got cleaned up in practice. The interval was also hardcoded, and there was no cross-replica coordination.
- **After**: The job selects a page of expired token ids (`ORDER BY expires_at ASC LIMIT <batchSize>`) and deletes exactly that batch (`whereInIds`), looping until a page comes back smaller than the batch size. This is portable across drivers and stays idempotent — a replica that loses a race for a given id simply finds it already gone. The interval is read from `REFRESH_TOKEN_CLEANUP_CRON` (falls back to 3 AM daily), matching the existing `PortfolioSnapshotJob` env-driven cron convention. The whole run is wrapped in `DistributedLockService.withLock(...)` so only one replica executes per tick, on top of the idempotent delete. Non-expired tokens are never selected or touched. Start, per-batch, and total-deleted counts are logged.

## Testing
- Updated `src/auth/refresh-token-cleanup.service.spec.ts` (unit, mocked repository/lock) to cover: single-batch deletion, multi-batch looping across the batch-size boundary, no-op when nothing is expired, the query only ever targets `expiresAt < now`, error handling, and that `handleCron` runs under the distributed lock and skips entirely when another replica holds it.
- Added `test/integration/refresh-token-cleanup.integration.spec.ts`, a Testcontainers-backed integration test (same pattern as `test/integration/risk-gate.integration.spec.ts`) spinning up real Postgres + Redis containers to verify: expired tokens are deleted, active tokens are retained, deletions span multiple batches when the batch size is smaller than the row count, and two concurrent invocations never double-delete or error.
- Dependencies were **not** installed in this environment (per task constraints) and the test suite was **not executed** — these tests were written to match existing repo conventions and TypeORM's documented API but have not been run locally. Please run CI on this PR to confirm green.

Closes #821