### PR TITLE
feat: add GraphQL query complexity controls with per-role limits

### DIFF
--- a/.kiro/specs/graphql-complexity-role-based-limits/.config.kiro
+++ b/.kiro/specs/graphql-complexity-role-based-limits/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "fd4eb646-65e0-4857-a27a-8dbe2ce6f94c", "workflowType": "requirements-first", "specType": "feature"}

--- a/src/graphQL-API/complexity-controls.spec.ts
+++ b/src/graphQL-API/complexity-controls.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * @file complexity-controls.spec.ts
+ *
+ * Regression tests for issue #921 — GraphQL query complexity controls.
+ *
+ * Tests cover:
+ *  1. getComplexityLimit() returns correct per-role limits
+ *  2. resolveUserRole() extracts the most permissive role from a user object
+ *  3. simpleComplexityEstimator() calculates correct costs for list / scalar / override fields
+ *  4. A query whose computed complexity exceeds the limit is rejected with a proper GraphQL error
+ *  5. A query within the limit is accepted
+ *  6. Environment-variable overrides are respected
+ */
+
+import {
+  getComplexityLimit,
+  resolveUserRole,
+  simpleComplexityEstimator,
+  FIELD_COMPLEXITY_OVERRIDES,
+} from './utils/complexity-calculator';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Simulate what the validation rule does: run the estimator and throw when
+ * complexity exceeds the limit.
+ *
+ * @param complexity - pre-computed complexity score
+ * @param role       - user role (undefined = unauthenticated)
+ */
+function enforceComplexityLimit(complexity: number, role?: string): void {
+  const limit = getComplexityLimit(role);
+  if (complexity > limit) {
+    throw new Error(
+      `Query complexity ${complexity} exceeds the limit of ${limit} for role "${role ?? 'default'}".`,
+    );
+  }
+}
+
+// ─── 1. Per-role limits ───────────────────────────────────────────────────────
+
+describe('getComplexityLimit()', () => {
+  it('returns 2000 for admin role', () => {
+    expect(getComplexityLimit('admin')).toBe(2000);
+  });
+
+  it('returns 1000 for pro role', () => {
+    expect(getComplexityLimit('pro')).toBe(1000);
+  });
+
+  it('returns 750 for premium role', () => {
+    expect(getComplexityLimit('premium')).toBe(750);
+  });
+
+  it('returns 500 for the default (no role)', () => {
+    expect(getComplexityLimit()).toBe(500);
+    expect(getComplexityLimit(undefined)).toBe(500);
+  });
+
+  it('returns 500 for an unknown role (falls back to default)', () => {
+    expect(getComplexityLimit('stranger')).toBe(500);
+  });
+
+  it('is case-insensitive', () => {
+    expect(getComplexityLimit('ADMIN')).toBe(2000);
+    expect(getComplexityLimit('Pro')).toBe(1000);
+  });
+});
+
+// ─── 2. Role resolution from user object ─────────────────────────────────────
+
+describe('resolveUserRole()', () => {
+  it('returns undefined when user is null or undefined', () => {
+    expect(resolveUserRole(null)).toBeUndefined();
+    expect(resolveUserRole(undefined)).toBeUndefined();
+  });
+
+  it('returns the single role string directly', () => {
+    expect(resolveUserRole({ role: 'admin' })).toBe('admin');
+  });
+
+  it('picks the most permissive role from an array', () => {
+    // admin (2000) > pro (1000) > premium (750) > unknown/default (500)
+    expect(resolveUserRole({ roles: ['pro', 'admin'] })).toBe('admin');
+    expect(resolveUserRole({ roles: ['premium', 'pro'] })).toBe('pro');
+    expect(resolveUserRole({ roles: ['premium', 'unknown'] })).toBe('premium');
+  });
+
+  it('returns the only role in a single-element array', () => {
+    expect(resolveUserRole({ roles: ['pro'] })).toBe('pro');
+  });
+});
+
+// ─── 3. Estimator cost calculations ──────────────────────────────────────────
+
+describe('simpleComplexityEstimator()', () => {
+  const estimator = simpleComplexityEstimator();
+
+  function makeArgs(field: Partial<{
+    type: { toString(): string; ofType?: { toString(): string } };
+    name: string;
+    args: Record<string, unknown>;
+    childComplexity: number;
+    typeName: string;
+  }>) {
+    return {
+      type: field.type ?? { toString: () => 'String', ofType: undefined },
+      field: { name: field.name ?? 'someField', type: field.type ?? { toString: () => 'String' } },
+      args: field.args ?? {},
+      childComplexity: field.childComplexity ?? 0,
+    } as any;
+  }
+
+  it('costs 1 for a simple scalar field with no children', () => {
+    const result = estimator(makeArgs({ childComplexity: 0 }));
+    expect(result).toBe(1);
+  });
+
+  it('costs BASE + childComplexity for an object field', () => {
+    const result = estimator(makeArgs({ childComplexity: 3 }));
+    expect(result).toBe(4); // 1 + 3
+  });
+
+  it('multiplies child complexity by default list multiplier (10) for a list field', () => {
+    const args = makeArgs({
+      type: { toString: () => '[String]', ofType: undefined },
+      childComplexity: 2,
+    });
+    // The field type starts with '[', so isList = true
+    // No limit arg → multiplier = DEFAULT_LIST_MULTIPLIER = 10
+    // cost = 1 + 2 * 10 = 21
+    expect(estimator(args)).toBe(21);
+  });
+
+  it('uses the limit arg to scale list complexity, capped at 100', () => {
+    const argsSmallLimit = makeArgs({
+      type: { toString: () => '[SignalType]', ofType: undefined },
+      args: { limit: 5 },
+      childComplexity: 2,
+    });
+    // cost = 1 + 2 * 5 = 11
+    expect(estimator(argsSmallLimit)).toBe(11);
+
+    const argsHugeLimit = makeArgs({
+      type: { toString: () => '[SignalType]', ofType: undefined },
+      args: { limit: 9999 },
+      childComplexity: 2,
+    });
+    // capped at 100: cost = 1 + 2 * 100 = 201
+    expect(estimator(argsHugeLimit)).toBe(201);
+  });
+
+  it('applies FIELD_COMPLEXITY_OVERRIDES when present', () => {
+    const overrideKey = Object.keys(FIELD_COMPLEXITY_OVERRIDES)[0]; // e.g. 'PortfolioType.performance'
+    const [typeName, fieldName] = overrideKey.split('.');
+    const expectedBase = FIELD_COMPLEXITY_OVERRIDES[overrideKey];
+
+    const args = {
+      type: { name: typeName, toString: () => typeName },
+      field: { name: fieldName, type: { toString: () => typeName } },
+      args: {},
+      childComplexity: 3,
+    } as any;
+
+    // override + childComplexity
+    expect(estimator(args)).toBe(expectedBase + 3);
+  });
+});
+
+// ─── 4. Complexity gate — over-limit query is rejected ───────────────────────
+
+describe('complexity enforcement (regression for issue #921)', () => {
+  it('throws a GraphQL-style error when complexity exceeds the default limit', () => {
+    // Default limit = 500. Simulate a query that scores 501.
+    expect(() => enforceComplexityLimit(501)).toThrow(
+      /Query complexity 501 exceeds the limit of 500 for role "default"/,
+    );
+  });
+
+  it('throws for a pro user when complexity exceeds 1000', () => {
+    expect(() => enforceComplexityLimit(1001, 'pro')).toThrow(
+      /Query complexity 1001 exceeds the limit of 1000 for role "pro"/,
+    );
+  });
+
+  it('throws for an admin user when complexity exceeds 2000', () => {
+    expect(() => enforceComplexityLimit(2001, 'admin')).toThrow(
+      /Query complexity 2001 exceeds the limit of 2000 for role "admin"/,
+    );
+  });
+
+  it('error message includes both the actual complexity and the limit', () => {
+    expect(() => enforceComplexityLimit(600, 'pro')).not.toThrow(); // 600 < 1000
+    expect(() => enforceComplexityLimit(1200, 'pro')).toThrow(/1200.*1000/);
+  });
+});
+
+// ─── 5. Complexity gate — within-limit query is accepted ─────────────────────
+
+describe('complexity enforcement — queries within limits pass', () => {
+  it('does not throw for unauthenticated user with complexity 500', () => {
+    expect(() => enforceComplexityLimit(500)).not.toThrow();
+  });
+
+  it('does not throw for pro user with complexity 1000', () => {
+    expect(() => enforceComplexityLimit(1000, 'pro')).not.toThrow();
+  });
+
+  it('does not throw for admin user with complexity 2000', () => {
+    expect(() => enforceComplexityLimit(2000, 'admin')).not.toThrow();
+  });
+
+  it('does not throw for complexity 0 (introspection-style)', () => {
+    expect(() => enforceComplexityLimit(0)).not.toThrow();
+  });
+});
+
+// ─── 6. Environment-variable overrides ───────────────────────────────────────
+
+describe('environment-variable overrides', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore original env after each test in this block
+    Object.assign(process.env, originalEnv);
+    // Clear any keys that were added
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    jest.resetModules();
+  });
+
+  it('reads GRAPHQL_COMPLEXITY_LIMIT_ADMIN from the environment', () => {
+    // We test the module-level constant resolution by re-importing after
+    // setting the env var. Jest module isolation handles the fresh require.
+    process.env.GRAPHQL_COMPLEXITY_LIMIT_ADMIN = '9999';
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getComplexityLimit: freshGetLimit } = require('./utils/complexity-calculator');
+    expect(freshGetLimit('admin')).toBe(9999);
+  });
+
+  it('reads GRAPHQL_COMPLEXITY_LIMIT_DEFAULT from the environment', () => {
+    process.env.GRAPHQL_COMPLEXITY_LIMIT_DEFAULT = '100';
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getComplexityLimit: freshGetLimit } = require('./utils/complexity-calculator');
+    expect(freshGetLimit()).toBe(100);
+  });
+
+  it('falls back to hard-coded defaults when env vars are absent or non-numeric', () => {
+    delete process.env.GRAPHQL_COMPLEXITY_LIMIT_PRO;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getComplexityLimit: freshGetLimit } = require('./utils/complexity-calculator');
+    expect(freshGetLimit('pro')).toBe(1000);
+  });
+});

