### PR TITLE
feat: centralize admin access control

### DIFF
--- a/src/admin/access-control/admin-access-policy.service.spec.ts
+++ b/src/admin/access-control/admin-access-policy.service.spec.ts
@@ -1,0 +1,74 @@
+import { ForbiddenException } from '@nestjs/common';
+import { AdminAccessPolicyService } from './admin-access-policy.service';
+
+describe('AdminAccessPolicyService', () => {
+  const repository = {
+    find: jest.fn(),
+  };
+
+  let service: AdminAccessPolicyService;
+
+  beforeEach(() => {
+    repository.find.mockReset();
+    service = new AdminAccessPolicyService(repository as any);
+  });
+
+  const assignment = (
+    roleName: string,
+    permissions: string[],
+    active = true,
+  ) => ({
+    isActive: () => active,
+    role: {
+      name: roleName,
+      permissions: permissions.map((name) => ({ name, isActive: true })),
+    },
+  });
+
+  it('allows an authenticated admin with the required read permission', async () => {
+    repository.find.mockResolvedValue([assignment('admin', ['admin:read'])]);
+
+    await expect(
+      service.assertCanAccessAdminRoute({ id: 'admin-1' }, 'GET'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows higher admin permissions for lower-risk methods', async () => {
+    repository.find.mockResolvedValue([assignment('super-admin', ['admin:admin'])]);
+
+    await expect(
+      service.assertCanAccessAdminRoute({ id: 'admin-1' }, 'DELETE'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('denies unauthenticated requests', async () => {
+    await expect(
+      service.assertCanAccessAdminRoute(undefined, 'GET'),
+    ).rejects.toThrow(ForbiddenException);
+    expect(repository.find).not.toHaveBeenCalled();
+  });
+
+  it('denies users without an active admin role', async () => {
+    repository.find.mockResolvedValue([assignment('trader', ['admin:read'])]);
+
+    await expect(
+      service.assertCanAccessAdminRoute({ id: 'user-1' }, 'GET'),
+    ).rejects.toThrow(/Administrative role required/);
+  });
+
+  it('denies admins missing the method-level permission', async () => {
+    repository.find.mockResolvedValue([assignment('admin', ['admin:read'])]);
+
+    await expect(
+      service.assertCanAccessAdminRoute({ id: 'admin-1' }, 'POST'),
+    ).rejects.toThrow(/admin:write/);
+  });
+
+  it('ignores expired or revoked role assignments', async () => {
+    repository.find.mockResolvedValue([assignment('admin', ['admin:admin'], false)]);
+
+    await expect(
+      service.assertCanAccessAdminRoute({ id: 'admin-1' }, 'GET'),
+    ).rejects.toThrow(/Administrative role required/);
+  });
+});

--- a/src/admin/access-control/admin-access-policy.service.ts
+++ b/src/admin/access-control/admin-access-policy.service.ts
@@ -1,0 +1,107 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  AssignmentStatus,
+  UserRole,
+} from '../../authorization/entities/user-role.entity';
+
+export type AdminPermissionAction = 'read' | 'write' | 'delete';
+
+export interface AdminPrincipal {
+  id?: string;
+  userId?: string;
+}
+
+@Injectable()
+export class AdminAccessPolicyService {
+  constructor(
+    @InjectRepository(UserRole)
+    private readonly userRoleRepository: Repository<UserRole>,
+  ) {}
+
+  async assertCanAccessAdminRoute(
+    principal: AdminPrincipal | undefined,
+    method: string,
+  ): Promise<void> {
+    const userId = principal?.id ?? principal?.userId;
+    if (!userId) {
+      throw new ForbiddenException('User authentication required for admin access');
+    }
+
+    const assignments = await this.userRoleRepository.find({
+      where: { userId, status: AssignmentStatus.ACTIVE },
+      relations: ['role', 'role.permissions'],
+    });
+
+    const activeAssignments = assignments.filter((assignment) =>
+      assignment.isActive(),
+    );
+    const hasAdminRole = activeAssignments.some((assignment) =>
+      this.isAdminRole(assignment.role?.name),
+    );
+
+    if (!hasAdminRole) {
+      throw new ForbiddenException('Administrative role required');
+    }
+
+    const requiredAction = this.requiredActionForMethod(method);
+    const permissionNames = activeAssignments.flatMap(
+      (assignment) =>
+        assignment.role?.permissions
+          ?.filter((permission) => permission.isActive !== false)
+          .map((permission) => permission.name) ?? [],
+    );
+
+    if (!this.hasAdminPermission(permissionNames, requiredAction)) {
+      throw new ForbiddenException(
+        `Admin permission required: admin:${requiredAction}`,
+      );
+    }
+  }
+
+  private isAdminRole(roleName: string | undefined): boolean {
+    if (!roleName) return false;
+    const normalized = roleName.toLowerCase().replace(/_/g, '-');
+    return normalized === 'admin' || normalized === 'super-admin';
+  }
+
+  private requiredActionForMethod(method: string): AdminPermissionAction {
+    switch (method.toUpperCase()) {
+      case 'GET':
+      case 'HEAD':
+      case 'OPTIONS':
+        return 'read';
+      case 'DELETE':
+        return 'delete';
+      default:
+        return 'write';
+    }
+  }
+
+  private hasAdminPermission(
+    permissionNames: string[],
+    requiredAction: AdminPermissionAction,
+  ): boolean {
+    const allowedPermissions = new Set([
+      '*',
+      '*:*',
+      'admin:*',
+      'admin:admin',
+      `admin:${requiredAction}`,
+    ]);
+
+    if (requiredAction === 'read') {
+      allowedPermissions.add('admin:write');
+      allowedPermissions.add('admin:delete');
+    }
+
+    if (requiredAction === 'write') {
+      allowedPermissions.add('admin:delete');
+    }
+
+    return permissionNames.some((permission) =>
+      allowedPermissions.has(permission.toLowerCase()),
+    );
+  }
+}

--- a/src/admin/access-control/admin-access.guard.ts
+++ b/src/admin/access-control/admin-access.guard.ts
@@ -1,0 +1,35 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
+import { AdminAccessPolicyService } from './admin-access-policy.service';
+
+@Injectable()
+export class AdminAccessGuard extends AuthGuard('jwt') {
+  constructor(private readonly adminPolicy: AdminAccessPolicyService) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    if (!this.isAdminPath(request)) {
+      return true;
+    }
+
+    const authenticated = await super.canActivate(context);
+    if (!authenticated) {
+      return false;
+    }
+
+    await this.adminPolicy.assertCanAccessAdminRoute(
+      (request as Request & { user?: { id?: string; userId?: string } }).user,
+      request.method,
+    );
+    return true;
+  }
+
+  private isAdminPath(request: Request): boolean {
+    const path = request.originalUrl || request.url || '';
+    const pathname = path.split('?')[0];
+    return /(^|\/)admin(\/|$)/.test(pathname);
+  }
+}

--- a/src/admin/admin-audit.controller.ts
+++ b/src/admin/admin-audit.controller.ts
@@ -1,11 +1,9 @@
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { PermissionAuditService, AuditAction } from '../auth/permission-audit.service';
-import { AdminRoleGuard } from './guards/admin-role.guard';
 
 @ApiTags('Admin Audit')
 @ApiBearerAuth()
-@UseGuards(AdminRoleGuard)
 @Controller('admin/audit/permissions')
 export class AdminAuditController {
   constructor(private readonly permissionAuditService: PermissionAuditService) {}

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -12,8 +12,6 @@ import { AuditAction } from '../audit-log/entities/audit-log.entity';
 // import { RolesGuard } from '../common/guards/roles.guard';
 // import { Roles } from '../common/decorators/roles.decorator';
 // import { UserRole } from '../users/enums/user-role.enum';
-// Using placeholders for auth guards based on usual NestJS conventions mapped in the project
-import { AdminRoleGuard } from './guards/admin-role.guard';
 import { TracingService } from '../tracing/tracing.service';
 import { PriorityQueueService } from '../queue/priority-queue.service';
 

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminController } from './admin.controller';
 import { AdminManagementService } from './admin.service';
@@ -10,6 +11,9 @@ import { AdminAnalyticsModule } from './analytics/admin-analytics.module';
 import { PermissionAuditService, PermissionAuditLog } from '../auth/permission-audit.service';
 import { TracingModule } from '../tracing/tracing.module';
 import { QueueModule } from '../queue/queue.module';
+import { UserRole } from '../authorization/entities/user-role.entity';
+import { AdminAccessGuard } from './access-control/admin-access.guard';
+import { AdminAccessPolicyService } from './access-control/admin-access-policy.service';
 
 @Module({
     imports: [
@@ -18,13 +22,22 @@ import { QueueModule } from '../queue/queue.module';
             Signal,
             AuditLog,
             PermissionAuditLog,
+            UserRole,
         ]),
         AdminAnalyticsModule,
         TracingModule,
         QueueModule,
     ],
     controllers: [AdminController, AdminAuditController],
-    providers: [AdminManagementService, PermissionAuditService],
+    providers: [
+        AdminManagementService,
+        PermissionAuditService,
+        AdminAccessPolicyService,
+        {
+            provide: APP_GUARD,
+            useClass: AdminAccessGuard,
+        },
+    ],
     exports: [AdminManagementService],
 })
 export class AdminModule { }


### PR DESCRIPTION
Closes #924

## Summary

- Added a centralized admin access policy service for admin role and method-level permission checks.
- Added a global admin path guard that authenticates JWTs and enforces the centralized policy for any URL containing an `admin` path segment.
- Replaced the stale per-controller admin audit guard with centralized enforcement.
- Added focused policy tests for allowed admin access and denied unauthenticated, non-admin, missing-permission, and inactive-assignment scenarios.

## Validation

- `git diff --check`

## Notes

Full Jest/Prettier execution was blocked locally because `node_modules` was not installed and `npm ci` timed out before installing Jest/TypeScript binaries.
