### PR TITLE
Close dependency health, versioning, permission matrix, and audit trail gaps

### DIFF
--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -70,6 +70,32 @@ X-Deprecation-Notice: This endpoint is deprecated. Use /new-endpoint instead. Su
 | `@Deprecated()` decorator        | `src/versioning/decorators/deprecated.decorator.ts`   | Marks individual endpoints as deprecated                |
 | `@ApiVersion()` decorator        | `src/versioning/decorators/api-version.decorator.ts`  | Tags controllers/handlers with a version string         |
 
+## GraphQL Versioning & Deprecation
+
+The GraphQL surface (`/graphql`) follows the same version registry as REST, exposed
+through two mechanisms instead of response headers (GraphQL has no per-field headers):
+
+- **Schema-level version query** — `ApiVersionResolver` (`src/graphQL-API/resolvers/api-version.resolver.ts`)
+  exposes an `apiVersion` query backed by the same `VersionManagerService` used by REST,
+  so GraphQL clients can read the current version, status, and sunset date:
+  ```graphql
+  query {
+    apiVersion { version status sunsetDate successorVersion description }
+  }
+  ```
+- **Field-level deprecation** — use GraphQL's native `deprecationReason` option (surfaced
+  in introspection and IDEs like GraphiQL/Apollo Studio) on any `@Field()` or `@Query()`
+  that is superseded:
+  ```typescript
+  @Query(() => GqlUserType, { deprecationReason: 'Use `me` instead.' })
+  ```
+
+## REST Endpoints Currently Marked Deprecated
+
+| Endpoint | Sunset | Successor | Reason |
+|---|---|---|---|
+| `GET /trades/user/:userId` | 2025-12-31 | v2 (`GET /trades/user/:userId/history`) | Superseded by a richer, paginated history endpoint. |
+
 ## Adding a New Version
 
 1. Add the version entry to `VersionManagerService.config.versions`:

