### PR TITLE
Improve request validation across HTTP controllers

### DIFF
--- a/src/auth/session/dto/invalidate-session.dto.ts
+++ b/src/auth/session/dto/invalidate-session.dto.ts
@@ -18,6 +18,15 @@ export class InvalidateSessionDto {
   reason?: string;
 }
 
+export class AdminSessionActionDto {
+  @IsUUID()
+  adminId: string;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+
 export class InvalidateSessionResponseDto {
   invalidatedCount: number;
   sessionIds: string[];

--- a/src/auth/session/session.controller.ts
+++ b/src/auth/session/session.controller.ts
@@ -11,6 +11,7 @@ import { SessionInvalidationService } from './session-invalidation.service';
 import {
   InvalidateSessionDto,
   InvalidateSessionResponseDto,
+  AdminSessionActionDto,
 } from './dto/invalidate-session.dto';
 
 @Controller('auth/sessions')
@@ -30,7 +31,7 @@ export class SessionController {
   @HttpCode(200)
   invalidateBySessionId(
     @Param('sessionId') sessionId: string,
-    @Body() body: { adminId: string; reason?: string },
+    @Body() body: AdminSessionActionDto,
   ): Promise<InvalidateSessionResponseDto> {
     return this.sessionInvalidationService.invalidateBySessionId(
       sessionId,
@@ -43,7 +44,7 @@ export class SessionController {
   @HttpCode(200)
   invalidateByUserId(
     @Param('userId') userId: string,
-    @Body() body: { adminId: string; reason?: string },
+    @Body() body: AdminSessionActionDto,
   ): Promise<InvalidateSessionResponseDto> {
     return this.sessionInvalidationService.invalidateByUserId(
       userId,

--- a/src/authorization/dto/assign-role.dto.ts
+++ b/src/authorization/dto/assign-role.dto.ts
@@ -1,0 +1,17 @@
+import { IsDate, IsOptional, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class AssignRoleDto {
+  @IsUUID()
+  @IsOptional()
+  teamId?: string;
+
+  @IsUUID()
+  @IsOptional()
+  organizationId?: string;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  expiresAt?: Date;
+}

--- a/src/authorization/rbac.controller.ts
+++ b/src/authorization/rbac.controller.ts
@@ -22,6 +22,7 @@ import {
   RejectRequestDto,
   AccessRequestQueryDto,
 } from './dto/access-request.dto';
+import { AssignRoleDto } from './dto/assign-role.dto';
 import { RequirePermissions, RequireWorkflowApproval } from './decorators/require-permissions.decorator';
 import { PermissionsGuard } from './guards/permissions.guard';
 import { WorkflowApprovalGuard } from './guards/workflow-approval.guard';
@@ -86,7 +87,7 @@ export class RbacController {
   async assignRoleToUser(
     @Param('userId') userId: string,
     @Param('roleId') roleId: string,
-    @Body() body: { teamId?: string; organizationId?: string; expiresAt?: Date },
+    @Body() body: AssignRoleDto,
     @Request() req: any,
   ) {
     return this.rbacService.assignRoleToUser(userId, roleId, req.user.id, body);

--- a/src/compliance/compliance.controller.ts
+++ b/src/compliance/compliance.controller.ts
@@ -21,6 +21,7 @@ import { EvaluateTradeDto } from './rule-engine/dto/evaluate-trade.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ExportRequestDto } from './dto/export-request.dto';
 import { ComplianceReportDto } from './dto/compliance-report.dto';
+import { ScreenUserDto, ScreenWalletDto } from './dto/screen-user.dto';
 
 @Controller('compliance')
 @UseGuards(JwtAuthGuard)
@@ -88,13 +89,13 @@ export class ComplianceController {
   }
 
   @Post('screen-wallet')
-  async screenWallet(@Body('address') address: string) {
-    return this.sanctionsService.screenWalletAddress(address);
+  async screenWallet(@Body() dto: ScreenWalletDto) {
+    return this.sanctionsService.screenWalletAddress(dto.address);
   }
 
   @Post('screen-user')
   async screenUser(
-    @Body() data: { walletAddress?: string; email?: string; name?: string },
+    @Body() data: ScreenUserDto,
   ) {
     return this.sanctionsService.screenUser(data);
   }

--- a/src/compliance/dto/screen-user.dto.ts
+++ b/src/compliance/dto/screen-user.dto.ts
@@ -1,0 +1,21 @@
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class ScreenWalletDto {
+  @IsString()
+  @IsNotEmpty()
+  address: string;
+}
+
+export class ScreenUserDto {
+  @IsOptional()
+  @IsString()
+  walletAddress?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+}

--- a/src/nft/dto/create-collection.dto.ts
+++ b/src/nft/dto/create-collection.dto.ts
@@ -1,0 +1,22 @@
+import { IsInt, IsOptional, IsPositive, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateCollectionDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  name: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(20)
+  symbol: string;
+
+  @IsOptional()
+  @IsString()
+  contractId?: string;
+
+  @IsOptional()
+  @IsInt()
+  @IsPositive()
+  maxSupply?: number;
+}

--- a/src/nft/nft.controller.ts
+++ b/src/nft/nft.controller.ts
@@ -11,6 +11,7 @@ import {
 import { NftMinterService } from './nft-minter.service';
 import { MintNftDto } from './dto/mint-nft.dto';
 import { NftTransferDto } from './dto/nft-transfer.dto';
+import { CreateCollectionDto } from './dto/create-collection.dto';
 
 @Controller('nft')
 export class NftController {
@@ -22,7 +23,7 @@ export class NftController {
   }
 
   @Post('collections')
-  createCollection(@Body() body: { name: string; symbol: string; contractId?: string; maxSupply?: number }) {
+  createCollection(@Body() body: CreateCollectionDto) {
     return this.nftMinterService.createCollection(body);
   }
 

--- a/src/security/dto/security-alert.dto.ts
+++ b/src/security/dto/security-alert.dto.ts
@@ -8,6 +8,7 @@ import {
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AlertSeverity, AlertType } from '../entities/security-alert.entity';
+import { IncidentStatus } from '../entities/security-incident.entity';
 
 export class CreateSecurityAlertDto {
   @ApiProperty({ description: 'User ID associated with the alert' })
@@ -42,6 +43,21 @@ export class ResolveAlertDto {
   @IsOptional()
   @IsBoolean()
   falsePositive?: boolean;
+}
+
+export class UpdateIncidentStatusDto {
+  @ApiProperty({ enum: IncidentStatus, description: 'New incident status' })
+  @IsEnum(IncidentStatus)
+  status: IncidentStatus;
+
+  @ApiProperty({ description: 'ID of the actor performing the update' })
+  @IsUUID()
+  actorId: string;
+
+  @ApiPropertyOptional({ description: 'Optional note explaining the status change' })
+  @IsOptional()
+  @IsString()
+  note?: string;
 }
 
 export class SecurityAlertResponseDto {

--- a/src/security/security-dashboard.controller.ts
+++ b/src/security/security-dashboard.controller.ts
@@ -24,8 +24,8 @@ import {
   ResolveAlertDto,
   SecurityAlertQueryDto,
   SecurityDashboardDto,
+  UpdateIncidentStatusDto,
 } from './dto/security-alert.dto';
-import { IncidentStatus } from './entities/security-incident.entity';
 
 // Replace with your actual guards
 // import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -86,7 +86,7 @@ export class SecurityDashboardController {
   @ApiOperation({ summary: 'Update incident status' })
   async updateIncidentStatus(
     @Param('id', ParseUUIDPipe) incidentId: string,
-    @Body() body: { status: IncidentStatus; actorId: string; note?: string },
+    @Body() body: UpdateIncidentStatusDto,
   ) {
     return this.alertManager.updateIncidentStatus(
       incidentId,

--- a/src/stellar/services/dto/watch-accounts.dto.ts
+++ b/src/stellar/services/dto/watch-accounts.dto.ts
@@ -1,0 +1,19 @@
+import { ArrayMaxSize, ArrayMinSize, IsArray } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsStellarPublicKey } from '../../../common/decorators/is-stellar-address.decorator';
+
+export class WatchAccountsDto {
+  @ApiProperty({
+    description: 'Account public keys to watch',
+    type: [String],
+    example: ['GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU'],
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: 'publicKeys must contain at least one account' })
+  @ArrayMaxSize(100, { message: 'publicKeys must not contain more than 100 accounts' })
+  @IsStellarPublicKey({
+    each: true,
+    message: 'each entry in publicKeys must be a valid Stellar public key (56-char G... address)',
+  })
+  publicKeys: string[];
+}

--- a/src/stellar/services/horizon-stream.controller.ts
+++ b/src/stellar/services/horizon-stream.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Delete, Get, Body, Param, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { HorizonStreamService } from '../services/horizon-stream.service';
+import { WatchAccountsDto } from './dto/watch-accounts.dto';
 
 @ApiTags('Horizon Stream')
 @Controller('api/v1/horizon-stream')
@@ -45,7 +46,7 @@ export class HorizonStreamController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Start watching multiple accounts for events' })
   @ApiResponse({ status: 200, description: 'Accounts added to watch list' })
-  async watchMultipleAccounts(@Body() body: { publicKeys: string[] }) {
+  async watchMultipleAccounts(@Body() body: WatchAccountsDto) {
     const { publicKeys } = body;
     
     for (const publicKey of publicKeys) {

--- a/src/stellar/trustlines/dto/check-trustline.dto.ts
+++ b/src/stellar/trustlines/dto/check-trustline.dto.ts
@@ -1,0 +1,20 @@
+import { OmitType } from '@nestjs/swagger';
+import { CreateTrustlineDto } from './create-trustline.dto';
+
+/**
+ * Payload for pre-trade trustline checks — same account/asset shape as
+ * CreateTrustlineDto minus the secret key (no signing occurs) and limit.
+ */
+export class CheckTrustlineDto extends OmitType(CreateTrustlineDto, [
+  'secretKey',
+  'limit',
+] as const) {}
+
+/**
+ * Payload for auto-creating a trustline ahead of a trade. Same shape as
+ * CreateTrustlineDto minus the optional limit (auto-created trustlines use
+ * the maximum limit).
+ */
+export class AutoCreateTrustlineDto extends OmitType(CreateTrustlineDto, [
+  'limit',
+] as const) {}

--- a/src/stellar/trustlines/trustline.controller.spec.ts
+++ b/src/stellar/trustlines/trustline.controller.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ArgumentMetadata, BadRequestException, ValidationPipe } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { TrustlineController } from './trustline.controller';
+import { TrustlineService } from './trustline.service';
+import { CheckTrustlineDto, AutoCreateTrustlineDto } from './dto/check-trustline.dto';
+
+// Well-formed 56-char Stellar public/secret keys used across the existing
+// trustline test fixtures/examples in the codebase.
+const VALID_PUBLIC_KEY = 'GCLWGQPMKXQSPF776IU33AH4PZNOOWNAWGGKVTBQMIC5IMKUNP3E6NVU';
+const VALID_ISSUER_KEY = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+const VALID_SECRET_KEY = 'SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4';
+
+const mockTrustlineService = {
+  createTrustline: jest.fn(),
+  removeTrustline: jest.fn(),
+  getTrustlineStatus: jest.fn(),
+  checkTrustlineBeforeTrade: jest.fn().mockResolvedValue({
+    hasRequired: true,
+    needsCreation: false,
+  }),
+  autoCreateTrustlineForTrade: jest.fn().mockResolvedValue({
+    success: true,
+  }),
+};
+
+// Mirrors the global ValidationPipe configuration wired up in src/main.ts
+// (whitelist, forbidNonWhitelisted, transform) so this test exercises the
+// same rejection behavior real HTTP requests would hit.
+const globalPipeOptions = {
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+};
+
+describe('TrustlineController', () => {
+  let controller: TrustlineController;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TrustlineController],
+      providers: [{ provide: TrustlineService, useValue: mockTrustlineService }],
+    }).compile();
+
+    controller = module.get(TrustlineController);
+  });
+
+  describe('checkTrustlineBeforeTrade', () => {
+    const validBody: CheckTrustlineDto = {
+      publicKey: VALID_PUBLIC_KEY,
+      assetCode: 'USDC',
+      assetIssuer: VALID_ISSUER_KEY,
+    };
+
+    it('accepts a valid payload and delegates to the service', async () => {
+      const result = await controller.checkTrustlineBeforeTrade(validBody);
+      expect(result).toEqual({ hasRequired: true, needsCreation: false });
+      expect(mockTrustlineService.checkTrustlineBeforeTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a payload missing required fields with a structured 400 error', async () => {
+      const pipe = new ValidationPipe(globalPipeOptions);
+      const metadata: ArgumentMetadata = {
+        type: 'body',
+        metatype: CheckTrustlineDto,
+        data: '',
+      };
+
+      await expect(
+        pipe.transform({ publicKey: VALID_PUBLIC_KEY }, metadata),
+      ).rejects.toThrow(BadRequestException);
+
+      try {
+        await pipe.transform({ publicKey: VALID_PUBLIC_KEY }, metadata);
+        fail('expected ValidationPipe to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BadRequestException);
+        const response = err.getResponse();
+        expect(response.statusCode).toBe(400);
+        expect(Array.isArray(response.message)).toBe(true);
+        expect(response.message.length).toBeGreaterThan(0);
+        // assetCode and assetIssuer are required and were omitted above.
+        expect(response.message.join(' ')).toEqual(
+          expect.stringContaining('assetCode'),
+        );
+      }
+    });
+
+    it('rejects a payload with an invalid Stellar public key', async () => {
+      const dto = plainToInstance(CheckTrustlineDto, {
+        publicKey: 'not-a-valid-key',
+        assetCode: 'USDC',
+        assetIssuer: VALID_ISSUER_KEY,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.property === 'publicKey')).toBe(true);
+    });
+
+    it('rejects a payload containing unknown fields (forbidNonWhitelisted)', async () => {
+      const pipe = new ValidationPipe(globalPipeOptions);
+      const metadata: ArgumentMetadata = {
+        type: 'body',
+        metatype: CheckTrustlineDto,
+        data: '',
+      };
+
+      await expect(
+        pipe.transform(
+          { ...validBody, notAllowedField: 'oops' },
+          metadata,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('autoCreateTrustlineForTrade', () => {
+    const validBody: AutoCreateTrustlineDto = {
+      publicKey: VALID_PUBLIC_KEY,
+      secretKey: VALID_SECRET_KEY,
+      assetCode: 'USDC',
+      assetIssuer: VALID_ISSUER_KEY,
+    };
+
+    it('accepts a valid payload and delegates to the service', async () => {
+      const result = await controller.autoCreateTrustlineForTrade(validBody);
+      expect(result).toEqual({ success: true });
+      expect(mockTrustlineService.autoCreateTrustlineForTrade).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a malformed secret key with a structured 400 error', async () => {
+      const dto = plainToInstance(AutoCreateTrustlineDto, {
+        publicKey: VALID_PUBLIC_KEY,
+        secretKey: 'not-a-secret-key',
+        assetCode: 'USDC',
+        assetIssuer: VALID_ISSUER_KEY,
+      });
+
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.property === 'secretKey')).toBe(true);
+    });
+  });
+});

--- a/src/stellar/trustlines/trustline.controller.ts
+++ b/src/stellar/trustlines/trustline.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/
 import { TrustlineService } from './trustline.service';
 import { CreateTrustlineDto } from './dto/create-trustline.dto';
 import { TrustlineStatusDto } from './dto/trustline-status.dto';
+import { CheckTrustlineDto, AutoCreateTrustlineDto } from './dto/check-trustline.dto';
 
 @ApiTags('Trustlines')
 @Controller('api/v1/trustlines')
@@ -50,7 +51,7 @@ export class TrustlineController {
   @ApiOperation({ summary: 'Check if trustline exists before trade execution' })
   @ApiResponse({ status: 200, description: 'Trustline check completed' })
   async checkTrustlineBeforeTrade(
-    @Body() body: { publicKey: string; assetCode: string; assetIssuer: string }
+    @Body() body: CheckTrustlineDto
   ) {
     const { publicKey, assetCode, assetIssuer } = body;
     const asset = assetCode === 'XLM' 
@@ -66,7 +67,7 @@ export class TrustlineController {
   @ApiResponse({ status: 201, description: 'Trustline created or already exists' })
   @ApiResponse({ status: 400, description: 'Cannot create trustline' })
   async autoCreateTrustlineForTrade(
-    @Body() body: { publicKey: string; secretKey: string; assetCode: string; assetIssuer: string }
+    @Body() body: AutoCreateTrustlineDto
   ) {
     const { publicKey, secretKey, assetCode, assetIssuer } = body;
     const asset = assetCode === 'XLM' 


### PR DESCRIPTION
## Summary
Several controllers accepted request bodies typed as inline object literals or `Record<string, unknown>` instead of class-validator-decorated DTOs, so payloads reached services with no shape/type checking. This PR adds typed DTOs (with `class-validator`/`class-transformer` decorators) for the affected endpoints so they go through the app's global `ValidationPipe` like every other DTO-backed route.

## Context / before-after behavior
- **Global pipe**: `main.ts` already configures the global validation pipe (`I18nValidationPipe`) with `whitelist: true`, `forbidNonWhitelisted: true`, and `transform: true` — this was verified and required no change.
- **Before**: endpoints such as `POST /api/v1/trustlines/check-before-trade`, `POST /api/v1/horizon-stream/watch-multiple`, `POST /nft/collections`, `POST /auth/sessions/invalidate/session/:id` (and `/user/:id`), `PATCH /admin/security/incidents/:id/status`, `POST /authorization/users/:userId/roles/:roleId`, and `POST /compliance/screen-wallet` / `screen-user` accepted plain inline object types. Because there was no DTO class attached, the global `ValidationPipe` had nothing to validate against, so malformed/extra/missing fields passed straight through to the service layer.
- **After**: each endpoint now takes a typed DTO (e.g. `CheckTrustlineDto`, `AutoCreateTrustlineDto`, `WatchAccountsDto`, `CreateCollectionDto`, `AdminSessionActionDto`, `UpdateIncidentStatusDto`, `AssignRoleDto`, `ScreenUserDto`/`ScreenWalletDto`), reusing existing custom validators (e.g. `IsStellarPublicKey`) and following the `dto/` folder conventions already used elsewhere in the codebase (e.g. `OmitType` composition, as seen in `kyc`/`content` DTOs). Valid payloads continue to work exactly as before (additive/non-breaking); malformed payloads now get rejected with a `400` and a structured `message` array instead of silently reaching business logic. No business logic was changed — this is validation/typing only.

## Testing
- Added `src/stellar/trustlines/trustline.controller.spec.ts` covering the two newly-typed trustline endpoints:
  - valid payloads are accepted and delegate to the service as before,
  - payloads missing required fields, containing invalid Stellar keys, or containing extra/unwhitelisted fields are rejected via the same `ValidationPipe` options configured globally (`whitelist`, `forbidNonWhitelisted`, `transform`), returning a `400 BadRequestException` with a structured `message` array.
- **Note:** dependencies were not installed in this environment (per task constraints), so `npm install`/`jest` were **not run**. The test file was written to match the existing test conventions in this repo (see `src/common/pipes/validation.pipe.spec.ts`, `src/trades/trade-audit.controller.spec.ts`) but has not been executed — only written.

Closes #878