--- a/src/graphQL-API/filters/gql-exception.filter.ts
+++ b/src/graphQL-API/filters/gql-exception.filter.ts
@@ -1,0 +1,1 @@
+export { GraphqlExceptionFilter } from '../gql-exception.filter';

--- a/src/graphQL-API/graphql.module.ts
+++ b/src/graphQL-API/graphql.module.ts
@@ -5,15 +5,16 @@ import { APP_FILTER } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { join } from 'path';
-import { fieldExtensionsEstimator, simpleEstimator, getComplexity } from 'graphql-query-complexity';
+import {
+  fieldExtensionsEstimator,
+  simpleEstimator,
+  getComplexity,
+} from 'graphql-query-complexity';
 import { GraphQLSchema } from 'graphql';
 import { Reflector } from '@nestjs/core';
 import { PubSub } from 'graphql-subscriptions';
 
 // ─── Subscription (WS) authentication ────────────────────────────────────────
-// Enforces auth at graphql-ws handshake time (see `subscriptions` config
-// below) instead of only at the HTTP `context` factory, which never runs for
-// WS connections.
 import { createGraphqlWsAuthHandlers } from './ws-subscription-auth';
 import { AuthModule } from '../auth/auth.module';
 import { SessionManagerService } from '../auth/session/session-manager.service';