--- a/docs/AUDIT_TRAIL.md
+++ b/docs/AUDIT_TRAIL.md
@@ -1,0 +1,51 @@
+# Audit Trail for Privileged Administrative Actions
+
+StellarSwipe records privileged actions across two complementary audit trails.
+Both capture **actor, target, timestamp, and reason** and are queryable through
+a dedicated backend endpoint.
+
+## 1. General application audit trail (`src/audit-log`)
+
+Captures account-level admin actions: overrides (`AuditEventType.ADMIN_OVERRIDE`),
+user creation/deletion, wallet changes, exports, API key lifecycle, login/logout.
+Events are emitted via `EventEmitter2` (`audit.*`) and persisted by
+`AuditEventListener` → `AuditService` into the `audit_logs` table
+(`src/audit-log/entities/audit-log.entity.ts`), which stores `userId` (actor),
+`resource`/`resourceId` (target), `createdAt` (timestamp), and `metadata`
+(free-form context, including a reason where the caller supplies one).
+
+**Query endpoints** (`src/audit-log/audit.controller.ts`):
+- `GET /audit/logs` — filterable list (actor, action, date range, pagination).
+- `GET /audit/:id` — single entry.
+- `GET /audit/users/:userId` — full trail for one user.
+- `GET /audit/resources/:resource/:resourceId` — full trail for one resource.
+- `GET /audit/compliance/export/:userId` — compliance export.
+
+## 2. RBAC / permission audit trail (`src/auth/permission-audit.service.ts`)
+
+Captures role and permission changes and workflow approval decisions —
+narrower and more structured than the general trail, with explicit
+before/after diffs:
+
+| Action | Emitted from |
+|---|---|
+| `ROLE_CREATED` / `ROLE_UPDATED` / `ROLE_DELETED` | `RbacService.createRole` / `updateRole` / `deleteRole` |
+| `ROLE_ASSIGNED` / `ROLE_REVOKED` | `RbacService.assignRoleToUser` / `revokeRoleFromUser` |
+| `PERMISSION_GRANTED` | `RbacService.assignPermissionsToRole` |
+| `WORKFLOW_APPROVED` / `WORKFLOW_REJECTED` | `RbacService.approveRequest` / `rejectRequest` |
+
+Each `PermissionAuditLog` row stores `actorId` (who acted), `targetUserId`
+(whose access changed — for workflow decisions, the original requester),
+`createdAt` (timestamp), `beforeState`/`afterState` (diff), and `metadata`
+(includes the approver's `reason`/`comments` for workflow decisions).
+
+**Query endpoint:** `GET /authorization/audit-log` (`RbacController.getPermissionAuditLog`,
+requires `audit:read`), backed by `PermissionAuditService.query()`. Supports
+`actorId`, `targetUserId`, `action`, `from`, `to`, `limit`, `offset` query params.
+
+## Relationship to the permission matrix
+
+Attempts to assign a role a permission that violates `PERMISSION_MATRIX`
+(see `docs/PERMISSION_MATRIX.md`) are rejected with `400 Bad Request` before
+any row is written — so the audit trail only ever contains grants that were
+within policy at the time they were made.

--- a/docs/HEALTH_ENDPOINTS.md
+++ b/docs/HEALTH_ENDPOINTS.md
@@ -10,7 +10,8 @@ This document describes the expected behavior of each health endpoint when indiv
 | `GET /api/v1/health/ready` | Readiness (can traffic be served?) | DB, Redis, queue, Stellar, Soroban |
 | `GET /api/v1/health/liveness` | Alias for `/healthz` | None |
 | `GET /api/v1/health/readiness` | Alias for `/ready` (DB, Redis, queue only) | DB, Redis, queue |
-| `GET /api/v1/health` | Full aggregate check | DB, Redis, Stellar, Soroban, queue |
+| `GET /api/v1/health` | Full aggregate check | DB, Redis, Stellar, Soroban, queue, message broker |
+| `GET /api/v1/health/broker` | Message broker (Kafka) check | Message broker only |
 | `GET /api/v1/health/summary` | Detailed status report | All services with latency |
 
 ---
@@ -96,6 +97,31 @@ This document describes the expected behavior of each health endpoint when indiv
 **Note:** Because Bull is backed by Redis, a Redis outage typically causes both `cache` and `queue` checks to fail simultaneously.
 
 **Recovery:** Restore Redis connectivity. Bull automatically reconnects and resumes processing.
+
+---
+
+### 3b. Message broker (Kafka) unhealthy
+
+**Trigger:** The broker fails to deliver a round-trip probe message (`KafkaHealthIndicator`, `src/health/indicators/kafka.health.ts`).
+
+**Affected endpoints:** `/healthz` ✅ (still 200), `/broker` ❌ (503), aggregate `/health` ❌ (503)
+
+**Response (503):**
+```json
+{
+  "status": "error",
+  "error": {
+    "broker": {
+      "status": "disconnected",
+      "error": "Broker did not deliver the probe message"
+    }
+  }
+}
+```
+
+**Note:** `KafkaService` (`src/streaming/kafka/kafka.service.ts`) is not yet wired into request-handling code paths, so the broker is intentionally excluded from `/ready` and `/readiness` — it does not currently gate traffic. It is included in the full `/health` check and `/health/summary` so operators still get visibility into it.
+
+**Recovery:** Restart the broker connection / underlying pod. Once a real Kafka client replaces the in-process stub, update this indicator to verify actual broker connectivity (e.g. `admin.describeCluster()`).
 
 ---
 
@@ -186,4 +212,18 @@ During the startup window (up to 90s governed by `startupProbe`), the app retrie
 | Stellar down | 200 ✅ | 200 ✅ | 503 ❌ | Remove from rotation |
 | Soroban down | 200 ✅ | 200 ✅ | 503 ❌ | Remove from rotation |
 | Process hung | 503 ❌ | — | — | Restart pod |
+| Broker down | 200 ✅ | 200 ✅ | 200 ✅ | No action — not on the request path |
 | All healthy | 200 ✅ | 200 ✅ | 200 ✅ | Serve traffic |
+
+---
+
+## How These Endpoints Are Consumed
+
+**Kubernetes (`k8s/base/deployment.yaml`):**
+- `startupProbe` and `livenessProbe` both point at `/api/v1/health/live` — process-alive only, so a dependency outage never triggers a pod restart.
+- `readinessProbe` points at `/api/v1/health/ready` — DB, Redis, queue, and blockchain services must all be healthy for the pod to receive traffic.
+
+**Monitoring:**
+- `infrastructure/monitoring/alerts.yml` defines one Prometheus alert per dependency (`DatabaseDown`, `RedisDown`, `StellarHorizonDown`, `SorobanRpcDown`, `MessageBrokerDown`, ...), each firing when its `/api/v1/health/<dependency>` route returns 5xx for a sustained window — this is what pages on-call.
+- Every indicator also reports to the `service_health_status` Prometheus gauge (`recordHealthCheck` in `src/monitoring/metrics/custom-metrics.ts`), scraped independently of the HTTP routes — available for a Grafana panel alongside the request-rate/latency panels already in `infrastructure/monitoring/grafana/dashboards/system-health.json`.
+- `GET /api/v1/health/summary` is the human-readable endpoint operators hit during an incident — it returns latency and structured error detail per dependency in one call, avoiding the need to poll each `/health/<dependency>` route individually.

--- a/docs/PERMISSION_MATRIX.md
+++ b/docs/PERMISSION_MATRIX.md
@@ -1,0 +1,59 @@
+# Permission Matrix
+
+This document is the source of truth for what **admin**, **support**, and
+**service account** roles are allowed to do. The machine-readable version
+lives in `src/authorization/permission-matrix.ts` (`PERMISSION_MATRIX`) and
+is enforced by `PermissionMatrixService`, which `RbacService` calls on every
+role create/update and permission assignment — keep both in sync.
+
+## Role Archetypes
+
+| Archetype | `Role.name` | Who holds it |
+|---|---|---|
+| Admin | `admin` | Platform operators — full control over users, teams, content, billing, system config, trading, analytics, compliance. |
+| Support | `support` | Customer support agents — can manage user accounts and content, but cannot touch billing, team/org structure, or system configuration. |
+| Service account | `service_account` | Machine-to-machine callers (internal jobs, integrations) — scoped to trading and analytics pipelines only, no access to user PII or financial data. |
+
+Only roles whose `name` matches one of the three values above (case-insensitive)
+are constrained by the matrix. Custom/team roles created by `RbacService.createRole`
+with any other name are unaffected — the matrix documents fixed archetypes, not
+every ad-hoc role a team can define.
+
+## Matrix
+
+`PermissionLevel` values, from lowest to highest: `read` < `write` < `delete` < `admin`.
+The table shows the **maximum** level each archetype may hold per category —
+`—` means the archetype must hold no permission at all in that category.
+
+| Category | Admin | Support | Service account |
+|---|---|---|---|
+| `user_management` | admin | write | — |
+| `team_management` | admin | — | — |
+| `content_management` | admin | write | — |
+| `financial` | admin | — | — |
+| `system` | admin | — | read |
+| `trading` | admin | read | write |
+| `analytics` | admin | read | write |
+| `compliance` | admin | read | — |
+
+## Enforcement
+
+- **`PermissionMatrixService.findViolations(roleName, permissions)`** — compares a
+  set of permissions against the ceiling for the role's resolved archetype and
+  returns every permission that exceeds it.
+- **`RbacService`** calls this in `createRole`, `updateRole`, and
+  `assignPermissionsToRole` — attempting to grant `admin`, `support`, or
+  `service_account` a permission above its ceiling throws a `400 Bad Request`
+  before the assignment is persisted.
+- Every role/permission mutation is already recorded by `PermissionAuditService`
+  (see `src/audit-log`), so a rejected assignment shows up as a failed request
+  in application logs, and an accepted one is queryable in the audit trail —
+  see `docs/AUDIT_TRAIL.md`.
+
+## Updating the Matrix
+
+1. Edit `PERMISSION_MATRIX` in `src/authorization/permission-matrix.ts`.
+2. Update the table above to match.
+3. Existing role/permission assignments are **not** retroactively re-validated —
+   only new writes are checked. Audit the current assignments for the affected
+   archetype after tightening a ceiling.

--- a/infrastructure/monitoring/alerts.yml
+++ b/infrastructure/monitoring/alerts.yml
@@ -108,6 +108,19 @@ groups:
           summary: "Soroban RPC health check failing"
           description: "The /health/soroban endpoint has been returning errors for more than 2 minutes."
 
+      # ── Message broker ────────────────────────────────────────────────────
+
+      - alert: MessageBrokerDown
+        expr: |
+          sum(rate(http_requests_total{job="stellarswipe-backend", route="/api/v1/health/broker", status_code=~"5.."}[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+          service: broker
+        annotations:
+          summary: "Message broker health check failing"
+          description: "The /health/broker endpoint has been returning errors for more than 2 minutes."
+
       # ── HTTP error rate ───────────────────────────────────────────────────
 
       - alert: HighErrorRate

--- a/src/auth/permission-audit.service.ts
+++ b/src/auth/permission-audit.service.ts
@@ -21,6 +21,8 @@ export enum AuditAction {
   ROLE_CREATED = 'role_created',
   ROLE_UPDATED = 'role_updated',
   ROLE_DELETED = 'role_deleted',
+  WORKFLOW_APPROVED = 'workflow_approved',
+  WORKFLOW_REJECTED = 'workflow_rejected',
 }
 
 @Entity('permission_audit_logs')

--- a/src/authorization/authorization.module.ts
+++ b/src/authorization/authorization.module.ts
@@ -14,6 +14,7 @@ import { PermissionsGuard } from './guards/permissions.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { WorkflowApprovalGuard } from './guards/workflow-approval.guard';
 import { PermissionAuditService, PermissionAuditLog } from '../auth/permission-audit.service';
+import { PermissionMatrixService } from './permission-matrix.service';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { PermissionAuditService, PermissionAuditLog } from '../auth/permission-a
     RolesGuard,
     WorkflowApprovalGuard,
     PermissionAuditService,
+    PermissionMatrixService,
   ],
   exports: [
     RbacService,
@@ -45,6 +47,7 @@ import { PermissionAuditService, PermissionAuditLog } from '../auth/permission-a
     RolesGuard,
     WorkflowApprovalGuard,
     PermissionAuditService,
+    PermissionMatrixService,
     TypeOrmModule,
   ],
 })

--- a/src/authorization/permission-matrix.service.ts
+++ b/src/authorization/permission-matrix.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common';
+import { Permission, PermissionCategory } from './entities/permission.entity';
+import {
+  PERMISSION_MATRIX,
+  PERMISSION_LEVEL_ORDER,
+  RoleArchetype,
+} from './permission-matrix';
+
+export interface PermissionMatrixViolation {
+  permissionName: string;
+  category: PermissionCategory;
+  requiredLevel: string;
+  maxAllowedLevel: string | null;
+}
+
+/**
+ * Enforces `PERMISSION_MATRIX` against role/permission assignments.
+ *
+ * Only roles whose name matches a known archetype (admin, support,
+ * service_account — case-insensitive) are constrained; custom/team roles
+ * are unaffected, since the matrix documents fixed archetypes, not every
+ * possible custom role a team might create.
+ */
+@Injectable()
+export class PermissionMatrixService {
+  resolveArchetype(roleName: string): RoleArchetype | null {
+    const normalized = roleName?.trim().toLowerCase();
+    switch (normalized) {
+      case RoleArchetype.ADMIN:
+        return RoleArchetype.ADMIN;
+      case RoleArchetype.SUPPORT:
+        return RoleArchetype.SUPPORT;
+      case RoleArchetype.SERVICE_ACCOUNT:
+        return RoleArchetype.SERVICE_ACCOUNT;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Returns every permission that exceeds what the matrix allows for the
+   * given role name's archetype. An empty array means the assignment is
+   * consistent with the matrix (or the role isn't a recognized archetype).
+   */
+  findViolations(
+    roleName: string,
+    permissions: Pick<Permission, 'name' | 'category' | 'level'>[],
+  ): PermissionMatrixViolation[] {
+    const archetype = this.resolveArchetype(roleName);
+    if (!archetype) {
+      return [];
+    }
+
+    const ceiling = PERMISSION_MATRIX[archetype];
+    const violations: PermissionMatrixViolation[] = [];
+
+    for (const permission of permissions) {
+      const maxAllowedLevel = ceiling[permission.category] ?? null;
+
+      if (
+        maxAllowedLevel === null ||
+        PERMISSION_LEVEL_ORDER.indexOf(permission.level) >
+          PERMISSION_LEVEL_ORDER.indexOf(maxAllowedLevel)
+      ) {
+        violations.push({
+          permissionName: permission.name,
+          category: permission.category,
+          requiredLevel: permission.level,
+          maxAllowedLevel,
+        });
+      }
+    }
+
+    return violations;
+  }
+}

--- a/src/authorization/permission-matrix.ts
+++ b/src/authorization/permission-matrix.ts
@@ -1,0 +1,64 @@
+import { PermissionCategory, PermissionLevel } from './entities/permission.entity';
+
+/**
+ * Canonical role archetypes covered by the permission matrix.
+ * A `Role` is matched to an archetype by its `name` (see
+ * `PermissionMatrixService.resolveArchetype`) — this keeps the matrix
+ * decoupled from the free-form custom roles teams create for themselves.
+ */
+export enum RoleArchetype {
+  ADMIN = 'admin',
+  SUPPORT = 'support',
+  SERVICE_ACCOUNT = 'service_account',
+}
+
+/**
+ * The maximum `PermissionLevel` each archetype may hold per
+ * `PermissionCategory`. `null` means the archetype must never hold any
+ * permission in that category.
+ *
+ * This is the source of truth referenced by `docs/PERMISSION_MATRIX.md` —
+ * update both together.
+ */
+export const PERMISSION_MATRIX: Record<
+  RoleArchetype,
+  Partial<Record<PermissionCategory, PermissionLevel>>
+> = {
+  [RoleArchetype.ADMIN]: {
+    [PermissionCategory.USER_MANAGEMENT]: PermissionLevel.ADMIN,
+    [PermissionCategory.TEAM_MANAGEMENT]: PermissionLevel.ADMIN,
+    [PermissionCategory.CONTENT_MANAGEMENT]: PermissionLevel.ADMIN,
+    [PermissionCategory.FINANCIAL]: PermissionLevel.ADMIN,
+    [PermissionCategory.SYSTEM]: PermissionLevel.ADMIN,
+    [PermissionCategory.TRADING]: PermissionLevel.ADMIN,
+    [PermissionCategory.ANALYTICS]: PermissionLevel.ADMIN,
+    [PermissionCategory.COMPLIANCE]: PermissionLevel.ADMIN,
+  },
+  [RoleArchetype.SUPPORT]: {
+    [PermissionCategory.USER_MANAGEMENT]: PermissionLevel.WRITE,
+    [PermissionCategory.CONTENT_MANAGEMENT]: PermissionLevel.WRITE,
+    [PermissionCategory.TRADING]: PermissionLevel.READ,
+    [PermissionCategory.ANALYTICS]: PermissionLevel.READ,
+    [PermissionCategory.COMPLIANCE]: PermissionLevel.READ,
+    // No TEAM_MANAGEMENT, FINANCIAL, or SYSTEM access — support cannot
+    // change billing, org structure, or infrastructure config.
+  },
+  [RoleArchetype.SERVICE_ACCOUNT]: {
+    [PermissionCategory.TRADING]: PermissionLevel.WRITE,
+    [PermissionCategory.ANALYTICS]: PermissionLevel.WRITE,
+    [PermissionCategory.SYSTEM]: PermissionLevel.READ,
+    // Service accounts are machine callers scoped to trading/analytics
+    // pipelines — no access to user PII, financial, team, or compliance data.
+  },
+};
+
+/**
+ * PermissionLevel ordering used to compare a requested level against the
+ * matrix ceiling (mirrors `Permission.matchesLevel`).
+ */
+export const PERMISSION_LEVEL_ORDER: PermissionLevel[] = [
+  PermissionLevel.READ,
+  PermissionLevel.WRITE,
+  PermissionLevel.DELETE,
+  PermissionLevel.ADMIN,
+];

--- a/src/authorization/rbac.controller.ts
+++ b/src/authorization/rbac.controller.ts
@@ -67,6 +67,28 @@ export class RbacController {
     return this.rbacService.getRoles({ teamId, organizationId });
   }
 
+  @Get('audit-log')
+  @RequirePermissions('audit:read')
+  async getPermissionAuditLog(
+    @Query('actorId') actorId?: string,
+    @Query('targetUserId') targetUserId?: string,
+    @Query('action') action?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.rbacService.queryPermissionAuditLog({
+      actorId,
+      targetUserId,
+      action: action as any,
+      from: from ? new Date(from) : undefined,
+      to: to ? new Date(to) : undefined,
+      limit: limit ? Number(limit) : undefined,
+      offset: offset ? Number(offset) : undefined,
+    });
+  }
+
   // Permission Management Endpoints
   @Post('permissions/assign')
   @RequirePermissions('permissions:assign')

--- a/src/authorization/rbac.service.ts
+++ b/src/authorization/rbac.service.ts
@@ -13,6 +13,7 @@ import { CreateWorkflowDto, UpdateWorkflowDto } from './dto/workflow-config.dto'
 import { CreateAccessRequestDto, ApproveRequestDto, RejectRequestDto } from './dto/access-request.dto';
 import { IPermissionContext } from './interfaces/permission.interface';
 import { PermissionAuditService, AuditAction, diffObjects } from '../auth/permission-audit.service';
+import { PermissionMatrixService } from './permission-matrix.service';
 
 @Injectable()
 export class RbacService {
@@ -33,7 +34,26 @@ export class RbacService {
     private policyEvaluator: PolicyEvaluator,
     private dataSource: DataSource,
     private permissionAuditService: PermissionAuditService,
+    private permissionMatrixService: PermissionMatrixService,
   ) {}
+
+  /**
+   * Guards role/permission writes against `PERMISSION_MATRIX`
+   * (docs/PERMISSION_MATRIX.md) for admin/support/service_account roles.
+   */
+  private enforcePermissionMatrix(roleName: string, permissions: Permission[]): void {
+    const violations = this.permissionMatrixService.findViolations(roleName, permissions);
+    if (violations.length > 0) {
+      throw new BadRequestException(
+        `Permission matrix violation for role "${roleName}": ${violations
+          .map(
+            (v) =>
+              `${v.permissionName} (${v.category}) requires "${v.requiredLevel}" but the matrix caps this archetype at "${v.maxAllowedLevel ?? 'none'}"`,
+          )
+          .join('; ')}`,
+      );
+    }
+  }
 
   // Role Management
   async createRole(dto: CreateRoleDto, createdBy: string): Promise<Role> {
@@ -44,6 +64,9 @@ export class RbacService {
 
     if (dto.permissionIds?.length) {
       const permissions = await this.permissionRepository.findByIds(dto.permissionIds);
+      if (dto.name) {
+        this.enforcePermissionMatrix(dto.name, permissions);
+      }
       role.permissions = permissions;
     }
 
@@ -82,6 +105,7 @@ export class RbacService {
 
     if (dto.permissionIds) {
       const permissions = await this.permissionRepository.findByIds(dto.permissionIds);
+      this.enforcePermissionMatrix(role.name, permissions);
       role.permissions = permissions;
     }
 
@@ -191,6 +215,7 @@ export class RbacService {
     const previousPermissionIds = role.permissions?.map((p) => p.id) ?? [];
 
     const permissions = await this.permissionRepository.findByIds(dto.permissionIds);
+    this.enforcePermissionMatrix(role.name, permissions);
     role.permissions = permissions;
 
     const saved = await this.roleRepository.save(role);
@@ -316,6 +341,23 @@ export class RbacService {
       relations: ['role'],
       order: { createdAt: 'DESC' },
     });
+  }
+
+  /**
+   * Query the privileged-action audit trail — role changes, permission
+   * grants, and workflow approvals/rejections. Backs the
+   * `GET /authorization/audit-log` endpoint (see docs/AUDIT_TRAIL.md).
+   */
+  async queryPermissionAuditLog(query: {
+    actorId?: string;
+    targetUserId?: string;
+    action?: AuditAction;
+    from?: Date;
+    to?: Date;
+    limit?: number;
+    offset?: number;
+  }): ReturnType<PermissionAuditService['query']> {
+    return this.permissionAuditService.query(query);
   }
 
   // Permission Checking
@@ -499,7 +541,22 @@ export class RbacService {
       request.approvedAt = new Date();
     }
 
-    return this.requestRepository.save(request);
+    const saved = await this.requestRepository.save(request);
+
+    await this.permissionAuditService.log({
+      actorId: approverId,
+      targetUserId: request.requesterId,
+      action: AuditAction.WORKFLOW_APPROVED,
+      resourceName: request.title,
+      metadata: {
+        requestId,
+        workflowId: request.workflowId,
+        reason: dto.comments,
+        fullyApproved: decision.approved,
+      },
+    });
+
+    return saved;
   }
 
   async rejectRequest(
@@ -535,7 +592,22 @@ export class RbacService {
     request.status = 'rejected' as any;
     request.rejectionReason = dto.reason;
 
-    return this.requestRepository.save(request);
+    const saved = await this.requestRepository.save(request);
+
+    await this.permissionAuditService.log({
+      actorId: approverId,
+      targetUserId: request.requesterId,
+      action: AuditAction.WORKFLOW_REJECTED,
+      resourceName: request.title,
+      metadata: {
+        requestId,
+        workflowId: request.workflowId,
+        reason: dto.reason,
+        comments: dto.comments,
+      },
+    });
+
+    return saved;
   }
 
   async checkRequiresWorkflowApproval(

--- a/src/graphQL-API/graphql.module.ts
+++ b/src/graphQL-API/graphql.module.ts
@@ -42,6 +42,7 @@ import { PortfolioResolver } from './resolvers/portfolio.resolver';
 import { ProviderResolver } from './resolvers/provider.resolver';
 import { UserResolver } from './resolvers/user.resolver';
 import { SignalSubscriptionResolver } from './signal-subscription.resolver';
+import { ApiVersionResolver } from './resolvers/api-version.resolver';
 
 // ─── Domain modules ───────────────────────────────────────────────────────────
 import { SignalsModule } from '../signals/signals.module';
@@ -51,6 +52,7 @@ import { ProvidersModule } from '../providers/providers.module';
 import { UsersModule } from '../users/users.module';
 import { AssetsModule } from '../assets/assets.module';
 import { AuthorizationModule } from '../authorization/authorization.module';
+import { VersioningModule } from '../versioning/versioning.module';
 
 // ─── Utils ────────────────────────────────────────────────────────────────────
 import { createDataLoader, createGroupedDataLoader } from './utils/dataloader-factory';
@@ -72,6 +74,7 @@ import { AssetsService } from '../assets/assets.service';
     AssetsModule,
     UsersModule,
     AuthorizationModule,
+    VersioningModule,
 
     // AuthModule → SessionManagerService (session-revocation check reused by
     // the subscription handshake authenticator below).
@@ -232,6 +235,7 @@ import { AssetsService } from '../assets/assets.service';
     ProviderResolver,
     UserResolver,
     SignalSubscriptionResolver,
+    ApiVersionResolver,
   ],
 
   exports: [GqlAuthGuard],

--- a/src/graphQL-API/resolvers/api-version.resolver.ts
+++ b/src/graphQL-API/resolvers/api-version.resolver.ts
@@ -1,0 +1,46 @@
+import { Resolver, Query, ObjectType, Field } from '@nestjs/graphql';
+import { VersionManagerService } from '../../versioning/version-manager.service';
+
+@ObjectType()
+export class GqlApiVersionType {
+  @Field()
+  version: string;
+
+  @Field()
+  status: string;
+
+  @Field({ nullable: true })
+  sunsetDate?: string;
+
+  @Field({ nullable: true })
+  successorVersion?: string;
+
+  @Field()
+  description: string;
+}
+
+/**
+ * Exposes the same version/deprecation metadata REST clients get via
+ * response headers (see VersionResolverMiddleware) to GraphQL clients,
+ * which have no HTTP headers to inspect per-field.
+ */
+@Resolver()
+export class ApiVersionResolver {
+  constructor(private readonly versionManager: VersionManagerService) {}
+
+  @Query(() => GqlApiVersionType, {
+    description: 'Current GraphQL schema version and deprecation status.',
+  })
+  apiVersion(): GqlApiVersionType {
+    const version = this.versionManager.getDefaultVersion();
+    const metadata = this.versionManager.getVersionMetadata(version);
+
+    return {
+      version,
+      status: metadata?.status ?? 'unknown',
+      sunsetDate: metadata?.sunsetDate,
+      successorVersion: metadata?.successorVersion,
+      description: metadata?.description ?? '',
+    };
+  }
+}

--- a/src/health/health-summary.service.ts
+++ b/src/health/health-summary.service.ts
@@ -11,6 +11,7 @@ import {
   DatabaseHealthIndicator,
   RedisHealthIndicator,
   QueueHealthIndicator,
+  KafkaHealthIndicator,
 } from './indicators';
 import { PrometheusService } from '../monitoring/metrics/prometheus.service';
 import { recordHealthCheck } from '../monitoring/metrics/custom-metrics';
@@ -24,6 +25,7 @@ export interface ServiceHealthSummary {
     stellar: HealthStatus;
     soroban: HealthStatus;
     queue: HealthStatus;
+    broker: HealthStatus;
   };
   uptime: number;
   version: string;
@@ -56,6 +58,7 @@ export class HealthSummaryService {
     private databaseHealth: DatabaseHealthIndicator,
     private redisHealth: RedisHealthIndicator,
     private queueHealth: QueueHealthIndicator,
+    private kafkaHealth: KafkaHealthIndicator,
     private prometheus: PrometheusService,
     private configService: ConfigService,
   ) {}
@@ -67,6 +70,7 @@ export class HealthSummaryService {
       this.checkStellar(),
       this.checkSoroban(),
       this.checkQueue(),
+      this.checkBroker(),
     ]);
 
     const services: ServiceHealthSummary['services'] = {
@@ -75,6 +79,7 @@ export class HealthSummaryService {
       stellar: this.extractHealthStatus(results[2]),
       soroban: this.extractHealthStatus(results[3]),
       queue: this.extractHealthStatus(results[4]),
+      broker: this.extractHealthStatus(results[5]),
     };
 
     const overall = this.determineOverallStatus(services);
@@ -158,6 +163,21 @@ export class HealthSummaryService {
       recordHealthCheck(this.prometheus, 'queue', false);
       return {
         queue: { status: 'down', error: (error as Error).message },
+        responseTime: Date.now() - start,
+      };
+    }
+  }
+
+  private async checkBroker(): Promise<HealthIndicatorResultWithResponseTime> {
+    const start = Date.now();
+    try {
+      const result = await this.kafkaHealth.isHealthy('broker');
+      recordHealthCheck(this.prometheus, 'broker', true);
+      return { ...result, responseTime: Date.now() - start };
+    } catch (error) {
+      recordHealthCheck(this.prometheus, 'broker', false);
+      return {
+        broker: { status: 'down', error: (error as Error).message },
         responseTime: Date.now() - start,
       };
     }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -16,6 +16,7 @@ import {
   DatabaseHealthIndicator,
   RedisHealthIndicator,
   QueueHealthIndicator,
+  KafkaHealthIndicator,
 } from './indicators';
 import {
   HealthSummaryService,
@@ -37,6 +38,7 @@ export class HealthController implements OnApplicationBootstrap {
     private databaseHealth: DatabaseHealthIndicator,
     private redisHealth: RedisHealthIndicator,
     private queueHealth: QueueHealthIndicator,
+    private kafkaHealth: KafkaHealthIndicator,
     private healthSummary: HealthSummaryService,
   ) {}
 
@@ -79,7 +81,18 @@ export class HealthController implements OnApplicationBootstrap {
       () => this.stellarHealth.isHealthy('stellar'),
       () => this.sorobanHealth.isHealthy('soroban'),
       () => this.queueHealth.isHealthy('queue'),
+      () => this.kafkaHealth.isHealthy('broker'),
     ]);
+  }
+
+  /**
+   * Message broker (Kafka) health — kept out of readiness/ready since no
+   * request path currently depends on it synchronously.
+   */
+  @Get('broker')
+  @HealthCheck()
+  async checkBroker(): Promise<HealthCheckResult> {
+    return this.health.check([() => this.kafkaHealth.isHealthy('broker')]);
   }
 
   @Get('stellar')

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -8,6 +8,7 @@ import {
   DatabaseHealthIndicator,
   RedisHealthIndicator,
   QueueHealthIndicator,
+  KafkaHealthIndicator,
 } from './indicators';
 import { StellarConfigService } from '../config/stellar.service';
 import { HealthSummaryService } from './health-summary.service';
@@ -17,6 +18,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../users/entities/user.entity';
 import { Signal } from '../signals/entities/signal.entity';
 import { Trade } from '../trades/entities/trade.entity';
+import { StreamingModule } from '../streaming/streaming.module';
 
 @Module({
   imports: [
@@ -24,6 +26,7 @@ import { Trade } from '../trades/entities/trade.entity';
     MonitoringModule,
     BullModule.registerQueue({ name: 'priority-queue' }),
     TypeOrmModule.forFeature([User, Signal, Trade]),
+    StreamingModule,
   ],
   controllers: [HealthController],
   providers: [
@@ -33,6 +36,7 @@ import { Trade } from '../trades/entities/trade.entity';
     DatabaseHealthIndicator,
     RedisHealthIndicator,
     QueueHealthIndicator,
+    KafkaHealthIndicator,
     HealthSummaryService,
     SyntheticMonitoringService,
   ],
@@ -42,6 +46,7 @@ import { Trade } from '../trades/entities/trade.entity';
     DatabaseHealthIndicator,
     RedisHealthIndicator,
     QueueHealthIndicator,
+    KafkaHealthIndicator,
     HealthSummaryService,
     SyntheticMonitoringService,
   ],

--- a/src/health/indicators/index.ts
+++ b/src/health/indicators/index.ts
@@ -4,3 +4,4 @@ export * from './database.health';
 export * from './redis.health';
 export * from './queue.health';
 export * from './bullmq.health';
+export * from './kafka.health';

--- a/src/health/indicators/kafka.health.ts
+++ b/src/health/indicators/kafka.health.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { KafkaService } from '../../streaming/kafka/kafka.service';
+import { KafkaTopics } from '../../streaming/kafka/topics/kafka.topics';
+
+/**
+ * Health indicator for the message broker (Kafka).
+ *
+ * The current KafkaService is an in-process event bus (no external broker
+ * connection yet), so "healthy" means the service can register and dispatch
+ * a probe message end-to-end. Once a real Kafka client replaces the stub,
+ * this check should be updated to verify broker connectivity instead.
+ */
+@Injectable()
+export class KafkaHealthIndicator extends HealthIndicator {
+  constructor(private readonly kafkaService: KafkaService) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const startTime = Date.now();
+    const probeTopic = `${Object.values(KafkaTopics)[0] ?? 'health-probe'}.__health__`;
+
+    try {
+      let received = false;
+      const handler = () => {
+        received = true;
+      };
+
+      this.kafkaService.subscribe(probeTopic, 'health-check', handler);
+      this.kafkaService.emit(probeTopic, {
+        key: 'health-check',
+        value: { probe: true },
+        timestamp: new Date(),
+      });
+      this.kafkaService.unsubscribe(probeTopic, handler);
+
+      const latency = Date.now() - startTime;
+
+      if (!received) {
+        throw new Error('Broker did not deliver the probe message');
+      }
+
+      return this.getStatus(key, true, {
+        status: 'connected',
+        consumerGroups: this.kafkaService.getConsumerGroups().size,
+        latency: `${latency}ms`,
+      });
+    } catch (error) {
+      const latency = Date.now() - startTime;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      throw new HealthCheckError(
+        'Message broker check failed',
+        this.getStatus(key, false, {
+          status: 'disconnected',
+          error: errorMessage,
+          latency: `${latency}ms`,
+        }),
+      );
+    }
+  }
+}

--- a/src/trades/trades.controller.ts
+++ b/src/trades/trades.controller.ts
@@ -53,6 +53,7 @@ import {
   CloseTradeResultDto,
 } from './dto/trade-result.dto';
 import { PaginatedTradeHistoryDto } from './trade-history.service';
+import { Deprecated } from '../versioning/decorators/deprecated.decorator';
 
 @Controller('trades')
 @UseInterceptors(IdempotencyInterceptor)
@@ -207,6 +208,11 @@ export class TradesController {
    */
   @Get('user/:userId')
   @RequireScopes(ApiKeyScope.TRADES_READ)
+  @Deprecated({
+    sunsetDate: '2025-12-31',
+    successorVersion: '2',
+    reason: 'Use GET /trades/user/:userId/history instead, which supports richer filtering and pagination.',
+  })
   async getUserTrades(
     @Param('userId', ParseUUIDPipe) userId: string,
     @Query('status') status?: string,


### PR DESCRIPTION
## Summary

Each of these areas already had substantial infrastructure in the repo; this PR closes the specific gaps against each issue's acceptance criteria rather than re-implementing what already existed.

**#958 — Dependency health checks**
- The message broker (Kafka) was the only dependency in the issue with no health check at all. Added `KafkaHealthIndicator` (round-trip probe through `KafkaService`) and wired it into the aggregate `/health` check, a new `/health/broker` endpoint, `/health/summary`, and a new `MessageBrokerDown` Prometheus alert.
- Documented deployment/monitoring consumption (k8s probes, alerting, Grafana) in `docs/HEALTH_ENDPOINTS.md`.

**#959 — API versioning & deprecation**
- The versioning/deprecation infrastructure (middleware, interceptor, decorators) existed but was applied to zero endpoints and had no GraphQL story. Applied `@Deprecated()` to the legacy `GET /trades/user/:userId` endpoint (superseded by `/history`).
- Added an `apiVersion` GraphQL query (`ApiVersionResolver`) backed by the same `VersionManagerService` REST uses, and documented the REST + GraphQL versioning strategy in `docs/API_VERSIONING.md`.

**#960 — Permission matrix**
- Added a documented, machine-readable permission matrix (`src/authorization/permission-matrix.ts`) for the `admin`/`support`/`service_account` archetypes.
- `PermissionMatrixService` enforces it inside `RbacService` on every role create/update/permission-assignment — writes that exceed the matrix are rejected with 400 before being persisted. Documented in `docs/PERMISSION_MATRIX.md`.

**#961 — Audit trail for privileged actions**
- Workflow approvals/rejections (`RbacService.approveRequest`/`rejectRequest`) previously recorded no audit trail at all — added `WORKFLOW_APPROVED`/`WORKFLOW_REJECTED` audit events capturing actor, target, timestamp, and reason.
- The existing `PermissionAuditService.query()` had no HTTP endpoint — added `GET /authorization/audit-log`. Documented both audit trails (general + RBAC) in `docs/AUDIT_TRAIL.md`.

Closes #958
Closes #959
Closes #960
Closes #961

## Test plan

- [ ] No automated tests were added or run for this change (scoped out per task instructions); a full `npm run build`/`nest build` could not be executed in this environment (no `node_modules` installed).
- [ ] Manual review of each changed file for type/import correctness was performed in place of a build.