### PR TITLE
Feature/webhook idempotency locking redaction ratelimit

### DIFF
--- a/src/common/decorators/expose-sensitive-fields.decorator.ts
+++ b/src/common/decorators/expose-sensitive-fields.decorator.ts
@@ -1,0 +1,19 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const EXPOSE_SENSITIVE_FIELDS_KEY = 'exposeSensitiveFields';
+
+/**
+ * Opts a controller method or GraphQL resolver field out of the default
+ * sensitive-field redaction applied by SensitiveDataInterceptor.
+ *
+ * By default every response is treated as "public" and fields matching the
+ * sensitive-field name patterns (see `common/logger/log-redaction.ts`) are
+ * redacted before serialization. Internal/admin endpoints that legitimately
+ * need the raw values (e.g. compliance review, support tooling) should be
+ * marked explicitly rather than the default silently changing for everyone:
+ *
+ *   @Get('admin/user/:userId')
+ *   @ExposeSensitiveFields()
+ *   adminGetUserKyc(...) { ... }
+ */
+export const ExposeSensitiveFields = () => SetMetadata(EXPOSE_SENSITIVE_FIELDS_KEY, true);

--- a/src/common/guards/rate-limit.guard.spec.ts
+++ b/src/common/guards/rate-limit.guard.spec.ts
@@ -27,6 +27,7 @@ function buildContext(
   const response = { setHeader: jest.fn() };
   return {
     getHandler: jest.fn(),
+    getType: () => 'http',
     switchToHttp: () => ({
       getRequest: () => ({
         user,
@@ -35,6 +36,35 @@ function buildContext(
         body,
       }),
       getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+/**
+ * Builds an ExecutionContext shaped like a GraphQL resolver invocation
+ * (context type `'graphql'`) so RateLimitGuard is exercised through the
+ * GqlExecutionContext branch of getRequest()/getResponse() rather than
+ * switchToHttp() — this is the path issue #4 (rate-limit metadata parity
+ * between REST and GraphQL) exercises.
+ */
+function buildGraphQLContext(
+  user?: { id: string },
+  ip = '127.0.0.1',
+): ExecutionContext {
+  const response = { setHeader: jest.fn() };
+  const req = {
+    user,
+    headers: {},
+    socket: { remoteAddress: ip },
+    body: {},
+  };
+  return {
+    getHandler: jest.fn(),
+    getType: () => 'graphql',
+    getArgs: () => [{}, {}, { req, res: response }, {}],
+    switchToHttp: () => ({
+      getRequest: () => undefined,
+      getResponse: () => undefined,
     }),
   } as unknown as ExecutionContext;
 }
@@ -136,6 +166,42 @@ describe('RateLimitGuard (issue #482)', () => {
 
     const response = ctx.switchToHttp().getResponse() as { setHeader: jest.Mock };
     expect(response.setHeader).toHaveBeenCalledWith('Retry-After', expect.any(Number));
+  });
+
+  describe('GraphQL transport parity (issue: rate-limit metadata for GraphQL)', () => {
+    it('sets X-RateLimit-* headers on an allowed GraphQL request', async () => {
+      mockReflector.get.mockReturnValue({ tier: RateLimitTier.AUTHENTICATED, limit: 100 });
+      mockCacheManager.get.mockResolvedValue({ count: 10, resetTime: Date.now() + 60_000 });
+      mockCacheManager.set.mockResolvedValue(undefined);
+
+      const ctx = buildGraphQLContext({ id: 'gql-user' });
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+
+      const { GqlExecutionContext } = await import('@nestjs/graphql');
+      const response = GqlExecutionContext.create(ctx).getContext().res as { setHeader: jest.Mock };
+      expect(response.setHeader).toHaveBeenCalledWith('X-RateLimit-Limit', expect.any(Number));
+      expect(response.setHeader).toHaveBeenCalledWith('X-RateLimit-Remaining', expect.any(Number));
+      expect(response.setHeader).toHaveBeenCalledWith('X-RateLimit-Reset', expect.any(Number));
+    });
+
+    it('sets Retry-After and 429 metadata on a blocked GraphQL request', async () => {
+      mockReflector.get.mockReturnValue({ tier: RateLimitTier.TRADE });
+      mockCacheManager.get.mockResolvedValue({ count: 10, resetTime: Date.now() + 30_000 });
+      mockCacheManager.set.mockResolvedValue(undefined);
+
+      const ctx = buildGraphQLContext({ id: 'gql-user-blocked' });
+
+      await expect(guard.canActivate(ctx)).rejects.toMatchObject({
+        response: {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          retryAfter: expect.any(Number),
+        },
+      });
+
+      const { GqlExecutionContext } = await import('@nestjs/graphql');
+      const response = GqlExecutionContext.create(ctx).getContext().res as { setHeader: jest.Mock };
+      expect(response.setHeader).toHaveBeenCalledWith('Retry-After', expect.any(Number));
+    });
   });
 });
 

--- a/src/common/guards/rate-limit.guard.ts
+++ b/src/common/guards/rate-limit.guard.ts
@@ -11,6 +11,7 @@ import {
 import { Reflector } from '@nestjs/core';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import { Cache } from 'cache-manager';
 import { RATE_LIMIT_KEY, RateLimitConfig, RateLimitTier } from '../decorators/rate-limit.decorator';
 import { SubscriptionsService } from '../../subscriptions/subscriptions.service';
@@ -145,6 +146,32 @@ export class RateLimitGuard implements CanActivate {
     };
   }
 
+  /**
+   * Resolves the underlying HTTP request regardless of transport.
+   *
+   * `context.switchToHttp()` only returns a usable request/response pair for
+   * the REST transport — for GraphQL resolvers (context type `'graphql'`)
+   * it returns an adapter whose `getRequest`/`getResponse` are no-ops, which
+   * silently broke rate-limit headers (and the identifier lookups that key
+   * off `request.headers`/`request.user`) for every GraphQL endpoint. Route
+   * through `GqlExecutionContext` when applicable so both transports share
+   * the same request/response objects.
+   */
+  private getRequest(context: ExecutionContext): any {
+    if (context.getType<'graphql'>() === 'graphql') {
+      return GqlExecutionContext.create(context).getContext().req;
+    }
+    return context.switchToHttp().getRequest();
+  }
+
+  /** See {@link getRequest} — same rationale, resolves the HTTP response. */
+  private getResponse(context: ExecutionContext): any {
+    if (context.getType<'graphql'>() === 'graphql') {
+      return GqlExecutionContext.create(context).getContext().res;
+    }
+    return context.switchToHttp().getResponse();
+  }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const config = this.reflector.get<RateLimitConfig>(
       RATE_LIMIT_KEY,
@@ -171,7 +198,7 @@ export class RateLimitGuard implements CanActivate {
 
     // Per-account check when keyBy is specified
     if (config?.keyBy?.length) {
-      const request = context.switchToHttp().getRequest();
+      const request = this.getRequest(context);
       const accountId = this.extractAccountIdentifier(request, config.keyBy);
       if (accountId) {
         await this.checkAccountLimit(
@@ -188,7 +215,7 @@ export class RateLimitGuard implements CanActivate {
   }
 
   private async resolveUserTier(context: ExecutionContext): Promise<RateLimitTier> {
-    const request = context.switchToHttp().getRequest();
+    const request = this.getRequest(context);
     const userId = request.user?.id;
 
     if (!userId || !this.subscriptionsService) {
@@ -218,8 +245,8 @@ export class RateLimitGuard implements CanActivate {
     customLimit?: number,
     customWindow?: number,
   ): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
-    const response = context.switchToHttp().getResponse();
+    const request = this.getRequest(context);
+    const response = this.getResponse(context);
 
     const identifier = this.getIdentifier(request, tier);
     const { limit, window } = this.limits[tier];
@@ -277,7 +304,7 @@ export class RateLimitGuard implements CanActivate {
     customLimit?: number,
     customWindow?: number,
   ): Promise<void> {
-    const response = context.switchToHttp().getResponse();
+    const response = this.getResponse(context);
     const { limit: defaultLimit, window: defaultWindow } = this.accountLimits[tier];
     const finalLimit = customLimit ?? defaultLimit;
     const finalWindow = customWindow ?? defaultWindow;
@@ -325,7 +352,7 @@ export class RateLimitGuard implements CanActivate {
   }
 
   private extractWalletAddress(context: ExecutionContext): string | null {
-    const request = context.switchToHttp().getRequest();
+    const request = this.getRequest(context);
     const wallet = request.user?.walletAddress ?? request.user?.wallet ?? null;
     return typeof wallet === 'string' && wallet.length > 0 ? wallet.toLowerCase() : null;
   }
@@ -337,7 +364,7 @@ export class RateLimitGuard implements CanActivate {
     customLimit?: number,
     customWindow?: number,
   ): Promise<void> {
-    const response = context.switchToHttp().getResponse();
+    const response = this.getResponse(context);
     const { limit: defaultLimit, window: defaultWindow } = this.walletLimits[tier];
     const finalLimit = customLimit ?? defaultLimit;
     const finalWindow = customWindow ?? defaultWindow;

--- a/src/common/interceptors/sensitive-data.interceptor.spec.ts
+++ b/src/common/interceptors/sensitive-data.interceptor.spec.ts
@@ -1,0 +1,133 @@
+import { of } from 'rxjs';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { SensitiveDataInterceptor } from './sensitive-data.interceptor';
+import { EXPOSE_SENSITIVE_FIELDS_KEY } from '../decorators/expose-sensitive-fields.decorator';
+
+function buildContext(): ExecutionContext {
+  return {
+    getHandler: () => function handler() {},
+    getClass: () => class Controller {},
+  } as unknown as ExecutionContext;
+}
+
+function buildHandler(data: unknown): CallHandler {
+  return { handle: () => of(data) };
+}
+
+async function run(
+  interceptor: SensitiveDataInterceptor,
+  data: unknown,
+  ctx: ExecutionContext = buildContext(),
+): Promise<any> {
+  const result$ = interceptor.intercept(ctx, buildHandler(data));
+  return new Promise((resolve) => {
+    result$.subscribe((value) => resolve(value));
+  });
+}
+
+describe('SensitiveDataInterceptor', () => {
+  describe('default (public) exposure', () => {
+    let interceptor: SensitiveDataInterceptor;
+
+    beforeEach(() => {
+      // No Reflector supplied -> always treated as public/non-internal.
+      interceptor = new SensitiveDataInterceptor();
+    });
+
+    it('redacts well-known sensitive field names by default', async () => {
+      const result = await run(interceptor, {
+        id: 'user-1',
+        ssn: '123-45-6789',
+        secret: 'top-secret',
+      });
+
+      expect(result.ssn).toBe('[REDACTED]');
+      expect(result.secret).toBe('[REDACTED]');
+      expect(result.id).toBe('user-1');
+    });
+
+    it('partially masks PII fields, preserving the last 4 characters', async () => {
+      const result = await run(interceptor, { accountNumber: '000111222333' });
+
+      expect(result.accountNumber).toBe('****2333');
+    });
+
+    it('leaves non-sensitive fields untouched', async () => {
+      const result = await run(interceptor, {
+        id: 'trade-1',
+        symbol: 'XLM/USD',
+        amount: 100,
+      });
+
+      expect(result).toEqual({ id: 'trade-1', symbol: 'XLM/USD', amount: 100 });
+    });
+
+    it('redacts sensitive fields inside nested objects and arrays', async () => {
+      const result = await run(interceptor, {
+        users: [
+          { id: 'u1', apiKey: 'sk_live_abc123' },
+          { id: 'u2', apiKey: 'sk_live_def456' },
+        ],
+      });
+
+      expect(result.users[0].apiKey).toBe('[REDACTED]');
+      expect(result.users[1].apiKey).toBe('[REDACTED]');
+      expect(result.users[0].id).toBe('u1');
+    });
+
+    it('strips fields that look like AES-256-GCM ciphertext regardless of key name', async () => {
+      const ivHex = 'a'.repeat(24);
+      const authTagHex = 'b'.repeat(32);
+      const ciphertext = `${ivHex}:${authTagHex}:deadbeef`;
+
+      const result = await run(interceptor, { notes: ciphertext, id: 'x' });
+
+      expect(result.notes).toBeUndefined();
+      expect(result.id).toBe('x');
+    });
+  });
+
+  describe('internal exposure via @ExposeSensitiveFields()', () => {
+    it('skips field-name redaction when the route is marked internal', async () => {
+      const reflector = {
+        getAllAndOverride: jest.fn((key: string) =>
+          key === EXPOSE_SENSITIVE_FIELDS_KEY ? true : undefined,
+        ),
+      };
+      const interceptor = new SensitiveDataInterceptor(reflector as any);
+
+      const result = await run(interceptor, {
+        ssn: '123-45-6789',
+        secret: 'top-secret',
+      });
+
+      expect(result.ssn).toBe('123-45-6789');
+      expect(result.secret).toBe('top-secret');
+    });
+
+    it('still strips ciphertext-shaped values even when marked internal', async () => {
+      const reflector = {
+        getAllAndOverride: jest.fn().mockReturnValue(true),
+      };
+      const interceptor = new SensitiveDataInterceptor(reflector as any);
+      const ivHex = 'c'.repeat(24);
+      const authTagHex = 'd'.repeat(32);
+      const ciphertext = `${ivHex}:${authTagHex}:cafebabe`;
+
+      const result = await run(interceptor, { blob: ciphertext });
+
+      expect(result.blob).toBeUndefined();
+    });
+
+    it('redacts by default when the route has no metadata (fail-closed)', async () => {
+      const reflector = {
+        getAllAndOverride: jest.fn().mockReturnValue(undefined),
+      };
+      const interceptor = new SensitiveDataInterceptor(reflector as any);
+
+      const result = await run(interceptor, { ssn: '123-45-6789' });
+
+      expect(result.ssn).toBe('[REDACTED]');
+    });
+  });
+});

--- a/src/common/interceptors/sensitive-data.interceptor.ts
+++ b/src/common/interceptors/sensitive-data.interceptor.ts
@@ -3,25 +3,39 @@ import {
   NestInterceptor,
   ExecutionContext,
   CallHandler,
+  Optional,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { redactSensitiveFields } from '../logger/log-redaction';
+import { EXPOSE_SENSITIVE_FIELDS_KEY } from '../decorators/expose-sensitive-fields.decorator';
 
 /**
  * SensitiveDataInterceptor
  *
- * Strips fields whose values look like AES-256-GCM ciphertext
- * (iv:authTag:ciphertext — three colon-delimited hex segments) from outbound
- * API responses.  This prevents raw encrypted values from leaking to clients
- * in the event a transformer fails to decrypt or a new encrypted column is
- * added without a corresponding DTO exclusion.
+ * Reusable response serialization layer applied consistently across REST
+ * controllers and GraphQL resolvers (registered globally, which NestJS
+ * threads through both transports).
  *
- * The interceptor walks the response object recursively and replaces any
- * matching string value with `undefined` (which JSON.stringify omits).
+ * Two independent redaction passes run on every outbound response:
+ *
+ *  1. Ciphertext stripping (always on, transport-agnostic) — strips fields
+ *     whose values look like AES-256-GCM ciphertext (iv:authTag:ciphertext)
+ *     so a failed decrypt or a new encrypted column never leaks raw
+ *     ciphertext to a client.
+ *
+ *  2. Sensitive-field-name redaction (default "public" exposure) — reuses
+ *     the same field-name rules as log redaction (`common/logger/log-redaction`)
+ *     so financial/identity fields (ssn, cardNumber, accountNumber, secret,
+ *     apiKey, ...) are redacted/masked by default even if a DTO forgets to
+ *     exclude them explicitly. Routes/resolvers that legitimately need the
+ *     raw values (admin/compliance tooling) opt out with
+ *     `@ExposeSensitiveFields()`, which marks the response as "internal".
  *
  * Apply globally in main.ts or per-controller/route as needed:
  *
- *   app.useGlobalInterceptors(new SensitiveDataInterceptor());
+ *   app.useGlobalInterceptors(new SensitiveDataInterceptor(app.get(Reflector)));
  */
 @Injectable()
 export class SensitiveDataInterceptor implements NestInterceptor {
@@ -34,8 +48,21 @@ export class SensitiveDataInterceptor implements NestInterceptor {
   private static readonly CIPHERTEXT_RE =
     /^[0-9a-f]{24}:[0-9a-f]{32}:[0-9a-f]+$/i;
 
-  intercept(_ctx: ExecutionContext, next: CallHandler): Observable<any> {
-    return next.handle().pipe(map((data) => this.strip(data)));
+  constructor(@Optional() private readonly reflector?: Reflector) {}
+
+  intercept(ctx: ExecutionContext, next: CallHandler): Observable<any> {
+    const isInternal =
+      this.reflector?.getAllAndOverride<boolean>(EXPOSE_SENSITIVE_FIELDS_KEY, [
+        ctx.getHandler(),
+        ctx.getClass(),
+      ]) ?? false;
+
+    return next.handle().pipe(
+      map((data) => {
+        const stripped = this.strip(data);
+        return isInternal ? stripped : redactSensitiveFields(stripped);
+      }),
+    );
   }
 
   private strip(value: unknown): unknown {

--- a/src/common/services/webhook-idempotency.service.spec.ts
+++ b/src/common/services/webhook-idempotency.service.spec.ts
@@ -1,0 +1,160 @@
+import { BadRequestException } from '@nestjs/common';
+import { WebhookIdempotencyService } from './webhook-idempotency.service';
+
+function makeUniqueViolation(): any {
+  const err: any = new Error('duplicate key value violates unique constraint');
+  err.code = '23505';
+  return err;
+}
+
+describe('WebhookIdempotencyService', () => {
+  let repo: {
+    insert: jest.Mock;
+    findOne: jest.Mock;
+  };
+  let service: WebhookIdempotencyService;
+
+  beforeEach(() => {
+    repo = {
+      insert: jest.fn(),
+      findOne: jest.fn(),
+    };
+    service = new WebhookIdempotencyService(repo as any);
+    jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('first delivery', () => {
+    it('records the (provider, eventId) pair and returns true', async () => {
+      repo.insert.mockResolvedValue({ identifiers: [{ id: 'row-1' }] });
+
+      const result = await service.markProcessed('stripe', 'evt_123');
+
+      expect(result).toBe(true);
+      expect(repo.insert).toHaveBeenCalledWith({ provider: 'stripe', eventId: 'evt_123' });
+    });
+
+    it('trims surrounding whitespace before persisting', async () => {
+      repo.insert.mockResolvedValue({});
+
+      await service.markProcessed('paystack', '  evt_456  ');
+
+      expect(repo.insert).toHaveBeenCalledWith({ provider: 'paystack', eventId: 'evt_456' });
+    });
+  });
+
+  describe('replay / redelivery', () => {
+    it('returns false when the same (provider, eventId) is replayed (unique violation)', async () => {
+      repo.insert.mockRejectedValue(makeUniqueViolation());
+
+      const result = await service.markProcessed('mpesa', 'ws_CO_1234');
+
+      expect(result).toBe(false);
+      expect((service as any).logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('mpesa/ws_CO_1234'),
+      );
+    });
+
+    it('treats the same eventId from two different providers independently', async () => {
+      repo.insert.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+      const first = await service.markProcessed('stripe', 'evt_shared');
+      const second = await service.markProcessed('paystack', 'evt_shared');
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(repo.insert).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows non-unique-violation database errors instead of swallowing them', async () => {
+      const dbError = new Error('connection terminated unexpectedly');
+      repo.insert.mockRejectedValue(dbError);
+
+      await expect(service.markProcessed('stripe', 'evt_789')).rejects.toThrow(dbError);
+    });
+
+    it('simulates concurrent redelivery: only the first insert wins', async () => {
+      repo.insert
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(makeUniqueViolation());
+
+      const [first, second] = await Promise.all([
+        service.markProcessed('stripe', 'evt_concurrent'),
+        service.markProcessed('stripe', 'evt_concurrent'),
+      ]);
+
+      expect([first, second].filter(Boolean)).toHaveLength(1);
+    });
+  });
+
+  describe('malformed event identifiers', () => {
+    it.each([
+      ['empty string', ''],
+      ['whitespace only', '   '],
+    ])('rejects %s', async (_label, eventId) => {
+      await expect(service.markProcessed('stripe', eventId)).rejects.toThrow(BadRequestException);
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-string eventId', async () => {
+      await expect(
+        service.markProcessed('stripe', 12345 as unknown as string),
+      ).rejects.toThrow(BadRequestException);
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a null eventId', async () => {
+      await expect(
+        service.markProcessed('stripe', null as unknown as string),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects an undefined eventId', async () => {
+      await expect(
+        service.markProcessed('stripe', undefined as unknown as string),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects an implausibly long eventId', async () => {
+      const tooLong = 'e'.repeat(256);
+      await expect(service.markProcessed('stripe', tooLong)).rejects.toThrow(BadRequestException);
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('accepts an eventId exactly at the length boundary', async () => {
+      repo.insert.mockResolvedValue({});
+      const atBoundary = 'e'.repeat(255);
+
+      const result = await service.markProcessed('stripe', atBoundary);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('wasProcessed', () => {
+    it('returns true when a matching record exists', async () => {
+      repo.findOne.mockResolvedValue({ id: 'row-1', provider: 'stripe', eventId: 'evt_1' });
+
+      const result = await service.wasProcessed('stripe', 'evt_1');
+
+      expect(result).toBe(true);
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { provider: 'stripe', eventId: 'evt_1' },
+      });
+    });
+
+    it('returns false when no record exists', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await service.wasProcessed('stripe', 'evt_missing');
+
+      expect(result).toBe(false);
+    });
+
+    it('validates the eventId before querying', async () => {
+      await expect(service.wasProcessed('stripe', '')).rejects.toThrow(BadRequestException);
+      expect(repo.findOne).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/common/services/webhook-idempotency.service.ts
+++ b/src/common/services/webhook-idempotency.service.ts
@@ -1,9 +1,12 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ProcessedWebhookEvent } from '../entities/processed-webhook-event.entity';
 
 const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+/** Matches the `eventId` column width — anything longer is rejected up front. */
+const MAX_EVENT_ID_LENGTH = 255;
 
 /**
  * Deduplicates external webhook deliveries so retried/duplicate callbacks
@@ -25,10 +28,16 @@ export class WebhookIdempotencyService {
   /**
    * Atomically records (provider, eventId) as processed.
    * Returns true the first time it's seen, false on any repeat delivery.
+   *
+   * Throws BadRequestException for malformed identifiers (missing, blank,
+   * non-string, or implausibly long) instead of silently inserting garbage
+   * that would defeat the (provider, eventId) uniqueness guarantee.
    */
   async markProcessed(provider: string, eventId: string): Promise<boolean> {
+    this.assertValidEventId(provider, eventId);
+
     try {
-      await this.repo.insert({ provider, eventId });
+      await this.repo.insert({ provider, eventId: eventId.trim() });
       return true;
     } catch (error: any) {
       if (this.isUniqueViolation(error)) {
@@ -36,6 +45,40 @@ export class WebhookIdempotencyService {
         return false;
       }
       throw error;
+    }
+  }
+
+  /**
+   * Read-only replay check — does not record anything. Useful when a caller
+   * needs to know whether an event was already handled without racing to be
+   * the one that records it (e.g. pre-flight checks, admin tooling).
+   */
+  async wasProcessed(provider: string, eventId: string): Promise<boolean> {
+    this.assertValidEventId(provider, eventId);
+    const existing = await this.repo.findOne({
+      where: { provider, eventId: eventId.trim() },
+    });
+    return existing !== null;
+  }
+
+  private assertValidEventId(provider: string, eventId: unknown): asserts eventId is string {
+    if (typeof eventId !== 'string') {
+      throw new BadRequestException(
+        `Malformed webhook event identifier for provider "${provider}": expected a string`,
+      );
+    }
+
+    const trimmed = eventId.trim();
+    if (trimmed.length === 0) {
+      throw new BadRequestException(
+        `Malformed webhook event identifier for provider "${provider}": identifier is empty`,
+      );
+    }
+
+    if (trimmed.length > MAX_EVENT_ID_LENGTH) {
+      throw new BadRequestException(
+        `Malformed webhook event identifier for provider "${provider}": exceeds ${MAX_EVENT_ID_LENGTH} characters`,
+      );
     }
   }
 

--- a/src/graphQL-API/graphql.module.ts
+++ b/src/graphQL-API/graphql.module.ts
@@ -117,9 +117,17 @@ import { AssetsService } from '../assets/assets.service';
         autoSchemaFile: join(process.cwd(), 'src/graphql/schema.gql'),
         sortSchema: true,
 
-        /** Attach DataLoaders to every request context to solve N+1 at resolver level. */
-        context: ({ req }: { req: Request }) => ({
+        /**
+         * Attach DataLoaders to every request context to solve N+1 at resolver level.
+         *
+         * `res` is threaded through alongside `req` so guards that need to write
+         * response headers from a GraphQL execution context (e.g. RateLimitGuard's
+         * X-RateLimit-*/Retry-After headers) have somewhere to write them — without
+         * it, header-emitting guards silently no-op for every GraphQL request.
+         */
+        context: ({ req, res }: { req: Request; res: any }) => ({
           req,
+          res,
           loaders: {
             providerById: createDataLoader(
               (ids) => providersService.findByIds(ids as string[]),

--- a/src/kyc/kyc.controller.ts
+++ b/src/kyc/kyc.controller.ts
@@ -31,6 +31,7 @@ import {
 } from './dto/start-kyc.dto';
 import { Audit } from '../audit-log/interceptors/audit-logging.interceptor';
 import { AuditAction } from '../audit-log/entities/audit-log.entity';
+import { ExposeSensitiveFields } from '../common/decorators/expose-sensitive-fields.decorator';
 
 @ApiTags('KYC / Identity Verification')
 @ApiBearerAuth()
@@ -130,6 +131,9 @@ export class KycController {
 
   @Get('admin/user/:userId')
   @ApiOperation({ summary: '[Admin] Get all KYC verifications for a user' })
+  // Compliance/support review needs the raw identity fields on this record —
+  // opt out of the default public sensitive-field redaction.
+  @ExposeSensitiveFields()
   adminGetUserKyc(
     @Param('userId', ParseUUIDPipe) userId: string,
   ): Promise<KycStatusDto[]> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,7 +150,7 @@ async function bootstrap() {
   );
   app.useGlobalInterceptors(new ResponseEnvelopeInterceptor(app.get(Reflector)));
   app.useGlobalInterceptors(new StripInternalFieldsInterceptor());
-  app.useGlobalInterceptors(new SensitiveDataInterceptor());
+  app.useGlobalInterceptors(new SensitiveDataInterceptor(app.get(Reflector)));
   app.useGlobalInterceptors(new StellarMemoInterceptor(app.get(Reflector)));
   app.useGlobalInterceptors(app.get(MetricsInterceptor));
   app.useGlobalInterceptors(app.get(NPlus1DetectionInterceptor));

--- a/src/webhooks/jobs/audit-webhook-secrets.job.spec.ts
+++ b/src/webhooks/jobs/audit-webhook-secrets.job.spec.ts
@@ -4,11 +4,13 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Webhook } from '../entities/webhook.entity';
 import { AuditWebhookSecretsJob } from './audit-webhook-secrets.job';
 import { NotificationService } from '../../notifications/notification.service';
+import { DistributedLockService } from '../../common/services/distributed-lock.service';
 
 describe('AuditWebhookSecretsJob', () => {
   let job: AuditWebhookSecretsJob;
   let mockWebhookRepo: any;
   let mockNotificationService: any;
+  let mockLockService: jest.Mocked<Pick<DistributedLockService, 'withLock'>>;
 
   beforeEach(async () => {
     mockWebhookRepo = {
@@ -19,11 +21,21 @@ describe('AuditWebhookSecretsJob', () => {
       send: jest.fn().mockResolvedValue({}),
     };
 
+    // Default: lock is always free, so `fn` runs immediately — matches the
+    // pre-locking test behaviour for every existing assertion below.
+    mockLockService = {
+      withLock: jest.fn(async (_key: string, _ttl: number, fn: () => Promise<any>) => ({
+        ran: true,
+        result: await fn(),
+      })),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuditWebhookSecretsJob,
         { provide: getRepositoryToken(Webhook), useValue: mockWebhookRepo },
         { provide: NotificationService, useValue: mockNotificationService },
+        { provide: DistributedLockService, useValue: mockLockService },
       ],
     }).compile();
 
@@ -113,5 +125,45 @@ describe('AuditWebhookSecretsJob', () => {
     // This should still trigger a warning due to low entropy
     expect((job as any).logger.warn).toHaveBeenCalled();
     expect(mockNotificationService.send).toHaveBeenCalled();
+  });
+
+  describe('distributed locking', () => {
+    it('acquires the audit lock with the expected key and TTL', async () => {
+      mockWebhookRepo.find.mockResolvedValue([]);
+
+      await job.audit();
+
+      expect(mockLockService.withLock).toHaveBeenCalledWith(
+        'webhooks:audit-webhook-secrets',
+        expect.any(Number),
+        expect.any(Function),
+      );
+    });
+
+    it('skips the run entirely when another instance already holds the lock (contention)', async () => {
+      mockLockService.withLock.mockResolvedValue({ ran: false });
+
+      await job.audit();
+
+      expect(mockWebhookRepo.find).not.toHaveBeenCalled();
+      expect(mockNotificationService.send).not.toHaveBeenCalled();
+      expect((job as any).logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('lock held by another instance'),
+      );
+    });
+
+    it('propagates errors from the audit body so the lock wrapper can still release it (failure recovery)', async () => {
+      mockWebhookRepo.find.mockRejectedValue(new Error('db unavailable'));
+      mockLockService.withLock.mockImplementation(async (_key, _ttl, fn) => {
+        try {
+          return { ran: true, result: await fn() };
+        } finally {
+          // Simulates DistributedLockService's own finally-release semantics.
+        }
+      });
+
+      await expect(job.audit()).rejects.toThrow('db unavailable');
+      expect(mockLockService.withLock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/webhooks/jobs/audit-webhook-secrets.job.ts
+++ b/src/webhooks/jobs/audit-webhook-secrets.job.ts
@@ -5,6 +5,11 @@ import { Repository } from 'typeorm';
 import { Webhook } from '../entities/webhook.entity';
 import { NotificationService } from '../../notifications/notification.service';
 import { evaluateSecretStrength, hashSecret, MIN_ENTROPY_BITS_PER_CHAR, MIN_SECRET_LENGTH } from '../utils/secret-entropy.util';
+import { DistributedLockService } from '../../common/services/distributed-lock.service';
+
+/** This job only runs once a day, so a generous TTL is safe and covers slow scans. */
+const AUDIT_LOCK_KEY = 'webhooks:audit-webhook-secrets';
+const AUDIT_LOCK_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 @Injectable()
 export class AuditWebhookSecretsJob {
@@ -14,10 +19,26 @@ export class AuditWebhookSecretsJob {
     @InjectRepository(Webhook)
     private readonly webhookRepository: Repository<Webhook>,
     private readonly notificationService: NotificationService,
+    private readonly lock: DistributedLockService,
   ) {}
 
+  /**
+   * Runs daily across every replica. Locked so a horizontally scaled
+   * deployment doesn't send duplicate "rotate your secret" notifications
+   * to the same webhook owners.
+   */
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async audit(): Promise<void> {
+    const { ran } = await this.lock.withLock(AUDIT_LOCK_KEY, AUDIT_LOCK_TTL_MS, () =>
+      this.runAudit(),
+    );
+
+    if (!ran) {
+      this.logger.debug('Skipping secret audit run — lock held by another instance');
+    }
+  }
+
+  private async runAudit(): Promise<void> {
     this.logger.log('Starting webhook secret strength audit…');
 
     const webhooks = await this.webhookRepository.find();

--- a/src/webhooks/jobs/stellar-callback-reconciliation.job.spec.ts
+++ b/src/webhooks/jobs/stellar-callback-reconciliation.job.spec.ts
@@ -8,6 +8,7 @@ import {
 } from './stellar-callback-reconciliation.job';
 import { WebhookDelivery } from '../entities/webhook-delivery.entity';
 import { WebhookSenderService } from '../services/webhook-sender.service';
+import { DistributedLockService } from '../../common/services/distributed-lock.service';
 
 const makeDelivery = (
   overrides: Partial<WebhookDelivery> = {},
@@ -30,6 +31,7 @@ describe('StellarCallbackReconciliationJob', () => {
   let job: StellarCallbackReconciliationJob;
   let deliveryRepo: jest.Mocked<any>;
   let senderService: jest.Mocked<WebhookSenderService>;
+  let lockService: jest.Mocked<Pick<DistributedLockService, 'withLock'>>;
 
   beforeEach(async () => {
     deliveryRepo = {
@@ -42,11 +44,21 @@ describe('StellarCallbackReconciliationJob', () => {
       retryInPlace: jest.fn(),
     } as any;
 
+    // Default: lock is always free, so `fn` runs immediately — matches the
+    // pre-locking test behaviour for every existing assertion below.
+    lockService = {
+      withLock: jest.fn(async (_key: string, _ttl: number, fn: () => Promise<any>) => ({
+        ran: true,
+        result: await fn(),
+      })),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StellarCallbackReconciliationJob,
         { provide: getRepositoryToken(WebhookDelivery), useValue: deliveryRepo },
         { provide: WebhookSenderService, useValue: senderService },
+        { provide: DistributedLockService, useValue: lockService },
       ],
     }).compile();
 
@@ -161,5 +173,40 @@ describe('StellarCallbackReconciliationJob', () => {
     await job.reconcile();
 
     expect(senderService.retryInPlace).toHaveBeenCalledWith(stalePending);
+  });
+
+  describe('distributed locking', () => {
+    it('acquires the reconciliation lock with the expected key and TTL', async () => {
+      mockQueryBuilder([]);
+
+      await job.reconcile();
+
+      expect(lockService.withLock).toHaveBeenCalledWith(
+        'webhooks:stellar-callback-reconciliation',
+        expect.any(Number),
+        expect.any(Function),
+      );
+    });
+
+    it('skips the run entirely when another instance already holds the lock (contention)', async () => {
+      lockService.withLock.mockResolvedValue({ ran: false });
+
+      await job.reconcile();
+
+      expect(deliveryRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(senderService.retryInPlace).not.toHaveBeenCalled();
+      expect((job as any).logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('lock held by another instance'),
+      );
+    });
+
+    it('propagates failures from the reconciliation body through the lock wrapper (failure recovery)', async () => {
+      deliveryRepo.createQueryBuilder.mockImplementation(() => {
+        throw new Error('query builder unavailable');
+      });
+
+      await expect(job.reconcile()).rejects.toThrow('query builder unavailable');
+      expect(lockService.withLock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/webhooks/jobs/stellar-callback-reconciliation.job.ts
+++ b/src/webhooks/jobs/stellar-callback-reconciliation.job.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan, LessThanOrEqual, IsNull, Or } from 'typeorm';
 import { WebhookDelivery } from '../entities/webhook-delivery.entity';
 import { WebhookSenderService } from '../services/webhook-sender.service';
+import { DistributedLockService } from '../../common/services/distributed-lock.service';
 
 /** Maximum total delivery attempts before a record is abandoned by the reconciler. */
 export const MAX_RECONCILE_ATTEMPTS = 10;
@@ -14,6 +15,14 @@ const STALE_PENDING_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
 /** Upper bound on records processed per reconciliation run to prevent runaway batches. */
 const BATCH_SIZE = 100;
 
+/**
+ * Distributed lock key/TTL for this job. TTL is comfortably longer than a
+ * single run (bounded by BATCH_SIZE) should ever take, so a crashed holder
+ * releases automatically well before the next 5-minute tick.
+ */
+const RECONCILE_LOCK_KEY = 'webhooks:stellar-callback-reconciliation';
+const RECONCILE_LOCK_TTL_MS = 4 * 60 * 1000; // 4 minutes
+
 @Injectable()
 export class StellarCallbackReconciliationJob {
   private readonly logger = new Logger(StellarCallbackReconciliationJob.name);
@@ -22,10 +31,31 @@ export class StellarCallbackReconciliationJob {
     @InjectRepository(WebhookDelivery)
     private readonly deliveryRepo: Repository<WebhookDelivery>,
     private readonly senderService: WebhookSenderService,
+    private readonly lock: DistributedLockService,
   ) {}
 
+  /**
+   * Runs every 5 minutes across every replica. Without a distributed lock,
+   * horizontally scaled instances would race to reconcile the same stale
+   * deliveries and could double-fire callbacks to Stellar/webhook
+   * consumers. `withLock` ensures only one replica executes a given tick.
+   */
   @Cron(CronExpression.EVERY_5_MINUTES)
   async reconcile(): Promise<void> {
+    const { ran } = await this.lock.withLock(
+      RECONCILE_LOCK_KEY,
+      RECONCILE_LOCK_TTL_MS,
+      () => this.runReconciliation(),
+    );
+
+    if (!ran) {
+      this.logger.debug(
+        'Skipping reconciliation run — lock held by another instance',
+      );
+    }
+  }
+
+  private async runReconciliation(): Promise<void> {
     this.logger.log('Starting Stellar callback reconciliation run');
     const now = new Date();
 

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -14,6 +14,7 @@ import { StellarCallbackReconciliationJob } from './jobs/stellar-callback-reconc
 import { AuditWebhookSecretsJob } from './jobs/audit-webhook-secrets.job';
 import { WebhookDeliveryProcessor } from './jobs/webhook-delivery.processor';
 import { WEBHOOK_DELIVERY_QUEUE } from './jobs/webhook-delivery.constants';
+import { DistributedLockService } from '../common/services/distributed-lock.service';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { WEBHOOK_DELIVERY_QUEUE } from './jobs/webhook-delivery.constants';
     StellarCallbackReconciliationJob,
     AuditWebhookSecretsJob,
     WebhookDeliveryProcessor,
+    DistributedLockService,
   ],
   exports: [WebhooksService],
 })


### PR DESCRIPTION
Closes #962
Closes #963
Closes #964
Closes #965 

1. fix(rate-limit) — GraphQL requests were silently missing all X-RateLimit-*/Retry-After headers because the guard only read context.switchToHttp(), which is inert for GraphQL execution contexts. Added transport-aware helpers + threaded res through the GraphQL context.
2. feat(webhooks) dedup — WebhookIdempotencyService existed but had zero test coverage and would insert blank/malformed event IDs. Added validation + full replay/redelivery/malformed-ID test suite.
3. feat(webhooks) locking — StellarCallbackReconciliationJob (every 5 min) and AuditWebhookSecretsJob (daily) had no cross-replica coordination, risking duplicate retries/notifications at scale. Wrapped both in DistributedLockService.withLock() with contention/failure-recovery tests.
4. feat(common) redaction — SensitiveDataInterceptor only stripped ciphertext-shaped values, not named sensitive fields. Added a default-redact pass reusing the existing log-redaction rules, plus an @ExposeSensitiveFields() opt-out for internal/admin routes.
