### PR TITLE
feat: validate runtime configuration schema

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,7 +18,8 @@ import { redisCacheConfig } from './config/redis.config';
 import { configuration } from './config/configuration';
 import { nplus1DetectionConfig } from './config/nplus1.config';
 import { queueRetryConfig } from './queue/queue-retry.config';
-import { configSchema } from './config/schemas/config.schema';
+import { validateEnvironment } from './config/schemas/config.schema';
+import { ConfigValidationService } from './config/config-validation.service';
 import { StellarConfigService } from './config/stellar.service';
 import { HorizonBulkheadModule } from './stellar/bulkhead/horizon-bulkhead.module';
 import { TenancyModule } from './tenancy/tenancy.module';
@@ -124,11 +125,7 @@ import { SearchModule } from './search/search.module';
       // eslint-disable-next-line no-restricted-syntax -- ConfigModule bootstrap runs before the DI container (and ConfigService) exist.
       envFilePath: [`.env.${process.env.NODE_ENV || 'development'}`, '.env'],
       cache: true,
-      validationSchema: configSchema,
-      validationOptions: {
-        allowUnknown: true,
-        abortEarly: false,
-      },
+      validate: validateEnvironment,
     }),
     BullModule.forRootAsync({
       imports: [ConfigModule],
@@ -184,7 +181,8 @@ import { SearchModule } from './search/search.module';
       useFactory: (configService: ConfigService) => ({
         type: 'postgres' as const,
         host: configService.get<string>('database.replica.host'),
-        port: configService.get<number>('database.replica.port'),n        username: configService.get<string>('database.replica.username'),
+        port: configService.get<number>('database.replica.port'),
+        username: configService.get<string>('database.replica.username'),
         password: configService.get<string>('database.replica.password'),
         database: configService.get<string>('database.replica.database'),
         synchronize: false,
@@ -298,7 +296,11 @@ import { SearchModule } from './search/search.module';
     TracingModule,
     TenancyModule,
   ],
-  providers: [StellarConfigService, RateLimitMiddleware],
+  providers: [
+    StellarConfigService,
+    RateLimitMiddleware,
+    ConfigValidationService,
+  ],
   exports: [StellarConfigService],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,39 +1,29 @@
 import { registerAs } from '@nestjs/config';
 import { AppConfig, SentryConfig } from './schemas/config.interface';
 
-export const appConfig = registerAs(
-  'app',
-  (): AppConfig => ({
-    port: parseInt(process.env.PORT || '3000', 10),
-    environment: (process.env.NODE_ENV || 'development') as
-      | 'development'
-      | 'testnet'
-      | 'mainnet',
-    host: process.env.HOST || '0.0.0.0',
-    apiPrefix: process.env.API_PREFIX || 'api',
-    apiVersion: process.env.API_VERSION || 'v1',
-    logLevel: process.env.LOG_LEVEL || 'debug',
-    logDirectory: process.env.LOG_DIRECTORY || './logs',
-    logMaxFiles: process.env.LOG_MAX_FILES || '14d',
-    logMaxSize: process.env.LOG_MAX_SIZE || '20m',
-    corsOrigin: (process.env.CORS_ALLOWED_ORIGINS || process.env.CORS_ORIGIN)?.split(',') || [
-      'http://localhost:3000',
-    ],
-    corsCredentials: process.env.CORS_CREDENTIALS !== 'false',
-    slippageToleranceBps: parseInt(
-      process.env.SLIPPAGE_TOLERANCE_BPS || '50',
-      10,
-    ),
-  }),
-);
+export const appConfig = registerAs('app', (): AppConfig => ({
+  port: parseInt(process.env.PORT || '3000', 10),
+  environment: (process.env.NODE_ENV || 'development') as
+    'development' | 'test' | 'testnet' | 'mainnet',
+  host: process.env.HOST || '0.0.0.0',
+  apiPrefix: process.env.API_PREFIX || 'api',
+  apiVersion: process.env.API_VERSION || 'v1',
+  logLevel: process.env.LOG_LEVEL || 'debug',
+  logDirectory: process.env.LOG_DIRECTORY || './logs',
+  logMaxFiles: process.env.LOG_MAX_FILES || '14d',
+  logMaxSize: process.env.LOG_MAX_SIZE || '20m',
+  corsOrigin: (
+    process.env.CORS_ALLOWED_ORIGINS || process.env.CORS_ORIGIN
+  )?.split(',') || ['http://localhost:3000'],
+  corsCredentials: process.env.CORS_CREDENTIALS !== 'false',
+  slippageToleranceBps: parseInt(
+    process.env.SLIPPAGE_TOLERANCE_BPS || '50',
+    10,
+  ),
+}));
 
-export const sentryConfig = registerAs(
-  'sentry',
-  (): SentryConfig => ({
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.NODE_ENV || 'development',
-    tracesSampleRate: parseFloat(
-      process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1',
-    ),
-  }),
-);
+export const sentryConfig = registerAs('sentry', (): SentryConfig => ({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV || 'development',
+  tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0.1'),
+}));

--- a/src/config/config-validation.service.ts
+++ b/src/config/config-validation.service.ts
@@ -1,11 +1,10 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { configSchema } from './schemas/config.schema';
+import { validateEnvironment } from './schemas/config.schema';
 
 /**
- * Validates all required environment variables at startup via the shared
- * Joi configSchema.  A missing or invalid variable aborts the process with
- * a human-readable message so misconfiguration is caught before any service
- * dependency is reached.
+ * Validates all required environment variables at startup with the shared typed
+ * schema. Missing or invalid values abort boot before downstream services are
+ * constructed with unsafe defaults.
  */
 @Injectable()
 export class ConfigValidationService implements OnModuleInit {
@@ -16,24 +15,15 @@ export class ConfigValidationService implements OnModuleInit {
   }
 
   validate(): void {
-    const { error } = configSchema.validate(process.env, {
-      allowUnknown: true,
-      abortEarly: false,
-    });
-
-    if (!error) {
+    try {
+      validateEnvironment(process.env);
       this.logger.log('Environment configuration validated successfully.');
-      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Application startup aborted - environment misconfiguration:\n${message}`,
+      );
+      throw error;
     }
-
-    const messages = error.details.map((d) => `  • ${d.message}`).join('\n');
-    this.logger.error(
-      `Application startup aborted – environment misconfiguration:\n${messages}`,
-    );
-    // Throw so NestJS bootstrap() rejects and the process exits with a
-    // non-zero code, making deployment failures immediately visible.
-    throw new Error(
-      `Missing or invalid environment variables:\n${messages}`,
-    );
   }
 }

--- a/src/config/schemas/config.interface.ts
+++ b/src/config/schemas/config.interface.ts
@@ -1,6 +1,6 @@
 export interface AppConfig {
   port: number;
-  environment: 'development' | 'testnet' | 'mainnet';
+  environment: 'development' | 'test' | 'testnet' | 'mainnet';
   host: string;
   apiPrefix: string;
   apiVersion: string;

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -1,109 +1,180 @@
 import * as Joi from 'joi';
 
-/**
- * Shared NestJS configuration schema (Joi).
- *
- * Convention:
- *   - .required()          → must be present; startup fails with a clear message if missing.
- *   - .default(value)      → optional; documented default used when variable is absent.
- *   - .optional().allow('') → genuinely optional; may be empty.
- *
- * Non-sensitive defaults are listed inline so developers can understand
- * the expected values without consulting external documentation.
- */
-export const configSchema = Joi.object({
-  // ─── Application ────────────────────────────────────────────────────────────
-  // Default: 'development' | Values: development | testnet | mainnet
-  NODE_ENV: Joi.string()
-    .valid('development', 'testnet', 'mainnet')
-    .default('development'),
-  // Default: 3000
-  PORT: Joi.number().integer().positive().default(3000),
-  // Default: '0.0.0.0'
-  HOST: Joi.string().default('0.0.0.0'),
-  // Default: 'api'
-  API_PREFIX: Joi.string().default('api'),
-  // Default: 'v1'
-  API_VERSION: Joi.string().default('v1'),
-  // Default: 50 (bps)
-  SLIPPAGE_TOLERANCE_BPS: Joi.number().integer().min(0).default(50),
+export type RuntimeEnvironment = 'development' | 'test' | 'testnet' | 'mainnet';
+export type StellarNetwork = 'testnet' | 'public';
+export type MaxCallDepthPolicy = 'reject' | 'warn';
 
-  // ─── Logging ────────────────────────────────────────────────────────────────
-  // Default: 'info' | Values: error | warn | info | http | verbose | debug | silly
+export interface ValidatedEnvironment {
+  NODE_ENV: RuntimeEnvironment;
+  PORT: number;
+  HOST: string;
+  API_PREFIX: string;
+  API_VERSION: string;
+  LOG_LEVEL: 'error' | 'warn' | 'info' | 'http' | 'verbose' | 'debug' | 'silly';
+  LOG_DIRECTORY: string;
+  LOG_MAX_FILES: string;
+  LOG_MAX_SIZE: string;
+  CORS_ORIGIN: string;
+  CORS_ALLOWED_ORIGINS?: string;
+  CORS_CREDENTIALS: boolean;
+  SLIPPAGE_TOLERANCE_BPS: number;
+  DATABASE_HOST: string;
+  DATABASE_PORT: number;
+  DATABASE_USER: string;
+  DATABASE_PASSWORD: string;
+  DATABASE_NAME: string;
+  DATABASE_LOGGING: boolean;
+  DATABASE_POOL_MIN: number;
+  DATABASE_POOL_MAX: number;
+  DATABASE_POOL_IDLE_TIMEOUT: number;
+  DATABASE_POOL_CONNECTION_TIMEOUT: number;
+  DATABASE_STATEMENT_TIMEOUT: number;
+  DATABASE_MAX_QUERY_TIME: number;
+  REDIS_HOST: string;
+  REDIS_PORT: number;
+  REDIS_DB: number;
+  REDIS_PASSWORD?: string;
+  STELLAR_NETWORK: StellarNetwork;
+  STELLAR_HORIZON_URL: string;
+  STELLAR_SOROBAN_RPC_URL: string;
+  STELLAR_NETWORK_PASSPHRASE: string;
+  STELLAR_API_TIMEOUT: number;
+  STELLAR_MAX_RETRIES: number;
+  STELLAR_MAX_CALL_DEPTH: number;
+  STELLAR_MAX_CALL_DEPTH_POLICY: MaxCallDepthPolicy;
+  STELLAR_HORIZON_READ_MAX_CONCURRENT: number;
+  STELLAR_HORIZON_READ_MAX_QUEUE: number;
+  STELLAR_HORIZON_WRITE_MAX_CONCURRENT: number;
+  STELLAR_HORIZON_WRITE_MAX_QUEUE: number;
+  JWT_SECRET: string;
+  JWT_EXPIRES_IN: string;
+  JWT_EXPIRATION?: string;
+  XAI_API_KEY: string;
+  XAI_MODEL: string;
+  SENTRY_DSN?: string;
+  SENTRY_ENVIRONMENT?: string;
+  SENTRY_TRACES_SAMPLE_RATE: number;
+  ENCRYPTION_KEY: string;
+  ENCRYPTION_KEY_PREVIOUS?: string;
+  NPLUS1_MAX_QUERIES: number;
+  NPLUS1_MAX_QUERY_TIME_MS: number;
+  NPLUS1_LOG_IN_PRODUCTION: boolean;
+  WEBHOOK_SIGNING_KEY?: string;
+  MPESA_WEBHOOK_SECRET?: string;
+  PAYSTACK_WEBHOOK_SECRET?: string;
+}
+
+export const configSchema = Joi.object<ValidatedEnvironment>({
+  NODE_ENV: Joi.string()
+    .valid('development', 'test', 'testnet', 'mainnet')
+    .default('development'),
+  PORT: Joi.number().integer().min(1).max(65535).default(3000),
+  HOST: Joi.string().hostname().default('0.0.0.0'),
+  API_PREFIX: Joi.string().trim().min(1).default('api'),
+  API_VERSION: Joi.string().trim().min(1).default('v1'),
   LOG_LEVEL: Joi.string()
     .valid('error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly')
     .default('info'),
-  // Default: './logs'
   LOG_DIRECTORY: Joi.string().default('./logs'),
-  // Default: '14d'  (14 days of log rotation)
   LOG_MAX_FILES: Joi.string().default('14d'),
-  // Default: '20m'  (20 MB per log file)
   LOG_MAX_SIZE: Joi.string().default('20m'),
-
-  // ─── CORS ───────────────────────────────────────────────────────────────────
-  // Default: 'http://localhost:3000'
   CORS_ORIGIN: Joi.string().default('http://localhost:3000'),
-  // Default: true
+  CORS_ALLOWED_ORIGINS: Joi.string().optional().allow(''),
   CORS_CREDENTIALS: Joi.boolean().default(true),
+  SLIPPAGE_TOLERANCE_BPS: Joi.number().integer().min(0).max(10000).default(50),
 
-  // ─── Database (PostgreSQL) — all required ───────────────────────────────────
   DATABASE_HOST: Joi.string().required(),
-  // Default: 5432
-  DATABASE_PORT: Joi.number().integer().positive().default(5432).required(),
+  DATABASE_PORT: Joi.number().integer().min(1).max(65535).default(5432),
   DATABASE_USER: Joi.string().required(),
   DATABASE_PASSWORD: Joi.string().required(),
   DATABASE_NAME: Joi.string().required(),
-  // Default: false  (never auto-sync schema in production)
   DATABASE_LOGGING: Joi.boolean().default(false),
+  DATABASE_POOL_MIN: Joi.number().integer().min(0).max(1000).default(10),
+  DATABASE_POOL_MAX: Joi.number()
+    .integer()
+    .min(Joi.ref('DATABASE_POOL_MIN'))
+    .max(1000)
+    .default(30),
+  DATABASE_POOL_IDLE_TIMEOUT: Joi.number().integer().min(1000).default(30000),
+  DATABASE_POOL_CONNECTION_TIMEOUT: Joi.number()
+    .integer()
+    .min(100)
+    .default(2000),
+  DATABASE_STATEMENT_TIMEOUT: Joi.number().integer().min(1000).default(100000),
+  DATABASE_MAX_QUERY_TIME: Joi.number().integer().min(1).default(10000),
 
-  // ─── Redis — required ───────────────────────────────────────────────────────
-  // Default: 'localhost'
-  REDIS_HOST: Joi.string().default('localhost').required(),
-  // Default: 6379
-  REDIS_PORT: Joi.number().integer().positive().default(6379).required(),
-  // Default: 0  (Redis DB index)
-  REDIS_DB: Joi.number().integer().min(0).default(0),
+  REDIS_HOST: Joi.string().default('localhost'),
+  REDIS_PORT: Joi.number().integer().min(1).max(65535).default(6379),
+  REDIS_DB: Joi.number().integer().min(0).max(15).default(0),
   REDIS_PASSWORD: Joi.string().optional().allow(''),
 
-  // ─── Stellar Network — required ────────────────────────────────────────────
-  // Default: 'testnet' | Values: testnet | public
-  STELLAR_NETWORK: Joi.string()
-    .valid('testnet', 'public')
-    .default('testnet')
-    .required(),
+  STELLAR_NETWORK: Joi.string().valid('testnet', 'public').default('testnet'),
   STELLAR_HORIZON_URL: Joi.string().uri().required(),
   STELLAR_SOROBAN_RPC_URL: Joi.string().uri().required(),
   STELLAR_NETWORK_PASSPHRASE: Joi.string().required(),
-  // Default: 30000 ms
-  STELLAR_API_TIMEOUT: Joi.number().integer().positive().default(30000),
-  // Default: 3 retries
-  STELLAR_MAX_RETRIES: Joi.number().integer().min(0).default(3),
+  STELLAR_API_TIMEOUT: Joi.number().integer().min(1000).default(30000),
+  STELLAR_MAX_RETRIES: Joi.number().integer().min(0).max(10).default(3),
+  STELLAR_MAX_CALL_DEPTH: Joi.number().integer().min(1).max(50).default(5),
+  STELLAR_MAX_CALL_DEPTH_POLICY: Joi.string()
+    .valid('reject', 'warn')
+    .default('reject'),
+  STELLAR_HORIZON_READ_MAX_CONCURRENT: Joi.number()
+    .integer()
+    .min(1)
+    .max(1000)
+    .default(20),
+  STELLAR_HORIZON_READ_MAX_QUEUE: Joi.number()
+    .integer()
+    .min(0)
+    .max(10000)
+    .default(100),
+  STELLAR_HORIZON_WRITE_MAX_CONCURRENT: Joi.number()
+    .integer()
+    .min(1)
+    .max(1000)
+    .default(5),
+  STELLAR_HORIZON_WRITE_MAX_QUEUE: Joi.number()
+    .integer()
+    .min(0)
+    .max(10000)
+    .default(25),
 
-  // ─── JWT — required ─────────────────────────────────────────────────────────
   JWT_SECRET: Joi.string().min(32).required(),
-  // Default: '7d'
   JWT_EXPIRES_IN: Joi.string().default('7d'),
+  JWT_EXPIRATION: Joi.string().optional().allow(''),
 
-  // ─── AI (xAI / Grok) — required ────────────────────────────────────────────
   XAI_API_KEY: Joi.string().required(),
-  // Default: 'grok-2-1212'
   XAI_MODEL: Joi.string().default('grok-2-1212'),
 
-  // ─── Sentry (optional) ─────────────────────────────────────────────────────
   SENTRY_DSN: Joi.string().uri().optional().allow(''),
   SENTRY_ENVIRONMENT: Joi.string().optional().allow(''),
-  // Default: 0.1  (10 % of transactions sampled)
   SENTRY_TRACES_SAMPLE_RATE: Joi.number().min(0).max(1).default(0.1),
 
-  // ─── Encryption — required ──────────────────────────────────────────────────
   ENCRYPTION_KEY: Joi.string().min(32).required(),
-  // Comma-separated list of retired keys, kept so ciphertext written before a
-  // rotation can still be decrypted. Optional — only set during/after a rotation.
   ENCRYPTION_KEY_PREVIOUS: Joi.string().optional().allow(''),
 
-  // ─── N+1 Detection (development mode only) ────────────────────────────────────
-  // Default: 25 queries
-  NPLUS1_MAX_QUERIES: Joi.number().integer().positive().default(25),
-  // Default: 1000 ms
-  NPLUS1_MAX_QUERY_TIME_MS: Joi.number().integer().positive().default(1000),
+  NPLUS1_MAX_QUERIES: Joi.number().integer().min(1).max(1000).default(25),
+  NPLUS1_MAX_QUERY_TIME_MS: Joi.number().integer().min(1).default(1000),
+  NPLUS1_LOG_IN_PRODUCTION: Joi.boolean().default(false),
+
+  WEBHOOK_SIGNING_KEY: Joi.string().min(32).optional().allow(''),
+  MPESA_WEBHOOK_SECRET: Joi.string().min(16).optional().allow(''),
+  PAYSTACK_WEBHOOK_SECRET: Joi.string().min(16).optional().allow(''),
 });
+
+export function validateEnvironment(
+  config: Record<string, unknown>,
+): ValidatedEnvironment {
+  const { error, value } = configSchema.validate(config, {
+    allowUnknown: true,
+    abortEarly: false,
+    convert: true,
+  });
+
+  if (error) {
+    const messages = error.details.map((detail) => detail.message).join('; ');
+    throw new Error(`Invalid application configuration: ${messages}`);
+  }
+
+  return value as ValidatedEnvironment;
+}

--- a/test/config-validation.service.spec.ts
+++ b/test/config-validation.service.spec.ts
@@ -1,6 +1,9 @@
-import { ConfigValidationService } from '../../src/config/config-validation.service';
+import { ConfigValidationService } from '../src/config/config-validation.service';
+import {
+  ValidatedEnvironment,
+  validateEnvironment,
+} from '../src/config/schemas/config.schema';
 
-/** Snapshot of the minimum valid environment. */
 const VALID_ENV: NodeJS.ProcessEnv = {
   NODE_ENV: 'development',
   PORT: '3000',
@@ -15,94 +18,101 @@ const VALID_ENV: NodeJS.ProcessEnv = {
   STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
   STELLAR_SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org:443',
   STELLAR_NETWORK_PASSPHRASE: 'Test SDF Network ; September 2015',
-  JWT_SECRET: 'a-very-secure-jwt-secret-at-least-32-chars!!',
+  JWT_SECRET: 'a-very-secure-jwt-secret-at-least-32-chars',
   XAI_API_KEY: 'xai-key',
-  ENCRYPTION_KEY: 'a-very-secure-encryption-key-32chars!',
+  ENCRYPTION_KEY: 'a-very-secure-encryption-key-32chars',
 };
 
-function makeService(overrides: NodeJS.ProcessEnv = {}): ConfigValidationService {
-  // Temporarily override process.env for the duration of validate()
+const withEnv = (env: NodeJS.ProcessEnv, callback: () => void) => {
   const original = { ...process.env };
-  Object.keys(process.env).forEach((k) => delete process.env[k]);
-  Object.assign(process.env, { ...VALID_ENV, ...overrides });
+  Object.keys(process.env).forEach((key) => delete process.env[key]);
+  Object.assign(process.env, env);
 
-  const svc = new ConfigValidationService();
   try {
-    return svc;
+    callback();
   } finally {
-    Object.keys(process.env).forEach((k) => delete process.env[k]);
+    Object.keys(process.env).forEach((key) => delete process.env[key]);
     Object.assign(process.env, original);
   }
-}
+};
 
-describe('ConfigValidationService – startup env validation (#Issue-2)', () => {
-  let savedEnv: NodeJS.ProcessEnv;
+describe('configuration schema validation (#923)', () => {
+  it('returns typed values and defaults for a valid environment', () => {
+    const validated = validateEnvironment(VALID_ENV);
 
-  beforeEach(() => {
-    savedEnv = { ...process.env };
-    // Clear env so we control exactly what is visible during each test
-    Object.keys(process.env).forEach((k) => delete process.env[k]);
+    expect(validated).toMatchObject<Partial<ValidatedEnvironment>>({
+      NODE_ENV: 'development',
+      PORT: 3000,
+      DATABASE_PORT: 5432,
+      REDIS_PORT: 6379,
+      STELLAR_NETWORK: 'testnet',
+      JWT_EXPIRES_IN: '7d',
+      DATABASE_POOL_MIN: 10,
+      DATABASE_POOL_MAX: 30,
+    });
   });
 
-  afterEach(() => {
-    Object.keys(process.env).forEach((k) => delete process.env[k]);
-    Object.assign(process.env, savedEnv);
+  it('allows the test runtime environment used by Nest test modules', () => {
+    expect(
+      validateEnvironment({ ...VALID_ENV, NODE_ENV: 'test' }).NODE_ENV,
+    ).toBe('test');
   });
 
-  it('passes when all required variables are present', () => {
-    Object.assign(process.env, VALID_ENV);
-    const svc = new ConfigValidationService();
-    expect(() => svc.validate()).not.toThrow();
-  });
-
-  it('fails with a clear message when DATABASE_HOST is missing', () => {
+  it('rejects missing required values', () => {
     const env = { ...VALID_ENV };
     delete env.DATABASE_HOST;
-    Object.assign(process.env, env);
-    const svc = new ConfigValidationService();
-    expect(() => svc.validate()).toThrow(/DATABASE_HOST/);
+
+    expect(() => validateEnvironment(env)).toThrow(/DATABASE_HOST/);
   });
 
-  it('fails with a clear message when JWT_SECRET is too short', () => {
-    Object.assign(process.env, { ...VALID_ENV, JWT_SECRET: 'short' });
-    const svc = new ConfigValidationService();
-    expect(() => svc.validate()).toThrow(/JWT_SECRET/);
+  it('rejects invalid enum values', () => {
+    expect(() =>
+      validateEnvironment({ ...VALID_ENV, STELLAR_NETWORK: 'devnet' }),
+    ).toThrow(/STELLAR_NETWORK/);
   });
 
-  it('fails with a clear message when STELLAR_HORIZON_URL is not a URI', () => {
-    Object.assign(process.env, { ...VALID_ENV, STELLAR_HORIZON_URL: 'not-a-url' });
-    const svc = new ConfigValidationService();
-    expect(() => svc.validate()).toThrow(/STELLAR_HORIZON_URL/);
+  it('rejects numeric values outside allowed ranges', () => {
+    expect(() => validateEnvironment({ ...VALID_ENV, PORT: '70000' })).toThrow(
+      /PORT/,
+    );
+    expect(() =>
+      validateEnvironment({
+        ...VALID_ENV,
+        DATABASE_POOL_MIN: '20',
+        DATABASE_POOL_MAX: '10',
+      }),
+    ).toThrow(/DATABASE_POOL_MAX/);
   });
 
-  it('fails when ENCRYPTION_KEY is under 32 characters', () => {
-    Object.assign(process.env, { ...VALID_ENV, ENCRYPTION_KEY: 'tooshort' });
-    const svc = new ConfigValidationService();
-    expect(() => svc.validate()).toThrow(/ENCRYPTION_KEY/);
-  });
-
-  it('reports all validation errors at once (abortEarly: false)', () => {
-    // Omit two required fields
-    const env = { ...VALID_ENV };
+  it('reports multiple validation errors at once', () => {
+    const env = {
+      ...VALID_ENV,
+      JWT_SECRET: 'short',
+      STELLAR_HORIZON_URL: 'not-a-url',
+    };
     delete env.DATABASE_HOST;
-    delete env.JWT_SECRET;
-    Object.assign(process.env, env);
-    const svc = new ConfigValidationService();
+
     let errorMessage = '';
     try {
-      svc.validate();
-    } catch (e: any) {
-      errorMessage = e.message;
+      validateEnvironment(env);
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error);
     }
+
     expect(errorMessage).toMatch(/DATABASE_HOST/);
     expect(errorMessage).toMatch(/JWT_SECRET/);
+    expect(errorMessage).toMatch(/STELLAR_HORIZON_URL/);
   });
 
-  it('onModuleInit delegates to validate', () => {
-    Object.assign(process.env, VALID_ENV);
-    const svc = new ConfigValidationService();
-    const spy = jest.spyOn(svc, 'validate');
-    svc.onModuleInit();
-    expect(spy).toHaveBeenCalledTimes(1);
+  it('startup validation succeeds for valid config and fails for invalid config', () => {
+    withEnv(VALID_ENV, () => {
+      const service = new ConfigValidationService();
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+
+    withEnv({ ...VALID_ENV, JWT_SECRET: 'short' }, () => {
+      const service = new ConfigValidationService();
+      expect(() => service.onModuleInit()).toThrow(/JWT_SECRET/);
+    });
   });
 });


### PR DESCRIPTION
Closes #923

## Summary

- Added a typed startup configuration validator around the shared Joi schema.
- Validates required values, runtime enums, ports, pool limits, timeout ranges, Stellar options, JWT/encryption secrets, and webhook signing config.
- Wired the typed validator into `ConfigModule.forRoot` and registered `ConfigValidationService` for explicit startup validation.
- Added focused tests for valid config, missing required values, invalid enums, numeric ranges, and startup success/failure.

## Validation

- `git diff --check`
- Direct runtime check of `validateEnvironment` for typed numeric conversion and combined invalid-config errors

## Notes

Full Jest/Prettier execution was blocked locally because `node_modules` was not installed and `npm ci` timed out before installing Jest/TypeScript binaries.