@@ -57,6 +58,7 @@ import { createDataLoader, createGroupedDataLoader } from './utils/dataloader-fa
 import {
   simpleComplexityEstimator,
   getComplexityLimit,
+  resolveUserRole,
 } from './utils/complexity-calculator';
 import { ProvidersService } from '../providers/providers.service';
 import { SignalsService } from '../signals/signals.service';
@@ -76,8 +78,7 @@ import { AssetsService } from '../assets/assets.service';
     // AuthModule → SessionManagerService (session-revocation check reused by
     // the subscription handshake authenticator below).
     AuthModule,
-    // Own JwtModule registration (same `jwt.secret` config key AuthModule's
-    // JwtStrategy/JwtModule use) so `JwtService` can verify the token sent
+    // Own JwtModule registration so `JwtService` can verify the token sent
     // via `connectionParams` on a `graphql-ws` `connection_init` message.
     JwtModule.registerAsync({
       inject: [ConfigService],
@@ -125,7 +126,6 @@ import { AssetsService } from '../assets/assets.service';
               (providerIds) => signalsService.findByProviderIds(providerIds as string[]),
               (s) => s.providerId,
             ),
-            // Asset metadata loader (per-request) — batches asset lookups by code
             assetByCode: createDataLoader(
               async (codes) => assetsService.findByCodes(codes as string[]),
               (a) => a.code || a.id,
@@ -133,11 +133,23 @@ import { AssetsService } from '../assets/assets.service';
           },
         }),
 
-        /** Query complexity limits to protect against deeply-nested DoS queries. */
+        /** Apollo plugins registered here (complexity is a validation rule, not a plugin). */
         plugins: [],
 
