### PR TITLE
feat: verify inbound webhook signatures

### DIFF
--- a/src/integrations/automation-platforms/automation.controller.spec.ts
+++ b/src/integrations/automation-platforms/automation.controller.spec.ts
@@ -1,0 +1,79 @@
+import * as crypto from 'crypto';
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { WebhookVerifierService } from '../webhooks/webhook-verifier.service';
+import { AutomationController } from './automation.controller';
+import { ActionType } from './dto/action-config.dto';
+import { TriggerEvent } from './dto/trigger-config.dto';
+
+describe('AutomationController webhook signatures', () => {
+  const secret = 'automation-webhook-secret-at-least-32-chars';
+  const zapier = { subscribe: jest.fn(), unsubscribe: jest.fn(), dispatch: jest.fn() };
+  const make = { subscribe: jest.fn(), unsubscribe: jest.fn(), dispatch: jest.fn() };
+  const signals = { create: jest.fn() };
+  const trades = { executeTrade: jest.fn() };
+  const portfolio = { getPerformance: jest.fn() };
+
+  let controller: AutomationController;
+
+  beforeEach(() => {
+    const verifier = new WebhookVerifierService({
+      get: jest.fn((key: string) => (key === 'WEBHOOK_SIGNING_KEY' ? secret : undefined)),
+    } as unknown as ConfigService);
+
+    controller = new AutomationController(
+      zapier as any,
+      make as any,
+      signals as any,
+      trades as any,
+      portfolio as any,
+      verifier,
+    );
+
+    jest.clearAllMocks();
+  });
+
+  it('rejects unsigned inbound action webhooks before executing actions', async () => {
+    await expect(
+      controller.handleAction(
+        { action: ActionType.GET_PORTFOLIO, userId: 'user-1' },
+        undefined as any,
+        { rawBody: Buffer.from('{}') } as any,
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+
+    expect(portfolio.getPerformance).not.toHaveBeenCalled();
+  });
+
+  it('accepts signed trigger dispatch webhooks', async () => {
+    const rawBody = Buffer.from(
+      '{"userId":"user-1","event":"trade_executed","data":{},"timestamp":"2026-07-29T00:00:00.000Z"}',
+    );
+    const signature =
+      'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+
+    await expect(
+      controller.dispatchTrigger(
+        {
+          userId: 'user-1',
+          event: TriggerEvent.TRADE_EXECUTED,
+          data: {},
+          timestamp: '2026-07-29T00:00:00.000Z',
+        },
+        signature,
+        { rawBody } as any,
+      ),
+    ).resolves.toEqual({ dispatched: true });
+
+    expect(zapier.dispatch).toHaveBeenCalledWith(
+      'user-1',
+      TriggerEvent.TRADE_EXECUTED,
+      {},
+    );
+    expect(make.dispatch).toHaveBeenCalledWith(
+      'user-1',
+      TriggerEvent.TRADE_EXECUTED,
+      {},
+    );
+  });
+});

--- a/src/integrations/automation-platforms/automation.controller.ts
+++ b/src/integrations/automation-platforms/automation.controller.ts
@@ -8,7 +8,11 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  Headers,
+  RawBodyRequest,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { ZapierService } from './zapier.service';
 import { MakeService } from './make.service';
 import { TriggerConfigDto } from './dto/trigger-config.dto';
@@ -24,6 +28,7 @@ import { executeTradeAction } from './actions/execute-trade.action';
 import { createSignalAction } from './actions/create-signal.action';
 import { getPortfolioAction } from './actions/get-portfolio.action';
 import { formatActionResponse } from './utils/payload-formatter';
+import { WebhookVerifierService } from '../webhooks/webhook-verifier.service';
 
 @Controller('api/v1/automation')
 export class AutomationController {
@@ -33,6 +38,7 @@ export class AutomationController {
     private readonly signalsService: SignalsService,
     private readonly tradesService: TradesService,
     private readonly portfolioService: PortfolioService,
+    private readonly webhookVerifier: WebhookVerifierService,
   ) {}
 
   @Get('triggers')
@@ -82,7 +88,17 @@ export class AutomationController {
   // --- Inbound action webhook (called by Zapier/Make to trigger actions) ---
 
   @Post('action')
-  async handleAction(@Body() dto: ActionConfigDto) {
+  async handleAction(
+    @Body() dto: ActionConfigDto,
+    @Headers('x-stellarswipe-signature') signature: string,
+    @Req() req: RawBodyRequest<Request>,
+  ) {
+    this.webhookVerifier.validateRequest({
+      rawBody: req.rawBody,
+      parsedBody: dto,
+      signatureHeader: signature,
+    });
+
     try {
       switch (dto.action) {
         case ActionType.GET_PORTFOLIO: {
@@ -118,7 +134,17 @@ export class AutomationController {
   // --- Inbound trigger webhook (for testing/manual dispatch) ---
 
   @Post('trigger/dispatch')
-  async dispatchTrigger(@Body() dto: WebhookPayloadDto) {
+  async dispatchTrigger(
+    @Body() dto: WebhookPayloadDto,
+    @Headers('x-stellarswipe-signature') signature: string,
+    @Req() req: RawBodyRequest<Request>,
+  ) {
+    this.webhookVerifier.validateRequest({
+      rawBody: req.rawBody,
+      parsedBody: dto,
+      signatureHeader: signature,
+    });
+
     await Promise.all([
       this.zapier.dispatch(dto.userId, dto.event, dto.data),
       this.make.dispatch(dto.userId, dto.event, dto.data),

--- a/src/integrations/automation-platforms/automation.module.ts
+++ b/src/integrations/automation-platforms/automation.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { HttpModule } from '@nestjs/axios';
 import { ZapierService } from './zapier.service';
 import { MakeService } from './make.service';
@@ -6,11 +7,12 @@ import { AutomationController } from './automation.controller';
 import { SignalsModule } from '../../signals/signals.module';
 import { TradesModule } from '../../trades/trades.module';
 import { PortfolioModule } from '../../portfolio/portfolio.module';
+import { WebhookVerifierService } from '../webhooks/webhook-verifier.service';
 
 @Module({
-  imports: [HttpModule, SignalsModule, TradesModule, PortfolioModule],
+  imports: [ConfigModule, HttpModule, SignalsModule, TradesModule, PortfolioModule],
   controllers: [AutomationController],
-  providers: [ZapierService, MakeService],
+  providers: [ZapierService, MakeService, WebhookVerifierService],
   exports: [ZapierService, MakeService],
 })
 export class AutomationModule {}

--- a/src/integrations/webhooks/utils/signature-validator.ts
+++ b/src/integrations/webhooks/utils/signature-validator.ts
@@ -1,12 +1,32 @@
 import * as crypto from 'crypto';
 
-export function verifyHmacSHA256(rawBody: string, signatureHeader: string, secret: string): boolean {
-  if (!signatureHeader || !secret) return false;
-  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
-  // header may be like "sha256=..." or raw hex
-  const received = signatureHeader.replace(/^sha256=/, '');
-  const rb = Buffer.from(received, 'hex');
-  const eb = Buffer.from(expected, 'hex');
-  if (rb.length !== eb.length) return false;
-  return crypto.timingSafeEqual(rb, eb);
+export type HmacAlgorithm = 'sha256' | 'sha512';
+
+export function verifyHmacSignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+  algorithm: HmacAlgorithm = 'sha256',
+): boolean {
+  if (!rawBody || !signatureHeader || !secret) return false;
+
+  const expected = crypto
+    .createHmac(algorithm, secret)
+    .update(rawBody)
+    .digest('hex');
+  const received = signatureHeader.replace(/^sha(256|512)=/, '');
+
+  if (!/^[a-f0-9]+$/i.test(received)) return false;
+
+  const receivedBuffer = Buffer.from(received, 'hex');
+  const expectedBuffer = Buffer.from(expected, 'hex');
+
+  if (receivedBuffer.length !== expectedBuffer.length) return false;
+  return crypto.timingSafeEqual(receivedBuffer, expectedBuffer);
 }
+
+export const verifyHmacSHA256 = (
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+): boolean => verifyHmacSignature(rawBody, signatureHeader, secret, 'sha256');

--- a/src/integrations/webhooks/webhook-verifier.service.spec.ts
+++ b/src/integrations/webhooks/webhook-verifier.service.spec.ts
@@ -1,29 +1,69 @@
+import * as crypto from 'crypto';
+import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { WebhookVerifierService } from './webhook-verifier.service';
-import * as crypto from 'crypto';
 
 describe('WebhookVerifierService', () => {
+  const secrets: Record<string, string> = {
+    WEBHOOK_SIGNING_KEY: 'generic-webhook-secret-at-least-32-chars',
+    PAYSTACK_SECRET_KEY: 'paystack-secret-at-least-32-chars',
+  };
+
   let service: WebhookVerifierService;
-  const secret = 'test-secret';
+
   beforeEach(() => {
-    const config = { get: (k: string) => secret } as unknown as ConfigService;
+    const config = {
+      get: jest.fn((key: string) => secrets[key]),
+    } as unknown as ConfigService;
     service = new WebhookVerifierService(config);
   });
 
-  it('validates correct signature', () => {
+  it('validates a correct sha256 signature', () => {
     const body = JSON.stringify({ hello: 'world' });
-    const sig = 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
-    expect(service.validate(body, sig)).toBe(true);
+    const signature =
+      'sha256=' +
+      crypto
+        .createHmac('sha256', secrets.WEBHOOK_SIGNING_KEY)
+        .update(body)
+        .digest('hex');
+
+    expect(service.validate(body, signature)).toBe(true);
   });
 
-  it('rejects incorrect signature', () => {
-    const body = 'x';
-    const sig = 'sha256=' + crypto.createHmac('sha256', 'other').update(body).digest('hex');
-    try {
-      service.validate(body, sig);
-      throw new Error('should have thrown');
-    } catch (err) {
-      expect(err.status).toBe(401);
-    }
+  it('validates provider-specific sha512 signatures', () => {
+    const body = JSON.stringify({ event: 'charge.success' });
+    const signature = crypto
+      .createHmac('sha512', secrets.PAYSTACK_SECRET_KEY)
+      .update(body)
+      .digest('hex');
+
+    expect(service.validate(body, signature, 'PAYSTACK_SECRET_KEY', 'sha512')).toBe(true);
+  });
+
+  it('rejects missing and malformed signatures with 401', () => {
+    expect(() => service.validate('{"ok":true}', undefined)).toThrow(
+      UnauthorizedException,
+    );
+    expect(() => service.validate('{"ok":true}', 'sha256=not-hex')).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('uses the raw request body before falling back to serialized parsed body', () => {
+    const rawBody = Buffer.from('{"hello":"world"}');
+    const signature =
+      'sha256=' +
+      crypto
+        .createHmac('sha256', secrets.WEBHOOK_SIGNING_KEY)
+        .update(rawBody)
+        .digest('hex');
+
+    expect(
+      service.validateRequest({
+        rawBody,
+        parsedBody: { hello: 'world' },
+        signatureHeader: signature,
+      }),
+    ).toBe(rawBody.toString('utf8'));
   });
 });

--- a/src/integrations/webhooks/webhook-verifier.service.ts
+++ b/src/integrations/webhooks/webhook-verifier.service.ts
@@ -1,19 +1,65 @@
-import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
-import { verifyHmacSHA256 } from './utils/signature-validator';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import {
+  HmacAlgorithm,
+  verifyHmacSignature,
+} from './utils/signature-validator';
+
+export interface WebhookVerificationOptions {
+  rawBody: Buffer | string | undefined;
+  parsedBody?: unknown;
+  signatureHeader?: string;
+  providerKeyName?: string;
+  algorithm?: HmacAlgorithm;
+}
 
 @Injectable()
 export class WebhookVerifierService {
   private readonly logger = new Logger(WebhookVerifierService.name);
+
   constructor(private readonly config: ConfigService) {}
 
-  validate(rawBody: string, signatureHeader?: string, providerKeyName = 'WEBHOOK_SIGNING_KEY'): boolean {
-    const secret = this.config.get<string>(providerKeyName) || '';
-    const ok = verifyHmacSHA256(rawBody, signatureHeader || '', secret);
+  validate(
+    rawBody: string,
+    signatureHeader?: string,
+    providerKeyName = 'WEBHOOK_SIGNING_KEY',
+    algorithm: HmacAlgorithm = 'sha256',
+  ): boolean {
+    const secret =
+      this.config.get<string>(providerKeyName) ||
+      this.config.get<string>('WEBHOOK_SIGNING_KEY') ||
+      '';
+    const ok = verifyHmacSignature(
+      rawBody,
+      signatureHeader || '',
+      secret,
+      algorithm,
+    );
+
     if (!ok) {
-      this.logger.warn('Invalid webhook signature');
+      this.logger.warn(`Invalid webhook signature for ${providerKeyName}`);
       throw new UnauthorizedException('Invalid webhook signature');
     }
+
     return true;
+  }
+
+  validateRequest(options: WebhookVerificationOptions): string {
+    const rawBody = this.getRawBody(options.rawBody, options.parsedBody);
+
+    this.validate(
+      rawBody,
+      options.signatureHeader,
+      options.providerKeyName,
+      options.algorithm,
+    );
+
+    return rawBody;
+  }
+
+  private getRawBody(rawBody: Buffer | string | undefined, parsedBody?: unknown): string {
+    if (Buffer.isBuffer(rawBody)) return rawBody.toString('utf8');
+    if (typeof rawBody === 'string') return rawBody;
+    return JSON.stringify(parsedBody ?? {});
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ initTracing();
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     bufferLogs: true,
+    rawBody: true,
   });
 
   // Get services

--- a/src/payments/local-methods/local-payment.controller.spec.ts
+++ b/src/payments/local-methods/local-payment.controller.spec.ts
@@ -1,0 +1,81 @@
+import * as crypto from 'crypto';
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { WebhookVerifierService } from '../../integrations/webhooks/webhook-verifier.service';
+import { LocalPaymentController } from './local-payment.controller';
+
+describe('LocalPaymentController webhook signatures', () => {
+  const secrets: Record<string, string> = {
+    MPESA_WEBHOOK_SECRET: 'mpesa-webhook-secret',
+    PAYSTACK_SECRET_KEY: 'paystack-secret-at-least-32-chars',
+  };
+
+  const localPaymentService = {
+    listAllProviders: jest.fn(),
+    getAvailableProviders: jest.fn(),
+    initiatePayment: jest.fn(),
+    getPaymentStatus: jest.fn(),
+    getUserPayments: jest.fn(),
+  };
+  const mpesaWebhook = { handle: jest.fn() };
+  const paystackWebhook = { handle: jest.fn() };
+
+  let controller: LocalPaymentController;
+
+  beforeEach(() => {
+    const verifier = new WebhookVerifierService({
+      get: jest.fn((key: string) => secrets[key]),
+    } as unknown as ConfigService);
+
+    controller = new LocalPaymentController(
+      localPaymentService as any,
+      mpesaWebhook as any,
+      paystackWebhook as any,
+      verifier,
+    );
+
+    jest.clearAllMocks();
+  });
+
+  it('rejects unsigned M-Pesa webhooks before processing', async () => {
+    await expect(
+      controller.mpesaWebhook({ Body: {} }, undefined as any, {
+        rawBody: Buffer.from('{}'),
+      } as any),
+    ).rejects.toThrow(UnauthorizedException);
+
+    expect(mpesaWebhook.handle).not.toHaveBeenCalled();
+  });
+
+  it('accepts signed M-Pesa webhooks and preserves the signature for the handler', async () => {
+    const rawBody = Buffer.from('{"Body":{"stkCallback":{"ResultCode":0}}}');
+    const signature =
+      'sha256=' +
+      crypto.createHmac('sha256', secrets.MPESA_WEBHOOK_SECRET).update(rawBody).digest('hex');
+    const payload = { Body: { stkCallback: { ResultCode: 0 } } };
+
+    await expect(
+      controller.mpesaWebhook(payload, signature, { rawBody } as any),
+    ).resolves.toEqual({ received: true });
+
+    expect(mpesaWebhook.handle).toHaveBeenCalledWith(payload, signature);
+  });
+
+  it('rejects Paystack webhooks signed with the wrong secret', async () => {
+    const rawBody = Buffer.from('{"event":"charge.success"}');
+    const badSignature = crypto
+      .createHmac('sha512', 'wrong-secret')
+      .update(rawBody)
+      .digest('hex');
+
+    await expect(
+      controller.paystackWebhook(
+        { event: 'charge.success' },
+        badSignature,
+        { rawBody } as any,
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+
+    expect(paystackWebhook.handle).not.toHaveBeenCalled();
+  });
+});

--- a/src/payments/local-methods/local-payment.controller.ts
+++ b/src/payments/local-methods/local-payment.controller.ts
@@ -1,5 +1,17 @@
-import { Controller, Get, Post, Body, Param, Query, Headers } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  Param,
+  Post,
+  Query,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
+import { Request } from 'express';
 import { RateLimit, RateLimitTier } from '../../common/decorators/rate-limit.decorator';
+import { WebhookVerifierService } from '../../integrations/webhooks/webhook-verifier.service';
 import { LocalPaymentService } from './local-payment.service';
 import { MpesaWebhookHandler } from './webhooks/mpesa-webhook.handler';
 import { PaystackWebhookHandler } from './webhooks/paystack-webhook.handler';
@@ -10,8 +22,9 @@ import { PaystackPaymentDto } from './dto/paystack-payment.dto';
 export class LocalPaymentController {
   constructor(
     private readonly localPaymentService: LocalPaymentService,
-    private readonly mpesaWebhook: MpesaWebhookHandler,
-    private readonly paystackWebhook: PaystackWebhookHandler,
+    private readonly mpesaWebhookHandler: MpesaWebhookHandler,
+    private readonly paystackWebhookHandler: PaystackWebhookHandler,
+    private readonly webhookVerifier: WebhookVerifierService,
   ) {}
 
   @Get('providers')
@@ -60,8 +73,18 @@ export class LocalPaymentController {
 
   @Post('webhooks/mpesa')
   @RateLimit({ tier: RateLimitTier.PUBLIC, limit: 120, window: 60 })
-  async mpesaWebhook(@Body() payload: Record<string, any>) {
-    await this.mpesaWebhook.handle(payload, '');
+  async mpesaWebhook(
+    @Body() payload: Record<string, any>,
+    @Headers('x-mpesa-signature') signature: string,
+    @Req() req: RawBodyRequest<Request>,
+  ) {
+    this.webhookVerifier.validateRequest({
+      rawBody: req.rawBody,
+      parsedBody: payload,
+      signatureHeader: signature,
+      providerKeyName: 'MPESA_WEBHOOK_SECRET',
+    });
+    await this.mpesaWebhookHandler.handle(payload, signature);
     return { received: true };
   }
 
@@ -70,8 +93,16 @@ export class LocalPaymentController {
   async paystackWebhook(
     @Body() payload: Record<string, any>,
     @Headers('x-paystack-signature') signature: string,
+    @Req() req: RawBodyRequest<Request>,
   ) {
-    await this.paystackWebhook.handle(payload, signature);
+    this.webhookVerifier.validateRequest({
+      rawBody: req.rawBody,
+      parsedBody: payload,
+      signatureHeader: signature,
+      providerKeyName: 'PAYSTACK_SECRET_KEY',
+      algorithm: 'sha512',
+    });
+    await this.paystackWebhookHandler.handle(payload, signature);
     return { received: true };
   }
 }

--- a/src/payments/local-methods/local-payment.module.ts
+++ b/src/payments/local-methods/local-payment.module.ts
@@ -12,6 +12,7 @@ import { UpiProvider } from './providers/upi.provider';
 import { RegionalRouter } from './utils/regional-router';
 import { MpesaWebhookHandler } from './webhooks/mpesa-webhook.handler';
 import { PaystackWebhookHandler } from './webhooks/paystack-webhook.handler';
+import { WebhookVerifierService } from '../../integrations/webhooks/webhook-verifier.service';
 
 @Module({
   imports: [ConfigModule, TypeOrmModule.forFeature([LocalPayment, PaymentConfig])],
@@ -24,6 +25,7 @@ import { PaystackWebhookHandler } from './webhooks/paystack-webhook.handler';
     RegionalRouter,
     MpesaWebhookHandler,
     PaystackWebhookHandler,
+    WebhookVerifierService,
   ],
   controllers: [LocalPaymentController],
   exports: [LocalPaymentService],


### PR DESCRIPTION
Closes #922

## Summary

- Added centralized inbound HMAC webhook verification with timing-safe comparison and SHA-256/SHA-512 support.
- Enabled Nest raw-body capture so signatures can be validated against the exact request body.
- Protected local payment and automation inbound webhook endpoints from missing, malformed, or invalid signatures.
- Added focused tests for signed and unsigned webhook deliveries.

## Validation

- `git diff --check`
- Direct HMAC utility runtime check for SHA-256, SHA-512, and malformed signatures

## Notes

Full Jest/Prettier execution was blocked locally because `node_modules` was not installed and `npm ci` timed out before installing Jest/TypeScript binaries.