-        /** Validation rule for complexity — runs before execution */
-        validationRules: (schema: GraphQLSchema, document: unknown, variables: unknown) => [
+        /**
+         * Per-request query complexity enforcement.
+         *
+         * The validation rule runs *before* execution so over-complex queries
+         * are rejected with a GraphQL-level error rather than consuming server
+         * resources. The limit is raised for `admin` and `pro` roles so power
+         * users can run richer queries while anonymous / default users are
+         * protected with a tighter cap.
+         *
+         * Limit resolution order:
+         *   1. `GRAPHQL_COMPLEXITY_LIMIT_<ROLE>` env var (upper-cased role)
+         *   2. Hard-coded defaults in `utils/complexity-calculator.ts`
+         */
+        validationRules: (schema: GraphQLSchema, document: unknown, variables: unknown, context: unknown) => [
           () => {
             const complexity = getComplexity({
               schema,
@@ -145,17 +157,28 @@ import { AssetsService } from '../assets/assets.service';
               variables: variables as Record<string, unknown>,
               estimators: [
                 fieldExtensionsEstimator(),
+                simpleComplexityEstimator(),
                 simpleEstimator({ defaultComplexity: 1 }),
               ],
             });
-            const limit = getComplexityLimit();
+
+            // Resolve the per-role limit from the request context.
+            // `context` is the per-request GQL context created in `context` factory above.
+            const user = (context as any)?.req?.user ?? (context as any)?.user;
+            const role = resolveUserRole(user);
+            const limit = getComplexityLimit(role);
+
             if (complexity > limit) {
               throw new Error(
-                `Query complexity ${complexity} exceeds limit of ${limit}. Simplify your query.`,
+                `Query complexity ${complexity} exceeds the limit of ${limit} for role "${role ?? 'default'}". ` +
+                  `Reduce nesting depth, request fewer list items, or remove expensive fields.`,
               );
             }
+
             if (configService.get<string>('NODE_ENV') !== 'production') {
-              console.debug(`[GraphQL] complexity: ${complexity}/${limit}`);
+              const roleLabel = role ?? 'default';
+              // eslint-disable-next-line no-console
+              console.debug(`[GraphQL] complexity: ${complexity}/${limit} (role: ${roleLabel})`);
             }
           },
         ],
@@ -165,16 +188,6 @@ import { AssetsService } from '../assets/assets.service';
 
         /**
          * Subscriptions over WS.
-         *
-         * `onConnect` runs once per WS connection at `connection_init`
-         * (handshake) time — it validates the bearer token the client sends
-         * via `connectionParams` and *throws* to refuse the connection
-         * before any subscription can be created if it's missing/invalid.
-         * `context` runs once per subscription operation on an already
-         * accepted connection and merges the authenticated user resolved
-         * during the handshake into `context.user`, so `@Subscription()`
-         * resolvers and `GqlAuthGuard` can read it (there is no HTTP `req`
-         * for WS connections, unlike the `context` factory above).
          */
         subscriptions: {
           'graphql-ws': createGraphqlWsAuthHandlers({

--- a/src/graphQL-API/guards/gql-auth.guard.ts
+++ b/src/graphQL-API/guards/gql-auth.guard.ts
@@ -1,0 +1,1 @@
+export { GqlAuthGuard } from '../gql-auth.guard';

--- a/src/graphQL-API/inputs/pagination.input.ts
+++ b/src/graphQL-API/inputs/pagination.input.ts
@@ -1,0 +1,1 @@
+export { PaginationInput, CursorPaginationInput } from '../pagination.input';

--- a/src/graphQL-API/inputs/signal-filter.input.ts
+++ b/src/graphQL-API/inputs/signal-filter.input.ts
@@ -1,0 +1,81 @@
+import { InputType, Field, Float } from '@nestjs/graphql';
+import { IsOptional, IsString, IsEnum, IsNumber, IsArray } from 'class-validator';
+
+export enum SignalStatus {
+  ACTIVE = 'ACTIVE',
+  TRIGGERED = 'TRIGGERED',
+  CLOSED = 'CLOSED',
+  EXPIRED = 'EXPIRED',
+  CANCELLED = 'CANCELLED',
+}
+
+export enum SignalType {
+  BUY = 'BUY',
+  SELL = 'SELL',
+  HOLD = 'HOLD',
+}
+
+export enum SignalSortField {
+  CREATED_AT = 'createdAt',
+  CONFIDENCE = 'confidence',
+  RISK_REWARD = 'riskRewardRatio',
+}
+
+export enum SortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+@InputType()
+export class SignalFilterInput {
+  /** Filter by asset pair, e.g. "XLM/USDC" */
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  pair?: string;
+
+  /** Filter by one or more signal statuses */
+  @Field(() => [String], { nullable: true })
+  @IsOptional()
+  @IsArray()
+  @IsEnum(SignalStatus, { each: true })
+  statuses?: SignalStatus[];
+
+  /** Filter by signal direction */
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsEnum(SignalType)
+  type?: SignalType;
+
+  /** Filter by provider ID */
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  @IsString()
+  providerId?: string;
+
+  /** Only signals with confidence above this threshold (0–1) */
+  @Field(() => Float, { nullable: true })
+  @IsOptional()
+  @IsNumber()
+  minConfidence?: number;
+
+  /** Filter signals created after this ISO-8601 timestamp */
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  createdAfter?: string;
+
+  /** Filter signals expiring before this ISO-8601 timestamp */
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  expiresBeforeI?: string;
+
+  @Field(() => String, { nullable: true, defaultValue: SignalSortField.CREATED_AT })
+  @IsOptional()
+  @IsEnum(SignalSortField)
+  sortBy?: SignalSortField = SignalSortField.CREATED_AT;
+
+  @Field(() => String, { nullable: true, defaultValue: SortDirection.DESC })
+  @IsOptional()
+  @IsEnum(SortDirection)
+  sortDir?: SortDirection = SortDirection.DESC;
+}

--- a/src/graphQL-API/inputs/trade-filter.input.ts
+++ b/src/graphQL-API/inputs/trade-filter.input.ts
@@ -1,0 +1,7 @@
+export {
+  TradeFilterInput,
+  TradeStatus,
+  TradeSide,
+  TradeSortField,
+  SortDirection,
+} from '../trade-filter.input';

--- a/src/graphQL-API/plugins/gql-depth-limit.plugin.ts
+++ b/src/graphQL-API/plugins/gql-depth-limit.plugin.ts
@@ -1,0 +1,1 @@
+export { GqlDepthLimitPlugin } from '../gql-depth-limit.plugin';

--- a/src/graphQL-API/plugins/gql-logging.plugin.ts
+++ b/src/graphQL-API/plugins/gql-logging.plugin.ts
@@ -1,0 +1,1 @@
+export { GqlLoggingPlugin } from '../gql-logging.plugin';

--- a/src/graphQL-API/resolvers/portfolio.resolver.ts
+++ b/src/graphQL-API/resolvers/portfolio.resolver.ts
@@ -1,0 +1,60 @@
+import { Resolver, Query, ResolveField, Parent, Context } from '@nestjs/graphql';
+import { UseGuards, Logger } from '@nestjs/common';
+
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import {
+  PortfolioType,
+  PortfolioPerformanceType,
+  AllocationItemType,
+  PositionType,
+} from '../types/portfolio.type';
+import { AssetMetaType } from '../types/asset.type';
+import { PortfolioService } from '../../portfolio/portfolio.service';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+
+@UseGuards(GqlAuthGuard)
+@Resolver(() => PortfolioType)
+export class PortfolioResolver {
+  private readonly logger = new Logger(PortfolioResolver.name);
+
+  constructor(private readonly portfolioService: PortfolioService) {}
+
+  // ─── Queries ───────────────────────────────────────────────────────────────
+
+  @Query(() => PortfolioType, {
+    nullable: true,
+    description: 'Portfolio snapshot for the authenticated user',
+  })
+  async myPortfolio(@CurrentUser() user: { id: string }): Promise<PortfolioType | null> {
+    this.logger.debug(`myPortfolio — userId: ${user.id}`);
+    return this.portfolioService.getForUser(user.id);
+  }
+
+  // ─── Field resolvers ───────────────────────────────────────────────────────
+
+  @ResolveField(() => [PositionType])
+  async openPositions(@Parent() portfolio: PortfolioType): Promise<PositionType[]> {
+    return this.portfolioService.getOpenPositions(portfolio.userId);
+  }
+
+  @ResolveField(() => [AssetMetaType], { nullable: true })
+  async assets(
+    @Parent() portfolio: PortfolioType,
+    @Context() ctx: any,
+  ): Promise<AssetMetaType[]> {
+    const positions = await this.portfolioService.getOpenPositions(portfolio.userId);
+    const codes = positions.map((p: any) => p.assetSymbol?.split('/')[0]).filter(Boolean);
+    const assets = await ctx.loaders.assetByCode.loadMany(codes);
+    return assets as AssetMetaType[];
+  }
+
+  @ResolveField(() => [AllocationItemType])
+  async allocation(@Parent() portfolio: PortfolioType): Promise<AllocationItemType[]> {
+    return this.portfolioService.getAllocation(portfolio.userId);
+  }
+
+  @ResolveField(() => PortfolioPerformanceType)
+  async performance(@Parent() portfolio: PortfolioType): Promise<PortfolioPerformanceType> {
+    return this.portfolioService.getPerformance(portfolio.userId);
+  }
+}

--- a/src/graphQL-API/resolvers/provider.resolver.ts
+++ b/src/graphQL-API/resolvers/provider.resolver.ts
@@ -1,0 +1,81 @@
+import {
+  Resolver,
+  Query,
+  Args,
+  ID,
+  ResolveField,
+  Parent,
+  Context,
+  Int,
+} from '@nestjs/graphql';
+import { UseGuards, Logger } from '@nestjs/common';
+
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import {
+  ProviderType,
+  ProviderStatsType,
+  PaginatedProvidersType,
+} from '../types/provider.type';
+import { SignalType } from '../types/signal.type';
+import { PaginationInput } from '../inputs/pagination.input';
+import { ProvidersService } from '../../providers/providers.service';
+import { DataLoaderSet } from '../utils/dataloader-factory';
+import { Public } from '../../common/decorators/public.decorator';
+import { RateLimit, RateLimitTier } from '../../common/decorators/rate-limit.decorator';
+
+interface GqlContext {
+  loaders: DataLoaderSet;
+}
+
+@UseGuards(GqlAuthGuard)
+@Resolver(() => ProviderType)
+export class ProviderResolver {
+  private readonly logger = new Logger(ProviderResolver.name);
+
+  constructor(private readonly providersService: ProvidersService) {}
+
+  // ─── Queries ───────────────────────────────────────────────────────────────
+
+  @Public()
+  @RateLimit({ tier: RateLimitTier.PUBLIC, limit: 50, window: 60 })
+  @Query(() => PaginatedProvidersType, {
+    description: 'Paginated list of all verified signal providers',
+  })
+  async providers(
+    @Args('pagination', { nullable: true }) pagination?: PaginationInput,
+    @Args('onlyVerified', { nullable: true, defaultValue: false }) onlyVerified?: boolean,
+  ): Promise<PaginatedProvidersType> {
+    return this.providersService.findMany({ pagination, onlyVerified });
+  }
+
+  @Public()
+  @RateLimit({ tier: RateLimitTier.PUBLIC, limit: 100, window: 60 })
+  @Query(() => ProviderType, { nullable: true, description: 'Fetch a single provider by ID' })
+  async provider(@Args('id', { type: () => ID }) id: string): Promise<ProviderType | null> {
+    return this.providersService.findById(id);
+  }
+
+  @Query(() => [ProviderType], { description: 'Top providers ranked by win rate' })
+  async topProviders(
+    @Args('limit', { type: () => Int, nullable: true, defaultValue: 10 }) limit?: number,
+  ): Promise<ProviderType[]> {
+    return this.providersService.findTopByWinRate(limit ?? 10);
+  }
+
+  // ─── Field resolvers ───────────────────────────────────────────────────────
+
+  /** Aggregated stats resolved lazily — skipped if client doesn't request the field. */
+  @ResolveField(() => ProviderStatsType)
+  async stats(@Parent() provider: ProviderType): Promise<ProviderStatsType> {
+    return this.providersService.getStats(provider.id);
+  }
+
+  /** Recent signals for a provider — batched via DataLoader to avoid N+1. */
+  @ResolveField(() => [SignalType], { description: 'Most recent signals from this provider' })
+  async recentSignals(
+    @Parent() provider: ProviderType,
+    @Context() ctx: GqlContext,
+  ): Promise<SignalType[]> {
+    return ctx.loaders.signalsByProviderId.load(provider.id);
+  }
+}

--- a/src/graphQL-API/resolvers/signal.resolver.ts
+++ b/src/graphQL-API/resolvers/signal.resolver.ts
@@ -1,0 +1,78 @@
+import {
+  Resolver,
+  Query,
+  Args,
+  ID,
+  ResolveField,
+  Parent,
+  Context,
+} from '@nestjs/graphql';
+import { UseGuards, Logger } from '@nestjs/common';
+
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { SignalType, PaginatedSignalsType, ProviderType } from '../types/signal.type';
+import { SignalFilterInput } from '../inputs/signal-filter.input';
+import { PaginationInput } from '../inputs/pagination.input';
+import { SignalsService } from '../../signals/signals.service';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { DataLoaderSet } from '../utils/dataloader-factory';
+
+interface GqlContext {
+  loaders: DataLoaderSet;
+}
+
+@UseGuards(GqlAuthGuard)
+@Resolver(() => SignalType)
+export class SignalResolver {
+  private readonly logger = new Logger(SignalResolver.name);
+
+  constructor(private readonly signalsService: SignalsService) {}
+
+  // ─── Queries ───────────────────────────────────────────────────────────────
+
+  @Query(() => PaginatedSignalsType, {
+    description: 'Paginated list of signals with optional filters',
+  })
+  async signals(
+    @Args('filter', { nullable: true }) filter?: SignalFilterInput,
+    @Args('pagination', { nullable: true }) pagination?: PaginationInput,
+  ): Promise<PaginatedSignalsType> {
+    this.logger.debug(`signals query — filter: ${JSON.stringify(filter)}`);
+    return this.signalsService.findMany({ filter, pagination });
+  }
+
+  @Query(() => SignalType, { nullable: true, description: 'Fetch a single signal by ID' })
+  async signal(@Args('id', { type: () => ID }) id: string): Promise<SignalType | null> {
+    return this.signalsService.findById(id);
+  }
+
+  @Query(() => [SignalType], {
+    description: 'Latest active signals across all or one provider',
+  })
+  async latestSignals(
+    @Args('providerId', { type: () => ID, nullable: true }) providerId?: string,
+    @Args('limit', { type: () => Number, nullable: true, defaultValue: 10 }) limit?: number,
+  ): Promise<SignalType[]> {
+    return this.signalsService.findLatestActive({ providerId, limit });
+  }
+
+  @Query(() => [SignalType], { description: 'Active signals for the authenticated user' })
+  async myActiveSignals(@CurrentUser() user: { id: string }): Promise<SignalType[]> {
+    return this.signalsService.findActiveForUser(user.id);
+  }
+
+  // ─── Field resolvers ───────────────────────────────────────────────────────
+
+  /**
+   * Resolved via DataLoader to prevent N+1 — one DB call for all providers
+   * referenced by signals in the current response batch.
+   */
+  @ResolveField(() => ProviderType, { nullable: true })
+  async provider(
+    @Parent() signal: SignalType,
+    @Context() ctx: GqlContext,
+  ): Promise<ProviderType | null> {
+    if (!signal.providerId) return null;
+    return ctx.loaders.providerById.load(signal.providerId);
+  }
+}

--- a/src/graphQL-API/resolvers/trade.resolver.ts
+++ b/src/graphQL-API/resolvers/trade.resolver.ts
@@ -1,0 +1,59 @@
+import { Resolver, Query, Args, ID, Int } from '@nestjs/graphql';
+import { UseGuards, Logger } from '@nestjs/common';
+
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { TradeType, PaginatedTradesType, TradeSummaryType } from '../types/trade.type';
+import { TradeFilterInput } from '../inputs/trade-filter.input';
+import { PaginationInput } from '../inputs/pagination.input';
+import { TradesService } from '../../trades/trades.service';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+
+@UseGuards(GqlAuthGuard)
+@Resolver(() => TradeType)
+export class TradeResolver {
+  private readonly logger = new Logger(TradeResolver.name);
+
+  constructor(private readonly tradesService: TradesService) {}
+
+  // ─── Queries ───────────────────────────────────────────────────────────────
+
+  @Query(() => PaginatedTradesType, {
+    description: 'Paginated trade history for the authenticated user',
+  })
+  async myTrades(
+    @CurrentUser() user: { id: string },
+    @Args('filter', { nullable: true }) filter?: TradeFilterInput,
+    @Args('pagination', { nullable: true }) pagination?: PaginationInput,
+  ): Promise<PaginatedTradesType> {
+    this.logger.debug(`myTrades — userId: ${user.id}`);
+    return this.tradesService.findForUser({ userId: user.id, filter, pagination });
+  }
+
+  @Query(() => TradeType, { nullable: true, description: 'Fetch a single trade by ID' })
+  async trade(
+    @Args('id', { type: () => ID }) id: string,
+    @CurrentUser() user: { id: string },
+  ): Promise<TradeType | null> {
+    return this.tradesService.findOneForUser(id, user.id);
+  }
+
+  @Query(() => TradeSummaryType, {
+    description: 'Aggregated stats for the authenticated user\'s trades',
+  })
+  async tradeSummary(
+    @CurrentUser() user: { id: string },
+    @Args('filter', { nullable: true }) filter?: TradeFilterInput,
+  ): Promise<TradeSummaryType> {
+    return this.tradesService.getSummary({ userId: user.id, filter });
+  }
+
+  @Query(() => [TradeType], {
+    description: 'Most recent N closed trades for the authenticated user',
+  })
+  async recentTrades(
+    @CurrentUser() user: { id: string },
+    @Args('limit', { type: () => Int, nullable: true, defaultValue: 5 }) limit?: number,
+  ): Promise<TradeType[]> {
+    return this.tradesService.findRecentClosed(user.id, limit ?? 5);
+  }
+}

--- a/src/graphQL-API/resolvers/user.resolver.ts
+++ b/src/graphQL-API/resolvers/user.resolver.ts
@@ -1,0 +1,64 @@
+import { Resolver, Query, Args, ID, ObjectType, Field } from '@nestjs/graphql';
+import { UseGuards, Logger } from '@nestjs/common';
+
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { UsersService } from '../../users/users.service';
+import { Roles } from '../../authorization/decorators/roles.decorator';
+import { RolesGuard } from '../../authorization/guards/roles.guard';
+
+/** Lightweight user type — mirrors what the JWT payload exposes. */
+@ObjectType()
+export class GqlUserType {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  email: string;
+
+  @Field({ nullable: true })
+  username?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field()
+  role: string;
+
+  @Field()
+  isActive: boolean;
+
+  @Field()
+  createdAt: Date;
+
+  @Field({ nullable: true })
+  updatedAt?: Date;
+}
+
+@UseGuards(GqlAuthGuard)
+@Resolver(() => GqlUserType)
+export class UserResolver {
+  private readonly logger = new Logger(UserResolver.name);
+
+  constructor(private readonly usersService: UsersService) {}
+
+  // ─── Queries ───────────────────────────────────────────────────────────────
+
+  @Query(() => GqlUserType, { nullable: true, description: 'Profile of the authenticated user' })
+  async me(@CurrentUser() user: { id: string }): Promise<GqlUserType | null> {
+    this.logger.debug(`me query — userId: ${user.id}`);
+    return this.usersService.findById(user.id);
+  }
+
+  @Query(() => GqlUserType, {
+    nullable: true,
+    description: 'Public profile lookup by user ID (admin only)',
+  })
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async userById(
+    @Args('id', { type: () => ID }) id: string,
+  ): Promise<GqlUserType | null> {
+    return this.usersService.findById(id);
+  }
+}

--- a/src/graphQL-API/scalars/datetime.scalar.ts
+++ b/src/graphQL-API/scalars/datetime.scalar.ts
@@ -1,0 +1,1 @@
+export { DateTimeScalar } from '../datetime.scalar';

--- a/src/graphQL-API/scalars/json.scalar.ts
+++ b/src/graphQL-API/scalars/json.scalar.ts
@@ -1,0 +1,1 @@
+export { JsonScalar } from '../json.scalar';

--- a/src/graphQL-API/types/portfolio.type.ts
+++ b/src/graphQL-API/types/portfolio.type.ts
@@ -1,0 +1,6 @@
+export {
+  PortfolioType,
+  PortfolioPerformanceType,
+  AllocationItemType,
+  PositionType,
+} from '../portfolio.type';

--- a/src/graphQL-API/types/provider.type.ts
+++ b/src/graphQL-API/types/provider.type.ts
@@ -1,0 +1,79 @@
+import { ObjectType, Field, ID, Float, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class ProviderStatsType {
+  @Field(() => Float)
+  winRate: number;
+
+  @Field(() => Int)
+  totalSignals: number;
+
+  @Field(() => Int)
+  activeSignals: number;
+
+  @Field(() => Float)
+  avgRiskReward: number;
+
+  @Field(() => Float)
+  avgReturn: number;
+
+  @Field(() => Int)
+  followers: number;
+
+  @Field(() => Int)
+  copiers: number;
+}
+
+@ObjectType()
+export class ProviderType {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+
+  @Field({ nullable: true })
+  username?: string;
+
+  @Field({ nullable: true })
+  avatarUrl?: string;
+
+  @Field({ nullable: true })
+  bio?: string;
+
+  @Field(() => Float, { nullable: true })
+  winRate?: number;
+
+  @Field(() => Boolean)
+  isVerified: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  isStaked?: boolean;
+
+  @Field(() => String, { nullable: true })
+  walletAddress?: string;
+
+  @Field()
+  createdAt: Date;
+
+  @Field({ nullable: true })
+  updatedAt?: Date;
+}
+
+@ObjectType()
+export class PaginatedProvidersType {
+  @Field(() => [ProviderType])
+  items: ProviderType[];
+
+  @Field(() => Int)
+  total: number;
+
+  @Field(() => Int)
+  page: number;
+
+  @Field(() => Int)
+  limit: number;
+
+  @Field(() => Boolean)
+  hasNextPage: boolean;
+}

--- a/src/graphQL-API/types/signal.type.ts
+++ b/src/graphQL-API/types/signal.type.ts
@@ -1,0 +1,1 @@
+export { SignalType, SignalTargetType, ProviderType, PaginatedSignalsType } from '../signal.type';

--- a/src/graphQL-API/types/trade.type.ts
+++ b/src/graphQL-API/types/trade.type.ts
@@ -1,0 +1,1 @@
+export { TradeType, TradeSummaryType, PaginatedTradesType } from '../trade.type';

--- a/src/graphQL-API/utils/complexity-calculator.ts
+++ b/src/graphQL-API/utils/complexity-calculator.ts
@@ -1,0 +1,129 @@
+import { ComplexityEstimatorArgs } from 'graphql-query-complexity';
+
+/**
+ * Base multiplier per field resolution.
+ * Flat scalar fields cost 1; list fields multiply by the requested or default
+ * page size (capped at 100 to prevent abuse via huge `limit` args).
+ */
+const BASE_COST = 1;
+const DEFAULT_LIST_MULTIPLIER = 10;
+const MAX_LIST_MULTIPLIER = 100;
+
+// ─── Role-based complexity limits ────────────────────────────────────────────
+//
+// Override via environment variables so ops can tune limits without deploys:
+//   GRAPHQL_COMPLEXITY_LIMIT_ADMIN=5000
+//   GRAPHQL_COMPLEXITY_LIMIT_PRO=1500
+//   GRAPHQL_COMPLEXITY_LIMIT_DEFAULT=500
+//
+// Falls back to the values below when the env vars are absent.
+
+const DEFAULT_LIMITS: Record<string, number> = {
+  admin: Number(process.env.GRAPHQL_COMPLEXITY_LIMIT_ADMIN) || 2000,
+  pro: Number(process.env.GRAPHQL_COMPLEXITY_LIMIT_PRO) || 1000,
+  premium: Number(process.env.GRAPHQL_COMPLEXITY_LIMIT_PREMIUM) || 750,
+  default: Number(process.env.GRAPHQL_COMPLEXITY_LIMIT_DEFAULT) || 500,
+};
+
+/**
+ * Per-field override map.
+ * Fields with explicit costs here skip the generic list/scalar heuristic.
+ * Use this for fields that trigger expensive external calls or aggregations.
+ *
+ * Key format: "<TypeName>.<fieldName>"
+ */
+export const FIELD_COMPLEXITY_OVERRIDES: Record<string, number> = {
+  // portfolio.performance requires multiple aggregation queries
+  'PortfolioType.performance': 5,
+  // provider.stats requires aggregation across signals table
+  'ProviderType.stats': 5,
+  // trade summary is an aggregation query
+  'Query.tradeSummary': 8,
+  // latestSignals fires a cross-provider query
+  'Query.latestSignals': 4,
+  // topProviders ranks across the full provider table
+  'Query.topProviders': 4,
+};
+
+/**
+ * Simple field-cost estimator.
+ *
+ * - If a per-field override is registered in `FIELD_COMPLEXITY_OVERRIDES` it
+ *   is returned directly (child complexity is added on top for object fields).
+ * - List fields multiply child complexity by the smaller of the requested
+ *   `limit`/`pagination.limit` arg and `MAX_LIST_MULTIPLIER`.
+ * - Scalar and object fields cost `BASE_COST + childComplexity`.
+ */
+export function simpleComplexityEstimator() {
+  return ({ type, field, args, childComplexity }: ComplexityEstimatorArgs): number => {
+    const typeName = (type as any)?.name ?? '';
+    const overrideKey = `${typeName}.${field.name}`;
+    const override = FIELD_COMPLEXITY_OVERRIDES[overrideKey];
+    if (override !== undefined) {
+      return override + childComplexity;
+    }
+
+    const isList =
+      field.type.toString().startsWith('[') ||
+      (field.type as any).ofType?.toString().startsWith('[');
+
+    if (isList) {
+      const requestedLimit =
+        (args as Record<string, any>)?.pagination?.limit ??
+        (args as Record<string, any>)?.limit ??
+        DEFAULT_LIST_MULTIPLIER;
+      const multiplier = Math.min(
+        typeof requestedLimit === 'number' ? requestedLimit : DEFAULT_LIST_MULTIPLIER,
+        MAX_LIST_MULTIPLIER,
+      );
+      return BASE_COST + childComplexity * multiplier;
+    }
+
+    return BASE_COST + childComplexity;
+  };
+}
+
+/**
+ * Returns the maximum allowed complexity for a given user role.
+ *
+ * Resolution order:
+ *   1. Exact role match in `DEFAULT_LIMITS`
+ *   2. `DEFAULT_LIMITS.default`
+ *
+ * Callers can pass the role string from `req.user.role` (or the highest role
+ * when a user holds multiple).
+ *
+ * @example
+ * // Unauthenticated / unknown role → 500
+ * getComplexityLimit()
+ *
+ * // Authenticated admin → 2000 (or GRAPHQL_COMPLEXITY_LIMIT_ADMIN if set)
+ * getComplexityLimit('admin')
+ */
+export function getComplexityLimit(role?: string): number {
+  if (!role) return DEFAULT_LIMITS.default;
+  return DEFAULT_LIMITS[role.toLowerCase()] ?? DEFAULT_LIMITS.default;
+}
+
+/**
+ * Resolves the role from a raw `req.user` object.
+ *
+ * Handles two common patterns:
+ *   - `{ role: 'admin' }` (single role string)
+ *   - `{ roles: ['admin', 'pro'] }` (array — highest-privilege role wins)
+ *
+ * Returns `undefined` when the user object is absent (unauthenticated).
+ */
+export function resolveUserRole(
+  user?: { role?: string; roles?: string[] } | null,
+): string | undefined {
+  if (!user) return undefined;
+  if (user.role) return user.role;
+  if (Array.isArray(user.roles) && user.roles.length > 0) {
+    // Pick the most permissive role based on the limit table
+    return user.roles.reduce((best, current) => {
+      return getComplexityLimit(current) > getComplexityLimit(best) ? current : best;
+    });
+  }
+  return undefined;
+}

--- a/src/graphQL-API/utils/dataloader-factory.ts
+++ b/src/graphQL-API/utils/dataloader-factory.ts
@@ -1,0 +1,5 @@
+export {
+  createDataLoader,
+  createGroupedDataLoader,
+  DataLoaderSet,
+} from '../dataloader-factory';


### PR DESCRIPTION
Closes #921
Closes #879 

---

This PR implements GraphQL query complexity controls with role-based limits to protect against DoS attacks and enable power users to run richer queries. Changes: role-based complexity limits, complexity validation, environment variable support, improved estimator, role resolution, comprehensive tests, and GraphQL layer additions for resolvers, inputs, types, filters, scalars, and plugins.