### PR TITLE
feat(trades): handle permanently failed BullMQ jobs

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -9,6 +9,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Docker repository names must be lowercase; GitHub repository names may not be.
+  IMAGE_REF: stellarswipe-backends:scan
 
 jobs:
   scan:
@@ -21,12 +23,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build image for scanning
-        run: docker build -t ${{ env.IMAGE_NAME }}:scan .
+        run: docker build -t "${IMAGE_REF}" .
 
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.IMAGE_NAME }}:scan
+          image-ref: ${{ env.IMAGE_REF }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 FROM node:18-alpine AS dependencies
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --only=production --legacy-peer-deps
 
 # Stage 2: Build
 FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 COPY . .
 RUN npm run build
 

--- a/src/trades/dto/dlq-query.dto.ts
+++ b/src/trades/dto/dlq-query.dto.ts
@@ -1,0 +1,87 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsNumber, IsIn } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class FailedTradesQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    default: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Number of items per page (max 100)',
+    default: 20,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Sort field',
+    default: 'updatedAt',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['updatedAt', 'createdAt', 'amount', 'baseAsset'])
+  sortBy?: string;
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    default: 'DESC',
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['ASC', 'DESC'])
+  sortOrder?: 'ASC' | 'DESC';
+
+  @ApiPropertyOptional({
+    description: 'Filter by base asset',
+  })
+  @IsOptional()
+  @IsString()
+  baseAsset?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by error message substring',
+  })
+  @IsOptional()
+  @IsString()
+  errorFilter?: string;
+}
+
+export class AdminFailedJobsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of recent jobs to return',
+    default: 10,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by user ID',
+  })
+  @IsOptional()
+  @IsString()
+  userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by date range start (ISO string)',
+  })
+  @IsOptional()
+  @IsString()
+  startDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by date range end (ISO string)',
+  })
+  @IsOptional()
+  @IsString()
+  endDate?: string;
+}

--- a/src/trades/dto/trade-retry-response.dto.ts
+++ b/src/trades/dto/trade-retry-response.dto.ts
@@ -1,0 +1,307 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsUUID,
+  ArrayMinSize,
+  IsOptional,
+  IsString,
+  IsNumber,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+// ---------------------------------------------------------------------------
+// Single-trade retry response
+// ---------------------------------------------------------------------------
+
+export class TradeRetryResponseDto {
+  @ApiProperty({ description: 'ID of the trade being retried' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'ID of the newly enqueued job' })
+  newJobId!: string;
+
+  @ApiProperty({ description: 'New status of the trade after retry' })
+  status!: string;
+
+  @ApiProperty({ description: 'Human-readable message about the retry' })
+  message!: string;
+}
+
+// ---------------------------------------------------------------------------
+// Failed job detail
+// ---------------------------------------------------------------------------
+
+export class FailedJobDto {
+  @ApiProperty({ description: 'ID of the failed job' })
+  jobId!: string | number;
+
+  @ApiProperty({ description: 'Trade ID associated with the failed job' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'User ID who owns the trade' })
+  userId!: string;
+
+  @ApiProperty({ description: 'Reason the job failed' })
+  failedReason!: string;
+
+  @ApiProperty({ description: 'Number of attempts made before failure' })
+  attemptsMade!: number;
+
+  @ApiProperty({ description: 'ISO timestamp of when the job failed' })
+  failedAt!: string;
+
+  @ApiPropertyOptional({ description: 'Original trade job data' })
+  tradeData?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Failed jobs summary (admin view)
+// ---------------------------------------------------------------------------
+
+export class FailedJobsSummaryDto {
+  @ApiProperty({ description: 'Total number of failed trade jobs in the DLQ' })
+  totalFailed!: number;
+
+  @ApiProperty({
+    description: 'Most recent failed jobs (up to requested limit)',
+    type: [FailedJobDto],
+  })
+  recentJobs!: FailedJobDto[];
+}
+
+// ---------------------------------------------------------------------------
+// Bulk retry request / response
+// ---------------------------------------------------------------------------
+
+export class BulkRetryRequestDto {
+  @ApiProperty({
+    description: 'Array of trade IDs to retry',
+    type: [String],
+    example: ['uuid-1', 'uuid-2'],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsUUID('4', { each: true })
+  tradeIds!: string[];
+}
+
+export class BulkRetryItemResultDto {
+  @ApiProperty({ description: 'Trade ID' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'Whether the retry succeeded' })
+  success!: boolean;
+
+  @ApiPropertyOptional({ description: 'New job ID if retry succeeded' })
+  newJobId?: string;
+
+  @ApiPropertyOptional({ description: 'Error message if retry failed' })
+  error?: string;
+}
+
+export class BulkRetryResponseDto {
+  @ApiProperty({ description: 'Total trades requested for retry' })
+  totalRequested!: number;
+
+  @ApiProperty({ description: 'Number of trades successfully re-enqueued' })
+  successCount!: number;
+
+  @ApiProperty({ description: 'Number of trades that failed to retry' })
+  failureCount!: number;
+
+  @ApiProperty({
+    description: 'Per-trade retry results',
+    type: [BulkRetryItemResultDto],
+  })
+  results!: BulkRetryItemResultDto[];
+}
+
+// ---------------------------------------------------------------------------
+// Failed trade stats (admin analytics)
+// ---------------------------------------------------------------------------
+
+export class ErrorTypeCountDto {
+  @ApiProperty({ description: 'Error category / message prefix' })
+  errorType!: string;
+
+  @ApiProperty({ description: 'Number of failures with this error type' })
+  count!: number;
+}
+
+export class TimePeriodCountDto {
+  @ApiProperty({ description: 'Time period label (e.g. "last_1h", "last_24h")' })
+  period!: string;
+
+  @ApiProperty({ description: 'Number of failures in this period' })
+  count!: number;
+}
+
+export class FailedTradeStatsDto {
+  @ApiProperty({ description: 'Total number of failed trades' })
+  totalFailed!: number;
+
+  @ApiProperty({ description: 'Total number of trades successfully retried' })
+  totalRetried!: number;
+
+  @ApiProperty({ description: 'Total number of trades discarded from DLQ' })
+  totalDiscarded!: number;
+
+  @ApiProperty({
+    description: 'Breakdown of failures by error type',
+    type: [ErrorTypeCountDto],
+  })
+  byErrorType!: ErrorTypeCountDto[];
+
+  @ApiProperty({
+    description: 'Breakdown of failures by time period',
+    type: [TimePeriodCountDto],
+  })
+  byTimePeriod!: TimePeriodCountDto[];
+
+  @ApiProperty({ description: 'Current DLQ depth (number of entries)' })
+  currentDlqDepth!: number;
+}
+
+// ---------------------------------------------------------------------------
+// Retry history
+// ---------------------------------------------------------------------------
+
+export class RetryHistoryEntryDto {
+  @ApiProperty({ description: 'ISO timestamp when the retry was initiated' })
+  retriedAt!: string;
+
+  @ApiPropertyOptional({ description: 'Error message from the previous failure' })
+  previousError?: string;
+
+  @ApiProperty({ description: 'Job ID of the new retry job' })
+  newJobId!: string;
+}
+
+export class RetryHistoryDto {
+  @ApiProperty({ description: 'Trade ID' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'Total number of retry attempts' })
+  totalRetries!: number;
+
+  @ApiProperty({
+    description: 'Ordered list of retry attempts',
+    type: [RetryHistoryEntryDto],
+  })
+  entries!: RetryHistoryEntryDto[];
+}
+
+// ---------------------------------------------------------------------------
+// User failed trades
+// ---------------------------------------------------------------------------
+
+export class UserFailedTradeDto {
+  @ApiProperty({ description: 'Trade ID' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'Trading pair base asset' })
+  baseAsset!: string;
+
+  @ApiProperty({ description: 'Trading pair counter asset' })
+  counterAsset!: string;
+
+  @ApiProperty({ description: 'Trade side (buy/sell)' })
+  side!: string;
+
+  @ApiProperty({ description: 'Trade amount' })
+  amount!: string;
+
+  @ApiProperty({ description: 'Entry price' })
+  entryPrice!: string;
+
+  @ApiPropertyOptional({ description: 'Error message from the failure' })
+  errorMessage?: string;
+
+  @ApiProperty({ description: 'ISO timestamp of when the trade failed' })
+  failedAt!: string;
+
+  @ApiProperty({ description: 'Number of retry attempts so far' })
+  retryCount!: number;
+
+  @ApiProperty({ description: 'Whether the trade can be retried' })
+  canRetry!: boolean;
+}
+
+export class UserFailedTradesDto {
+  @ApiProperty({ description: 'User ID' })
+  userId!: string;
+
+  @ApiProperty({ description: 'Total failed trades for this user' })
+  totalFailed!: number;
+
+  @ApiProperty({
+    description: 'List of failed trades',
+    type: [UserFailedTradeDto],
+  })
+  trades!: UserFailedTradeDto[];
+}
+
+// ---------------------------------------------------------------------------
+// Pagination query DTO
+// ---------------------------------------------------------------------------
+
+export class DlqPaginationDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-indexed)',
+    default: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 20,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Sort order (asc or desc)',
+    default: 'desc',
+  })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc';
+}
+
+// ---------------------------------------------------------------------------
+// Discard response
+// ---------------------------------------------------------------------------
+
+export class DiscardResponseDto {
+  @ApiProperty({ description: 'Trade ID that was discarded' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'Admin user who performed the discard' })
+  discardedBy!: string;
+
+  @ApiProperty({ description: 'ISO timestamp of when the discard occurred' })
+  discardedAt!: string;
+
+  @ApiProperty({ description: 'Human-readable message' })
+  message!: string;
+}
+
+// ---------------------------------------------------------------------------
+// Can-retry response
+// ---------------------------------------------------------------------------
+
+export class CanRetryResponseDto {
+  @ApiProperty({ description: 'Trade ID' })
+  tradeId!: string;
+
+  @ApiProperty({ description: 'Whether the trade can be retried' })
+  canRetry!: boolean;
+
+  @ApiPropertyOptional({ description: 'Reason why trade cannot be retried' })
+  reason?: string;
+}

--- a/src/trades/jobs/trade-dlq.processor.spec.ts
+++ b/src/trades/jobs/trade-dlq.processor.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TradeDlqProcessor } from './trade-dlq.processor';
+import { TradeDlqService } from '../services/trade-dlq.service';
+import { TradeDlqMetricsService } from '../services/trade-dlq-metrics.service';
+
+const mockJob = (overrides: Partial<any> = {}) => ({
+  id: 'job-100',
+  data: { tradeId: 'trade-100', userId: 'user-100' },
+  attemptsMade: 3,
+  opts: { attempts: 3 },
+  queue: { name: 'transactions' },
+  ...overrides,
+});
+
+describe('TradeDlqProcessor', () => {
+  let processor: TradeDlqProcessor;
+  let mockDlqService: any;
+  let mockMetricsService: any;
+
+  beforeEach(async () => {
+    mockDlqService = {
+      handleFailedJob: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockMetricsService = {
+      recordFailure: jest.fn(),
+      recordRetry: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeDlqProcessor,
+        { provide: TradeDlqService, useValue: mockDlqService },
+        { provide: TradeDlqMetricsService, useValue: mockMetricsService },
+      ],
+    }).compile();
+
+    processor = module.get(TradeDlqProcessor);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── onFailed ───────────────────────────────────────────────────────────────
+
+  describe('onFailed', () => {
+    it('should skip DLQ processing when attempts remain', async () => {
+      const job = mockJob({ attemptsMade: 1, opts: { attempts: 3 } });
+      const error = new Error('Temporary error');
+
+      await processor.onFailed(job, error);
+
+      expect(mockDlqService.handleFailedJob).not.toHaveBeenCalled();
+      expect(mockMetricsService.recordFailure).not.toHaveBeenCalled();
+    });
+
+    it('should delegate to DLQ service when all attempts exhausted', async () => {
+      const job = mockJob({ attemptsMade: 3, opts: { attempts: 3 } });
+      const error = new Error('Permanent failure');
+
+      await processor.onFailed(job, error);
+
+      expect(mockDlqService.handleFailedJob).toHaveBeenCalledWith(job, error);
+      expect(mockMetricsService.recordFailure).toHaveBeenCalledWith(
+        'trade-100',
+        'Permanent failure',
+      );
+    });
+
+    it('should handle DLQ service errors gracefully', async () => {
+      const job = mockJob({ attemptsMade: 3, opts: { attempts: 3 } });
+      const error = new Error('Test error');
+      mockDlqService.handleFailedJob.mockRejectedValue(
+        new Error('DLQ service crashed'),
+      );
+
+      await expect(processor.onFailed(job, error)).resolves.not.toThrow();
+    });
+
+    it('should handle jobs with no tradeId in data', async () => {
+      const job = mockJob({
+        data: {},
+        attemptsMade: 1,
+        opts: { attempts: 1 },
+      });
+      const error = new Error('Test');
+
+      await processor.onFailed(job, error);
+
+      expect(mockMetricsService.recordFailure).toHaveBeenCalledWith(
+        'unknown',
+        'Test',
+      );
+    });
+
+    it('should handle jobs with default attempts=1 when opts.attempts missing', async () => {
+      const job = mockJob({
+        attemptsMade: 1,
+        opts: {},
+      });
+      const error = new Error('Test');
+
+      await processor.onFailed(job, error);
+
+      expect(mockDlqService.handleFailedJob).toHaveBeenCalled();
+    });
+
+    it('should not record metrics when job will be retried', async () => {
+      const job = mockJob({ attemptsMade: 1, opts: { attempts: 5 } });
+      const error = new Error('Retry me');
+
+      await processor.onFailed(job, error);
+
+      expect(mockMetricsService.recordFailure).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── onCompleted ────────────────────────────────────────────────────────────
+
+  describe('onCompleted', () => {
+    it('should record successful retry in metrics for retry jobs', () => {
+      const job = mockJob({ data: { tradeId: 'trade-200', isRetry: true } });
+
+      processor.onCompleted(job);
+
+      expect(mockMetricsService.recordRetry).toHaveBeenCalledWith(
+        'trade-200',
+        true,
+      );
+    });
+
+    it('should not record retry metrics for non-retry jobs', () => {
+      const job = mockJob({ data: { tradeId: 'trade-200', isRetry: false } });
+
+      processor.onCompleted(job);
+
+      expect(mockMetricsService.recordRetry).not.toHaveBeenCalled();
+    });
+
+    it('should handle jobs with missing data gracefully', () => {
+      const job = mockJob({ data: {} });
+
+      expect(() => processor.onCompleted(job)).not.toThrow();
+    });
+  });
+
+  // ── onStalled ──────────────────────────────────────────────────────────────
+
+  describe('onStalled', () => {
+    it('should log stalled job without throwing', () => {
+      const job = mockJob();
+
+      expect(() => processor.onStalled(job)).not.toThrow();
+    });
+
+    it('should handle missing tradeId in stalled job data', () => {
+      const job = mockJob({ data: {} });
+
+      expect(() => processor.onStalled(job)).not.toThrow();
+    });
+  });
+});

--- a/src/trades/jobs/trade-dlq.processor.ts
+++ b/src/trades/jobs/trade-dlq.processor.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Processor, OnQueueFailed, OnQueueCompleted, OnQueueStalled } from '@nestjs/bull';
+import { Job } from 'bull';
+import { TradeDlqService } from '../services/trade-dlq.service';
+import { TradeDlqMetricsService } from '../services/trade-dlq-metrics.service';
+
+/**
+ * #999 -- Dead-letter queue processor for the `transactions` queue.
+ *
+ * Listens for failed jobs on the Bull `transactions` queue. When a job
+ * has exhausted all its retry attempts the processor delegates to
+ * `TradeDlqService.handleFailedJob()` which updates the trade record,
+ * captures the job to the DLQ, and notifies the user.
+ *
+ * Also tracks metrics on completions and stalled jobs for observability.
+ */
+@Injectable()
+@Processor('transactions')
+export class TradeDlqProcessor {
+  private readonly logger = new Logger(TradeDlqProcessor.name);
+
+  constructor(
+    private readonly tradeDlqService: TradeDlqService,
+    private readonly metricsService: TradeDlqMetricsService,
+  ) {}
+
+  @OnQueueFailed()
+  async onFailed(job: Job, error: Error): Promise<void> {
+    const tradeId = job.data?.tradeId ?? 'unknown';
+    const maxAttempts = job.opts?.attempts ?? 1;
+
+    this.logger.warn(
+      `Job ${job.id} failed (trade=${tradeId}, attempt ${job.attemptsMade}/${maxAttempts}): ${error.message}`,
+    );
+
+    if (job.attemptsMade < maxAttempts) {
+      this.logger.debug(
+        `Job ${job.id} will be retried (${maxAttempts - job.attemptsMade} attempt(s) remaining)`,
+      );
+      return;
+    }
+
+    this.logger.error(
+      `Job ${job.id} has exhausted all ${maxAttempts} attempt(s) — moving to DLQ`,
+    );
+
+    // Record failure in metrics
+    this.metricsService.recordFailure(tradeId, error.message);
+
+    try {
+      await this.tradeDlqService.handleFailedJob(job, error);
+    } catch (dlqError: any) {
+      this.logger.error(
+        `Error in DLQ processing for job ${job.id}: ${dlqError.message}`,
+        dlqError.stack,
+      );
+    }
+  }
+
+  @OnQueueCompleted()
+  onCompleted(job: Job): void {
+    const tradeId = job.data?.tradeId ?? 'unknown';
+    const isRetry = job.data?.isRetry === true;
+
+    if (isRetry) {
+      this.metricsService.recordRetry(tradeId, true);
+      this.logger.log(
+        `Retry job ${job.id} for trade ${tradeId} completed successfully`,
+      );
+    }
+  }
+
+  @OnQueueStalled()
+  onStalled(job: Job): void {
+    const tradeId = job.data?.tradeId ?? 'unknown';
+    this.logger.warn(
+      `Job ${job.id} for trade ${tradeId} has stalled — it may be retried automatically`,
+    );
+  }
+}

--- a/src/trades/services/trade-dlq-cleanup.service.spec.ts
+++ b/src/trades/services/trade-dlq-cleanup.service.spec.ts
@@ -1,0 +1,245 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { TradeDlqCleanupService } from './trade-dlq-cleanup.service';
+import { Trade, TradeStatus } from '../entities/trade.entity';
+import { DeadLetterService } from '../../jobs/dead-letter.service';
+import { TradeDlqMetricsService } from './trade-dlq-metrics.service';
+
+const mockTrade = (overrides: Partial<any> = {}) => ({
+  id: 'trade-old-001',
+  status: TradeStatus.FAILED,
+  metadata: { discarded: { discardedBy: 'admin', discardedAt: '2024-01-01T00:00:00Z' } },
+  updatedAt: new Date('2024-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+describe('TradeDlqCleanupService', () => {
+  let service: TradeDlqCleanupService;
+  let mockTradeRepository: any;
+  let mockDeadLetterService: any;
+  let mockMetricsService: any;
+
+  beforeEach(async () => {
+    mockTradeRepository = {
+      createQueryBuilder: jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      })),
+      softDelete: jest.fn().mockResolvedValue({ affected: 1 }),
+      save: jest.fn(),
+    };
+
+    mockDeadLetterService = {
+      list: jest.fn().mockResolvedValue([]),
+      discard: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockMetricsService = {
+      setDlqDepth: jest.fn(),
+    };
+
+    const mockConfigService = {
+      get: jest.fn((key: string, def: unknown) => {
+        if (key === 'dlq.retentionDays') return 90;
+        return def;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeDlqCleanupService,
+        { provide: getRepositoryToken(Trade), useValue: mockTradeRepository },
+        { provide: DeadLetterService, useValue: mockDeadLetterService },
+        { provide: TradeDlqMetricsService, useValue: mockMetricsService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(TradeDlqCleanupService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── cleanupOldEntries ──────────────────────────────────────────────────────
+
+  describe('cleanupOldEntries', () => {
+    it('should soft-delete old discarded trades past retention', async () => {
+      const oldTrade = mockTrade();
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([oldTrade]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.archivedCount).toBe(1);
+      expect(mockTradeRepository.softDelete).toHaveBeenCalledWith('trade-old-001');
+    });
+
+    it('should remove stale DLQ entries past retention', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+
+      mockDeadLetterService.list.mockResolvedValue([
+        {
+          id: 'dlq-old',
+          data: { failedAt: '2023-01-01T00:00:00Z', queue: 'transactions' },
+        },
+        {
+          id: 'dlq-recent',
+          data: { failedAt: new Date().toISOString(), queue: 'transactions' },
+        },
+      ]);
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.dlqEntriesRemoved).toBe(1);
+      expect(mockDeadLetterService.discard).toHaveBeenCalledWith('dlq-old');
+      expect(mockDeadLetterService.discard).not.toHaveBeenCalledWith('dlq-recent');
+    });
+
+    it('should preserve recent entries within retention period', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+
+      mockDeadLetterService.list.mockResolvedValue([
+        {
+          id: 'dlq-recent',
+          data: { failedAt: new Date().toISOString(), queue: 'transactions' },
+        },
+      ]);
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.dlqEntriesRemoved).toBe(0);
+    });
+
+    it('should handle individual trade archive errors gracefully', async () => {
+      const trade1 = mockTrade({ id: 'trade-fail' });
+      const trade2 = mockTrade({ id: 'trade-ok' });
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([trade1, trade2]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+      mockTradeRepository.softDelete
+        .mockRejectedValueOnce(new Error('DB error'))
+        .mockResolvedValueOnce({ affected: 1 });
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.archivedCount).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('trade-fail');
+    });
+
+    it('should handle DLQ list failure gracefully', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+      mockDeadLetterService.list.mockRejectedValue(new Error('Redis down'));
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('Redis down');
+    });
+
+    it('should return duration in milliseconds', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle no entries to clean up', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      mockTradeRepository.createQueryBuilder.mockReturnValue(qb);
+      mockDeadLetterService.list.mockResolvedValue([]);
+
+      const result = await service.cleanupOldEntries(90);
+
+      expect(result.archivedCount).toBe(0);
+      expect(result.dlqEntriesRemoved).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // ── syncDlqDepth ───────────────────────────────────────────────────────────
+
+  describe('syncDlqDepth', () => {
+    it('should sync DLQ depth with actual queue state', async () => {
+      mockDeadLetterService.list.mockResolvedValue([
+        { data: { queue: 'transactions' } },
+        { data: { queue: 'transactions' } },
+        { data: { queue: 'notifications' } },
+      ]);
+
+      await service.syncDlqDepth();
+
+      expect(mockMetricsService.setDlqDepth).toHaveBeenCalledWith(2);
+    });
+
+    it('should handle sync failure gracefully', async () => {
+      mockDeadLetterService.list.mockRejectedValue(new Error('Redis error'));
+
+      await expect(service.syncDlqDepth()).resolves.not.toThrow();
+    });
+
+    it('should set depth to 0 when no DLQ entries', async () => {
+      mockDeadLetterService.list.mockResolvedValue([]);
+
+      await service.syncDlqDepth();
+
+      expect(mockMetricsService.setDlqDepth).toHaveBeenCalledWith(0);
+    });
+  });
+
+  // ── getLastCleanupResult ───────────────────────────────────────────────────
+
+  describe('getLastCleanupResult', () => {
+    it('should return null before first cleanup', () => {
+      const result = service.getLastCleanupResult();
+
+      expect(result.result).toBeNull();
+      expect(result.runAt).toBeNull();
+    });
+  });
+
+  // ── getRetentionConfig ─────────────────────────────────────────────────────
+
+  describe('getRetentionConfig', () => {
+    it('should return retention configuration', () => {
+      const config = service.getRetentionConfig();
+
+      expect(config.retentionDays).toBe(90);
+      expect(config.cronExpression).toBeDefined();
+    });
+  });
+});

--- a/src/trades/services/trade-dlq-cleanup.service.ts
+++ b/src/trades/services/trade-dlq-cleanup.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Trade, TradeStatus } from '../entities/trade.entity';
+import { DeadLetterService } from '../../jobs/dead-letter.service';
+import { TradeDlqMetricsService } from './trade-dlq-metrics.service';
+
+export interface CleanupResult {
+  archivedCount: number;
+  dlqEntriesRemoved: number;
+  errors: string[];
+  durationMs: number;
+}
+
+/**
+ * #999 -- Scheduled cleanup service for the trade DLQ.
+ *
+ * Runs daily to:
+ * 1. Archive old FAILED trades that have been discarded and exceed retention
+ * 2. Remove stale DLQ entries from the Bull dead-letter queue
+ * 3. Sync DLQ depth metrics
+ */
+@Injectable()
+export class TradeDlqCleanupService {
+  private readonly logger = new Logger(TradeDlqCleanupService.name);
+  private readonly retentionDays: number;
+  private lastCleanupResult: CleanupResult | null = null;
+  private lastCleanupAt: Date | null = null;
+
+  constructor(
+    @InjectRepository(Trade)
+    private readonly tradeRepository: Repository<Trade>,
+    private readonly deadLetterService: DeadLetterService,
+    private readonly metricsService: TradeDlqMetricsService,
+    private readonly configService: ConfigService,
+  ) {
+    this.retentionDays = this.configService.get<number>(
+      'dlq.retentionDays',
+      90,
+    );
+  }
+
+  /**
+   * Daily cleanup job. Runs at 3 AM to avoid peak hours.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async handleDailyCleanup(): Promise<void> {
+    this.logger.log('Starting daily DLQ cleanup job');
+    try {
+      const result = await this.cleanupOldEntries(this.retentionDays);
+      this.lastCleanupResult = result;
+      this.lastCleanupAt = new Date();
+
+      this.logger.log(
+        `DLQ cleanup completed in ${result.durationMs}ms: ` +
+        `archived=${result.archivedCount}, dlqRemoved=${result.dlqEntriesRemoved}, ` +
+        `errors=${result.errors.length}`,
+      );
+    } catch (error: any) {
+      this.logger.error(`DLQ cleanup failed: ${error.message}`, error.stack);
+    }
+
+    // Sync DLQ depth metrics after cleanup
+    await this.syncDlqDepth();
+  }
+
+  /**
+   * Archive old DLQ entries that exceed the retention period.
+   */
+  async cleanupOldEntries(retentionDays: number): Promise<CleanupResult> {
+    const startTime = Date.now();
+    const errors: string[] = [];
+    let archivedCount = 0;
+    let dlqEntriesRemoved = 0;
+
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+    // 1. Find old failed trades that have been discarded
+    const oldDiscardedTrades = await this.tradeRepository
+      .createQueryBuilder('trade')
+      .where('trade.status = :status', { status: TradeStatus.FAILED })
+      .andWhere('trade.updatedAt < :cutoff', { cutoff: cutoffDate })
+      .andWhere("trade.metadata->>'discarded' IS NOT NULL")
+      .getMany();
+
+    this.logger.debug(
+      `Found ${oldDiscardedTrades.length} discarded failed trades older than ${retentionDays} days`,
+    );
+
+    // 2. Soft-delete old discarded trades
+    for (const trade of oldDiscardedTrades) {
+      try {
+        trade.metadata = {
+          ...trade.metadata,
+          archivedAt: new Date().toISOString(),
+          archivedReason: `DLQ cleanup: exceeded ${retentionDays}-day retention`,
+        };
+        await this.tradeRepository.softDelete(trade.id);
+        archivedCount++;
+      } catch (error: any) {
+        const msg = `Failed to archive trade ${trade.id}: ${error.message}`;
+        errors.push(msg);
+        this.logger.warn(msg);
+      }
+    }
+
+    // 3. Clean up stale DLQ entries
+    try {
+      const dlqJobs = await this.deadLetterService.list();
+      for (const job of dlqJobs) {
+        const failedAt = job.data?.failedAt;
+        if (failedAt && new Date(failedAt) < cutoffDate) {
+          try {
+            await this.deadLetterService.discard(String(job.id));
+            dlqEntriesRemoved++;
+          } catch (error: any) {
+            const msg = `Failed to remove DLQ entry ${job.id}: ${error.message}`;
+            errors.push(msg);
+            this.logger.warn(msg);
+          }
+        }
+      }
+    } catch (error: any) {
+      const msg = `Failed to list DLQ jobs for cleanup: ${error.message}`;
+      errors.push(msg);
+      this.logger.error(msg);
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    return {
+      archivedCount,
+      dlqEntriesRemoved,
+      errors,
+      durationMs,
+    };
+  }
+
+  /**
+   * Sync the DLQ depth metric with the actual queue state.
+   */
+  async syncDlqDepth(): Promise<void> {
+    try {
+      const dlqJobs = await this.deadLetterService.list();
+      const tradeDlqJobs = dlqJobs.filter(
+        (job) => job.data?.queue === 'transactions',
+      );
+      this.metricsService.setDlqDepth(tradeDlqJobs.length);
+    } catch (error: any) {
+      this.logger.warn(`Failed to sync DLQ depth: ${error.message}`);
+    }
+  }
+
+  /**
+   * Get the result of the last cleanup run.
+   */
+  getLastCleanupResult(): { result: CleanupResult | null; runAt: string | null } {
+    return {
+      result: this.lastCleanupResult,
+      runAt: this.lastCleanupAt?.toISOString() ?? null,
+    };
+  }
+
+  /**
+   * Get current retention configuration.
+   */
+  getRetentionConfig(): { retentionDays: number; cronExpression: string } {
+    return {
+      retentionDays: this.retentionDays,
+      cronExpression: CronExpression.EVERY_DAY_AT_3AM,
+    };
+  }
+}

--- a/src/trades/services/trade-dlq-metrics.service.spec.ts
+++ b/src/trades/services/trade-dlq-metrics.service.spec.ts
@@ -1,0 +1,270 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { TradeDlqMetricsService } from './trade-dlq-metrics.service';
+
+describe('TradeDlqMetricsService', () => {
+  let service: TradeDlqMetricsService;
+
+  beforeEach(async () => {
+    const mockConfigService = {
+      get: jest.fn().mockReturnValue(1000),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeDlqMetricsService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(TradeDlqMetricsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    service.reset();
+  });
+
+  // ── recordFailure ──────────────────────────────────────────────────────────
+
+  describe('recordFailure', () => {
+    it('should increment total failure count', () => {
+      service.recordFailure('trade-1', 'timeout error');
+      service.recordFailure('trade-2', 'network error');
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalFailures).toBe(2);
+    });
+
+    it('should increment current DLQ depth', () => {
+      service.recordFailure('trade-1', 'error');
+      service.recordFailure('trade-2', 'error');
+
+      const metrics = service.getMetrics();
+      expect(metrics.currentDlqDepth).toBe(2);
+    });
+
+    it('should categorize and count failure reasons', () => {
+      service.recordFailure('t1', 'Network timeout');
+      service.recordFailure('t2', 'Connection timed out');
+      service.recordFailure('t3', 'Insufficient balance');
+      service.recordFailure('t4', 'Soroban contract reverted');
+
+      const metrics = service.getMetrics();
+      expect(metrics.failureReasonDistribution['Timeout']).toBe(2);
+      expect(metrics.failureReasonDistribution['Insufficient Balance']).toBe(1);
+      expect(metrics.failureReasonDistribution['Smart Contract Error']).toBe(1);
+    });
+
+    it('should categorize unknown errors as Other', () => {
+      service.recordFailure('t1', 'Some unexpected error');
+
+      const metrics = service.getMetrics();
+      expect(metrics.failureReasonDistribution['Other']).toBe(1);
+    });
+
+    it('should categorize RPC/Horizon errors correctly', () => {
+      service.recordFailure('t1', 'Horizon server returned 503');
+      service.recordFailure('t2', 'RPC endpoint unavailable');
+
+      const metrics = service.getMetrics();
+      expect(metrics.failureReasonDistribution['RPC/Horizon Error']).toBe(2);
+    });
+
+    it('should categorize slippage errors correctly', () => {
+      service.recordFailure('t1', 'Slippage exceeded threshold');
+
+      const metrics = service.getMetrics();
+      expect(metrics.failureReasonDistribution['Slippage Exceeded']).toBe(1);
+    });
+
+    it('should categorize network errors correctly', () => {
+      service.recordFailure('t1', 'Network connection refused');
+
+      const metrics = service.getMetrics();
+      expect(metrics.failureReasonDistribution['Network Error']).toBe(1);
+    });
+  });
+
+  // ── recordRetry ────────────────────────────────────────────────────────────
+
+  describe('recordRetry', () => {
+    it('should increment total retry count', () => {
+      service.recordRetry('t1', true);
+      service.recordRetry('t2', false);
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalRetries).toBe(2);
+    });
+
+    it('should decrement DLQ depth on successful retry', () => {
+      service.recordFailure('t1', 'error');
+      service.recordFailure('t2', 'error');
+      expect(service.getMetrics().currentDlqDepth).toBe(2);
+
+      service.recordRetry('t1', true);
+      expect(service.getMetrics().currentDlqDepth).toBe(1);
+    });
+
+    it('should not decrement DLQ depth on failed retry', () => {
+      service.recordFailure('t1', 'error');
+      service.recordRetry('t1', false);
+
+      expect(service.getMetrics().currentDlqDepth).toBe(1);
+    });
+
+    it('should not go below zero for DLQ depth', () => {
+      service.recordRetry('t1', true);
+
+      expect(service.getMetrics().currentDlqDepth).toBe(0);
+    });
+
+    it('should calculate retry success rate correctly', () => {
+      service.recordRetry('t1', true);
+      service.recordRetry('t2', true);
+      service.recordRetry('t3', false);
+      service.recordRetry('t4', true);
+
+      const metrics = service.getMetrics();
+      expect(metrics.retrySuccessRate).toBe(75);
+    });
+
+    it('should return 0 retry success rate when no retries', () => {
+      const metrics = service.getMetrics();
+      expect(metrics.retrySuccessRate).toBe(0);
+    });
+  });
+
+  // ── recordDiscard ──────────────────────────────────────────────────────────
+
+  describe('recordDiscard', () => {
+    it('should increment discard count', () => {
+      service.recordDiscard('t1');
+      service.recordDiscard('t2');
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalDiscards).toBe(2);
+    });
+
+    it('should decrement DLQ depth on discard', () => {
+      service.recordFailure('t1', 'error');
+      service.recordDiscard('t1');
+
+      expect(service.getMetrics().currentDlqDepth).toBe(0);
+    });
+  });
+
+  // ── setDlqDepth ────────────────────────────────────────────────────────────
+
+  describe('setDlqDepth', () => {
+    it('should set the DLQ depth directly', () => {
+      service.setDlqDepth(42);
+
+      expect(service.getMetrics().currentDlqDepth).toBe(42);
+    });
+  });
+
+  // ── getMetrics ─────────────────────────────────────────────────────────────
+
+  describe('getMetrics', () => {
+    it('should return complete metrics snapshot', () => {
+      service.recordFailure('t1', 'timeout');
+      service.recordRetry('t1', true);
+      service.recordDiscard('t2');
+
+      const metrics = service.getMetrics();
+
+      expect(metrics.totalFailures).toBe(1);
+      expect(metrics.totalRetries).toBe(1);
+      expect(metrics.totalDiscards).toBe(1);
+      expect(metrics.lastUpdated).toBeDefined();
+      expect(metrics.uptimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should return all zeroes when no events recorded', () => {
+      const metrics = service.getMetrics();
+
+      expect(metrics.totalFailures).toBe(0);
+      expect(metrics.totalRetries).toBe(0);
+      expect(metrics.totalDiscards).toBe(0);
+      expect(metrics.currentDlqDepth).toBe(0);
+    });
+  });
+
+  // ── getFailuresInWindow ────────────────────────────────────────────────────
+
+  describe('getFailuresInWindow', () => {
+    it('should count failures within time window', () => {
+      service.recordFailure('t1', 'error');
+      service.recordFailure('t2', 'error');
+
+      const count = service.getFailuresInWindow(60_000); // last minute
+      expect(count).toBe(2);
+    });
+
+    it('should return 0 when no failures in window', () => {
+      const count = service.getFailuresInWindow(1); // 1ms window
+      expect(count).toBe(0);
+    });
+  });
+
+  // ── getRetrySuccessRateInWindow ────────────────────────────────────────────
+
+  describe('getRetrySuccessRateInWindow', () => {
+    it('should calculate rate within window', () => {
+      service.recordRetry('t1', true);
+      service.recordRetry('t2', false);
+
+      const rate = service.getRetrySuccessRateInWindow(60_000);
+      expect(rate).toBe(50);
+    });
+
+    it('should return 0 when no retries in window', () => {
+      const rate = service.getRetrySuccessRateInWindow(60_000);
+      expect(rate).toBe(0);
+    });
+  });
+
+  // ── getTopFailureReasons ───────────────────────────────────────────────────
+
+  describe('getTopFailureReasons', () => {
+    it('should return top N reasons sorted by count', () => {
+      service.recordFailure('t1', 'timeout');
+      service.recordFailure('t2', 'timeout');
+      service.recordFailure('t3', 'timeout');
+      service.recordFailure('t4', 'network error');
+      service.recordFailure('t5', 'network error');
+      service.recordFailure('t6', 'soroban contract error');
+
+      const top = service.getTopFailureReasons(2);
+      expect(top).toHaveLength(2);
+      expect(top[0].reason).toBe('Timeout');
+      expect(top[0].count).toBe(3);
+      expect(top[1].reason).toBe('Network Error');
+    });
+
+    it('should return empty array when no failures', () => {
+      const top = service.getTopFailureReasons(5);
+      expect(top).toHaveLength(0);
+    });
+  });
+
+  // ── reset ──────────────────────────────────────────────────────────────────
+
+  describe('reset', () => {
+    it('should clear all counters and records', () => {
+      service.recordFailure('t1', 'error');
+      service.recordRetry('t1', true);
+      service.recordDiscard('t2');
+
+      service.reset();
+
+      const metrics = service.getMetrics();
+      expect(metrics.totalFailures).toBe(0);
+      expect(metrics.totalRetries).toBe(0);
+      expect(metrics.totalDiscards).toBe(0);
+      expect(metrics.currentDlqDepth).toBe(0);
+      expect(Object.keys(metrics.failureReasonDistribution)).toHaveLength(0);
+    });
+  });
+});

--- a/src/trades/services/trade-dlq-metrics.service.ts
+++ b/src/trades/services/trade-dlq-metrics.service.ts
@@ -1,0 +1,207 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface DlqMetricsSnapshot {
+  totalFailures: number;
+  totalRetries: number;
+  totalDiscards: number;
+  retrySuccessRate: number;
+  failureReasonDistribution: Record<string, number>;
+  currentDlqDepth: number;
+  lastUpdated: string;
+  uptimeMs: number;
+}
+
+interface FailureRecord {
+  tradeId: string;
+  reason: string;
+  timestamp: Date;
+}
+
+interface RetryRecord {
+  tradeId: string;
+  success: boolean;
+  timestamp: Date;
+}
+
+/**
+ * #999 -- In-memory metrics collector for DLQ operations.
+ *
+ * Tracks failure counts, retry success rates, and reason distributions.
+ * Intended for lightweight monitoring; for production-grade metrics,
+ * integrate with Prometheus via prom-client.
+ */
+@Injectable()
+export class TradeDlqMetricsService {
+  private readonly logger = new Logger(TradeDlqMetricsService.name);
+  private readonly startTime = Date.now();
+
+  private totalFailures = 0;
+  private totalRetries = 0;
+  private totalSuccessfulRetries = 0;
+  private totalDiscards = 0;
+  private currentDlqDepth = 0;
+
+  private readonly failureReasons: Record<string, number> = {};
+  private readonly recentFailures: FailureRecord[] = [];
+  private readonly recentRetries: RetryRecord[] = [];
+
+  private readonly maxRecentRecords: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.maxRecentRecords = this.configService.get<number>(
+      'dlq.metrics.maxRecentRecords',
+      1000,
+    );
+  }
+
+  /**
+   * Record a job failure event.
+   */
+  recordFailure(tradeId: string, reason: string): void {
+    this.totalFailures++;
+    this.currentDlqDepth++;
+
+    const category = this.categorizeReason(reason);
+    this.failureReasons[category] = (this.failureReasons[category] || 0) + 1;
+
+    this.recentFailures.push({
+      tradeId,
+      reason: category,
+      timestamp: new Date(),
+    });
+
+    // Prune old records to prevent unbounded growth
+    if (this.recentFailures.length > this.maxRecentRecords) {
+      this.recentFailures.splice(0, this.recentFailures.length - this.maxRecentRecords);
+    }
+
+    this.logger.debug(
+      `DLQ metrics: failure recorded for trade ${tradeId} (reason: ${category}). Total: ${this.totalFailures}`,
+    );
+  }
+
+  /**
+   * Record a retry event (success or failure).
+   */
+  recordRetry(tradeId: string, success: boolean): void {
+    this.totalRetries++;
+    if (success) {
+      this.totalSuccessfulRetries++;
+      this.currentDlqDepth = Math.max(0, this.currentDlqDepth - 1);
+    }
+
+    this.recentRetries.push({
+      tradeId,
+      success,
+      timestamp: new Date(),
+    });
+
+    if (this.recentRetries.length > this.maxRecentRecords) {
+      this.recentRetries.splice(0, this.recentRetries.length - this.maxRecentRecords);
+    }
+
+    this.logger.debug(
+      `DLQ metrics: retry recorded for trade ${tradeId} (success: ${success}). Total retries: ${this.totalRetries}`,
+    );
+  }
+
+  /**
+   * Record a discard event.
+   */
+  recordDiscard(tradeId: string): void {
+    this.totalDiscards++;
+    this.currentDlqDepth = Math.max(0, this.currentDlqDepth - 1);
+
+    this.logger.debug(
+      `DLQ metrics: discard recorded for trade ${tradeId}. Total discards: ${this.totalDiscards}`,
+    );
+  }
+
+  /**
+   * Update the current DLQ depth (called during periodic sync).
+   */
+  setDlqDepth(depth: number): void {
+    this.currentDlqDepth = depth;
+  }
+
+  /**
+   * Get a snapshot of all current metrics.
+   */
+  getMetrics(): DlqMetricsSnapshot {
+    const retrySuccessRate =
+      this.totalRetries > 0
+        ? (this.totalSuccessfulRetries / this.totalRetries) * 100
+        : 0;
+
+    return {
+      totalFailures: this.totalFailures,
+      totalRetries: this.totalRetries,
+      totalDiscards: this.totalDiscards,
+      retrySuccessRate: Math.round(retrySuccessRate * 100) / 100,
+      failureReasonDistribution: { ...this.failureReasons },
+      currentDlqDepth: this.currentDlqDepth,
+      lastUpdated: new Date().toISOString(),
+      uptimeMs: Date.now() - this.startTime,
+    };
+  }
+
+  /**
+   * Get failure counts within a specific time window.
+   */
+  getFailuresInWindow(windowMs: number): number {
+    const cutoff = new Date(Date.now() - windowMs);
+    return this.recentFailures.filter((f) => f.timestamp >= cutoff).length;
+  }
+
+  /**
+   * Get retry success rate within a specific time window.
+   */
+  getRetrySuccessRateInWindow(windowMs: number): number {
+    const cutoff = new Date(Date.now() - windowMs);
+    const recentRetries = this.recentRetries.filter(
+      (r) => r.timestamp >= cutoff,
+    );
+    if (recentRetries.length === 0) return 0;
+
+    const successes = recentRetries.filter((r) => r.success).length;
+    return (successes / recentRetries.length) * 100;
+  }
+
+  /**
+   * Get the top N failure reasons by count.
+   */
+  getTopFailureReasons(n: number = 5): Array<{ reason: string; count: number }> {
+    return Object.entries(this.failureReasons)
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, n);
+  }
+
+  /**
+   * Reset all metrics counters. Primarily for testing.
+   */
+  reset(): void {
+    this.totalFailures = 0;
+    this.totalRetries = 0;
+    this.totalSuccessfulRetries = 0;
+    this.totalDiscards = 0;
+    this.currentDlqDepth = 0;
+    Object.keys(this.failureReasons).forEach(
+      (key) => delete this.failureReasons[key],
+    );
+    this.recentFailures.length = 0;
+    this.recentRetries.length = 0;
+  }
+
+  private categorizeReason(reason: string): string {
+    const lower = reason.toLowerCase();
+    if (lower.includes('timeout') || lower.includes('timed out')) return 'Timeout';
+    if (lower.includes('insufficient') || lower.includes('balance')) return 'Insufficient Balance';
+    if (lower.includes('network') || lower.includes('connection')) return 'Network Error';
+    if (lower.includes('soroban') || lower.includes('contract')) return 'Smart Contract Error';
+    if (lower.includes('rpc') || lower.includes('horizon')) return 'RPC/Horizon Error';
+    if (lower.includes('slippage')) return 'Slippage Exceeded';
+    return 'Other';
+  }
+}

--- a/src/trades/services/trade-dlq.service.spec.ts
+++ b/src/trades/services/trade-dlq.service.spec.ts
@@ -1,0 +1,858 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import {
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { TradeDlqService } from './trade-dlq.service';
+import { Trade, TradeStatus, TradeSide } from '../entities/trade.entity';
+import { DeadLetterService } from '../../jobs/dead-letter.service';
+import { NotificationService } from '../../notifications/notification.service';
+import { NotificationChannel } from '../../notifications/entities/notification.entity';
+import { createMockRepository } from '../../../test/utils/test-helpers';
+
+const mockTrade = (overrides: Partial<Trade> = {}): Trade =>
+  ({
+    id: 'trade-001',
+    userId: 'user-001',
+    signalId: 'signal-001',
+    status: TradeStatus.FAILED,
+    side: TradeSide.BUY,
+    baseAsset: 'XLM',
+    counterAsset: 'USDC',
+    entryPrice: '0.10',
+    amount: '1000',
+    totalValue: '100',
+    feeAmount: '0.01',
+    errorMessage: 'Soroban contract call timed out',
+    metadata: {
+      dlq: {
+        jobId: 'job-001',
+        attemptsMade: 3,
+        failedAt: '2024-06-01T12:00:00.000Z',
+        failedReason: 'Soroban contract call timed out',
+      },
+    },
+    createdAt: new Date('2024-06-01T10:00:00.000Z'),
+    updatedAt: new Date('2024-06-01T12:00:00.000Z'),
+    ...overrides,
+  }) as any;
+
+const mockJob = (overrides: Partial<any> = {}) => ({
+  id: 'job-001',
+  data: { tradeId: 'trade-001', userId: 'user-001' },
+  attemptsMade: 3,
+  opts: { attempts: 3 },
+  queue: { name: 'transactions' },
+  ...overrides,
+});
+
+describe('TradeDlqService', () => {
+  let service: TradeDlqService;
+  let mockRepository: any;
+  let mockQueue: any;
+  let mockDeadLetterService: any;
+  let mockNotificationService: any;
+  let mockConfigService: any;
+
+  beforeEach(async () => {
+    mockRepository = createMockRepository();
+    mockRepository.createQueryBuilder = jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      select: jest.fn().mockReturnThis(),
+    }));
+
+    mockQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'new-job-001' }),
+    };
+
+    mockDeadLetterService = {
+      capture: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([]),
+      discard: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockNotificationService = {
+      send: jest.fn().mockResolvedValue({ id: 'notif-001' }),
+    };
+
+    mockConfigService = {
+      get: jest.fn((key: string, def: unknown) => {
+        const map: Record<string, unknown> = {
+          'dlq.maxRetryAttempts': 5,
+          'dlq.retryCooldownMs': 60000,
+        };
+        return map[key] ?? def;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TradeDlqService,
+        { provide: getRepositoryToken(Trade), useValue: mockRepository },
+        { provide: 'BullQueue_transactions', useValue: mockQueue },
+        { provide: DeadLetterService, useValue: mockDeadLetterService },
+        { provide: NotificationService, useValue: mockNotificationService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(TradeDlqService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── handleFailedJob ────────────────────────────────────────────────────────
+
+  describe('handleFailedJob', () => {
+    it('should update trade to FAILED status and store error details', async () => {
+      const trade = mockTrade({ status: TradeStatus.EXECUTING });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      const job = mockJob();
+      const error = new Error('Network timeout');
+
+      await service.handleFailedJob(job, error);
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'trade-001' },
+      });
+      expect(mockRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: TradeStatus.FAILED,
+          errorMessage: 'Network timeout',
+        }),
+      );
+    });
+
+    it('should store DLQ metadata including jobId, attemptsMade, and failedAt', async () => {
+      const trade = mockTrade({ status: TradeStatus.EXECUTING, metadata: {} });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      const job = mockJob({ attemptsMade: 5 });
+      const error = new Error('Contract call failed');
+
+      await service.handleFailedJob(job, error);
+
+      const savedTrade = mockRepository.save.mock.calls[0][0];
+      expect(savedTrade.metadata.dlq).toBeDefined();
+      expect(savedTrade.metadata.dlq.jobId).toBe('job-001');
+      expect(savedTrade.metadata.dlq.attemptsMade).toBe(5);
+      expect(savedTrade.metadata.dlq.failedReason).toBe('Contract call failed');
+      expect(savedTrade.metadata.dlq.failedAt).toBeDefined();
+    });
+
+    it('should capture the job to the dead letter queue', async () => {
+      const trade = mockTrade({ status: TradeStatus.EXECUTING });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      const job = mockJob();
+      const error = new Error('Test error');
+
+      await service.handleFailedJob(job, error);
+
+      expect(mockDeadLetterService.capture).toHaveBeenCalledWith(job, error);
+    });
+
+    it('should send failure notification to the trade owner', async () => {
+      const trade = mockTrade({
+        status: TradeStatus.EXECUTING,
+        userId: 'user-xyz',
+        baseAsset: 'BTC',
+        counterAsset: 'USDC',
+        amount: '0.5',
+        side: TradeSide.SELL,
+      });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      const job = mockJob({ attemptsMade: 3 });
+      const error = new Error('Insufficient balance');
+
+      await service.handleFailedJob(job, error);
+
+      expect(mockNotificationService.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-xyz',
+          type: 'TRADE_EXECUTED',
+          title: 'Trade Failed',
+          channel: NotificationChannel.IN_APP,
+        }),
+      );
+
+      const notification = mockNotificationService.send.mock.calls[0][0];
+      expect(notification.message).toContain('SELL');
+      expect(notification.message).toContain('BTC/USDC');
+      expect(notification.message).toContain('Insufficient balance');
+      expect(notification.metadata.tradeId).toBe(trade.id);
+    });
+
+    it('should skip trade update when job has no tradeId', async () => {
+      const job = mockJob({ data: {} });
+      const error = new Error('No trade ID');
+
+      await service.handleFailedJob(job, error);
+
+      expect(mockRepository.findOne).not.toHaveBeenCalled();
+      expect(mockDeadLetterService.capture).toHaveBeenCalledWith(job, error);
+    });
+
+    it('should capture to DLQ when trade is not found in database', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      const job = mockJob();
+      const error = new Error('Test error');
+
+      await service.handleFailedJob(job, error);
+
+      expect(mockDeadLetterService.capture).toHaveBeenCalledWith(job, error);
+      expect(mockRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when notification sending fails', async () => {
+      const trade = mockTrade({ status: TradeStatus.EXECUTING });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+      mockNotificationService.send.mockRejectedValue(
+        new Error('Notification service unavailable'),
+      );
+
+      const job = mockJob();
+      const error = new Error('Test error');
+
+      await expect(
+        service.handleFailedJob(job, error),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // ── retryTrade ─────────────────────────────────────────────────────────────
+
+  describe('retryTrade', () => {
+    it('should re-enqueue the trade and transition to PENDING', async () => {
+      const trade = mockTrade({ metadata: { dlq: { failedReason: 'timeout' } } });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      const result = await service.retryTrade('trade-001', 'user-001');
+
+      expect(result.tradeId).toBe('trade-001');
+      expect(result.newJobId).toBe('new-job-001');
+      expect(result.status).toBe(TradeStatus.PENDING);
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'execute-trade',
+        expect.objectContaining({ tradeId: 'trade-001', isRetry: true }),
+        expect.objectContaining({ priority: 100, attempts: 3 }),
+      );
+    });
+
+    it('should record retry in trade metadata history', async () => {
+      const trade = mockTrade({ metadata: { dlq: { failedReason: 'timeout' } } });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      await service.retryTrade('trade-001', 'user-001');
+
+      const savedTrade = mockRepository.save.mock.calls[0][0];
+      expect(savedTrade.metadata.retryHistory).toBeDefined();
+      expect(savedTrade.metadata.retryHistory.length).toBe(1);
+      expect(savedTrade.metadata.retryHistory[0].previousError).toBe('timeout');
+      expect(savedTrade.metadata.retryHistory[0].newJobId).toBe('new-job-001');
+    });
+
+    it('should clear error message and DLQ metadata after retry', async () => {
+      const trade = mockTrade();
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      await service.retryTrade('trade-001', 'user-001');
+
+      const savedTrade = mockRepository.save.mock.calls[0][0];
+      expect(savedTrade.errorMessage).toBeUndefined();
+      expect(savedTrade.metadata.dlq).toBeUndefined();
+    });
+
+    it('should throw NotFoundException when trade does not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.retryTrade('nonexistent', 'user-001'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when user does not own the trade', async () => {
+      const trade = mockTrade({ userId: 'other-user' });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      await expect(
+        service.retryTrade('trade-001', 'user-001'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw BadRequestException when trade is not in FAILED status', async () => {
+      const trade = mockTrade({ status: TradeStatus.PENDING });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      await expect(
+        service.retryTrade('trade-001', 'user-001'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when max retries exceeded', async () => {
+      const retryHistory = Array.from({ length: 5 }, (_, i) => ({
+        retriedAt: new Date(Date.now() - (5 - i) * 120000).toISOString(),
+        newJobId: `job-${i}`,
+      }));
+      const trade = mockTrade({ metadata: { retryHistory } });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      await expect(
+        service.retryTrade('trade-001', 'user-001'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should include original trade data in retry job', async () => {
+      const trade = mockTrade({
+        signalId: 'sig-999',
+        side: TradeSide.SELL,
+        baseAsset: 'ETH',
+        counterAsset: 'USDC',
+        entryPrice: '3500.00',
+        amount: '2.5',
+        totalValue: '8750.00',
+        stopLossPrice: '3200.00',
+        takeProfitPrice: '4000.00',
+        metadata: { dlq: { failedReason: 'test' } },
+      });
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+
+      await service.retryTrade('trade-001', 'user-001');
+
+      const jobData = mockQueue.add.mock.calls[0][1];
+      expect(jobData.signalId).toBe('sig-999');
+      expect(jobData.side).toBe(TradeSide.SELL);
+      expect(jobData.baseAsset).toBe('ETH');
+      expect(jobData.counterAsset).toBe('USDC');
+      expect(jobData.amount).toBe('2.5');
+      expect(jobData.stopLossPrice).toBe('3200.00');
+      expect(jobData.takeProfitPrice).toBe('4000.00');
+    });
+  });
+
+  // ── bulkRetry ──────────────────────────────────────────────────────────────
+
+  describe('bulkRetry', () => {
+    it('should retry multiple trades and return combined results', async () => {
+      const trade1 = mockTrade({ id: 'trade-001', metadata: { dlq: { failedReason: 'err1' } } });
+      const trade2 = mockTrade({ id: 'trade-002', metadata: { dlq: { failedReason: 'err2' } } });
+      mockRepository.findOne
+        .mockResolvedValueOnce(trade1)
+        .mockResolvedValueOnce(trade1) // canRetry check
+        .mockResolvedValueOnce(trade2)
+        .mockResolvedValueOnce(trade2); // canRetry check
+      mockRepository.save.mockResolvedValue({});
+
+      const result = await service.bulkRetry(
+        ['trade-001', 'trade-002'],
+        'user-001',
+      );
+
+      expect(result.totalRequested).toBe(2);
+      expect(result.successCount).toBe(2);
+      expect(result.failureCount).toBe(0);
+      expect(result.results).toHaveLength(2);
+    });
+
+    it('should handle partial failures in bulk retry', async () => {
+      const trade1 = mockTrade({ id: 'trade-001', metadata: { dlq: { failedReason: 'err1' } } });
+      mockRepository.findOne
+        .mockResolvedValueOnce(trade1) // retryTrade findOne
+        .mockResolvedValueOnce(trade1) // canRetry findOne
+        .mockResolvedValueOnce(null);  // second trade not found
+      mockRepository.save.mockResolvedValue({});
+
+      const result = await service.bulkRetry(
+        ['trade-001', 'nonexistent'],
+        'user-001',
+      );
+
+      expect(result.totalRequested).toBe(2);
+      expect(result.successCount).toBe(1);
+      expect(result.failureCount).toBe(1);
+      expect(result.results[0].success).toBe(true);
+      expect(result.results[1].success).toBe(false);
+    });
+
+    it('should handle empty trade IDs array gracefully', async () => {
+      const result = await service.bulkRetry([], 'user-001');
+
+      expect(result.totalRequested).toBe(0);
+      expect(result.successCount).toBe(0);
+      expect(result.failureCount).toBe(0);
+    });
+  });
+
+  // ── getFailedJobs ──────────────────────────────────────────────────────────
+
+  describe('getFailedJobs', () => {
+    it('should return a summary of failed trade jobs from DLQ', async () => {
+      mockDeadLetterService.list.mockResolvedValue([
+        {
+          id: 'dlq-1',
+          data: {
+            queue: 'transactions',
+            jobId: 'job-1',
+            data: { tradeId: 'trade-1', userId: 'user-1' },
+            failedReason: 'timeout',
+            attemptsMade: 3,
+            failedAt: '2024-06-01T12:00:00.000Z',
+          },
+        },
+        {
+          id: 'dlq-2',
+          data: {
+            queue: 'transactions',
+            jobId: 'job-2',
+            data: { tradeId: 'trade-2', userId: 'user-2' },
+            failedReason: 'balance insufficient',
+            attemptsMade: 3,
+            failedAt: '2024-06-01T13:00:00.000Z',
+          },
+        },
+      ]);
+
+      const result = await service.getFailedJobs(10);
+
+      expect(result.totalFailed).toBe(2);
+      expect(result.recentJobs).toHaveLength(2);
+      // Should be sorted by failedAt descending
+      expect(result.recentJobs[0].tradeId).toBe('trade-2');
+      expect(result.recentJobs[1].tradeId).toBe('trade-1');
+    });
+
+    it('should filter out non-transaction queue jobs', async () => {
+      mockDeadLetterService.list.mockResolvedValue([
+        {
+          id: 'dlq-1',
+          data: { queue: 'transactions', failedReason: 'err' },
+        },
+        {
+          id: 'dlq-2',
+          data: { queue: 'notifications', failedReason: 'err' },
+        },
+      ]);
+
+      const result = await service.getFailedJobs(10);
+
+      expect(result.totalFailed).toBe(1);
+    });
+
+    it('should respect the limit parameter', async () => {
+      const jobs = Array.from({ length: 20 }, (_, i) => ({
+        id: `dlq-${i}`,
+        data: {
+          queue: 'transactions',
+          data: { tradeId: `t-${i}` },
+          failedAt: new Date(Date.now() - i * 60000).toISOString(),
+        },
+      }));
+      mockDeadLetterService.list.mockResolvedValue(jobs);
+
+      const result = await service.getFailedJobs(5);
+
+      expect(result.totalFailed).toBe(20);
+      expect(result.recentJobs).toHaveLength(5);
+    });
+
+    it('should return empty summary when no failed jobs exist', async () => {
+      mockDeadLetterService.list.mockResolvedValue([]);
+
+      const result = await service.getFailedJobs(10);
+
+      expect(result.totalFailed).toBe(0);
+      expect(result.recentJobs).toHaveLength(0);
+    });
+  });
+
+  // ── getFailedJobsCount ─────────────────────────────────────────────────────
+
+  describe('getFailedJobsCount', () => {
+    it('should return the count of transaction-queue DLQ entries', async () => {
+      mockDeadLetterService.list.mockResolvedValue([
+        { id: '1', data: { queue: 'transactions' } },
+        { id: '2', data: { queue: 'transactions' } },
+        { id: '3', data: { queue: 'notifications' } },
+      ]);
+
+      const count = await service.getFailedJobsCount();
+
+      expect(count).toBe(2);
+    });
+  });
+
+  // ── getFailedTradesByUser ──────────────────────────────────────────────────
+
+  describe('getFailedTradesByUser', () => {
+    it('should return failed trades for a specific user', async () => {
+      const trades = [
+        mockTrade({ id: 'trade-1' }),
+        mockTrade({ id: 'trade-2' }),
+      ];
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([trades, 2]),
+      };
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getFailedTradesByUser('user-001');
+
+      expect(result.userId).toBe('user-001');
+      expect(result.totalFailed).toBe(2);
+      expect(result.trades).toHaveLength(2);
+    });
+
+    it('should return empty list when user has no failed trades', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getFailedTradesByUser('user-002');
+
+      expect(result.totalFailed).toBe(0);
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it('should apply baseAsset filter when provided', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getFailedTradesByUser(
+        'user-001', 1, 20, 'updatedAt', 'DESC', 'XLM',
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'trade.baseAsset = :baseAsset',
+        { baseAsset: 'XLM' },
+      );
+    });
+
+    it('should apply error filter when provided', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getFailedTradesByUser(
+        'user-001', 1, 20, 'updatedAt', 'DESC', undefined, 'timeout',
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'trade.errorMessage ILIKE :errorFilter',
+        { errorFilter: '%timeout%' },
+      );
+    });
+
+    it('should include retry count and canRetry flag per trade', async () => {
+      const trade = mockTrade({
+        metadata: {
+          dlq: { failedAt: '2024-01-01T00:00:00Z', failedReason: 'err' },
+          retryHistory: [
+            { retriedAt: '2024-01-01T01:00:00Z', newJobId: 'j1' },
+            { retriedAt: '2024-01-01T02:00:00Z', newJobId: 'j2' },
+          ],
+        },
+      });
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[trade], 1]),
+      };
+      mockRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getFailedTradesByUser('user-001');
+
+      expect(result.trades[0].retryCount).toBe(2);
+      expect(result.trades[0].canRetry).toBe(true);
+    });
+  });
+
+  // ── getFailedTradeStats ────────────────────────────────────────────────────
+
+  describe('getFailedTradeStats', () => {
+    it('should return aggregate failure statistics', async () => {
+      mockRepository.find.mockResolvedValue([
+        mockTrade({ errorMessage: 'Network timeout', updatedAt: new Date() }),
+        mockTrade({ errorMessage: 'Insufficient balance', updatedAt: new Date() }),
+        mockTrade({
+          errorMessage: 'Network error',
+          updatedAt: new Date(),
+          metadata: { retryHistory: [{ retriedAt: new Date().toISOString() }] },
+        }),
+      ]);
+      mockDeadLetterService.list.mockResolvedValue([
+        { data: { queue: 'transactions' } },
+      ]);
+
+      const result = await service.getFailedTradeStats();
+
+      expect(result.totalFailed).toBe(3);
+      expect(result.totalRetried).toBe(1);
+      expect(result.byErrorType.length).toBeGreaterThan(0);
+      expect(result.byTimePeriod.length).toBe(4);
+      expect(result.currentDlqDepth).toBe(1);
+    });
+
+    it('should categorize errors correctly', async () => {
+      mockRepository.find.mockResolvedValue([
+        mockTrade({ errorMessage: 'Soroban contract reverted', updatedAt: new Date() }),
+        mockTrade({ errorMessage: 'RPC endpoint unavailable', updatedAt: new Date() }),
+        mockTrade({ errorMessage: 'Something unexpected', updatedAt: new Date() }),
+      ]);
+      mockDeadLetterService.list.mockResolvedValue([]);
+
+      const result = await service.getFailedTradeStats();
+
+      const categories = result.byErrorType.map((e) => e.errorType);
+      expect(categories).toContain('Smart Contract Error');
+      expect(categories).toContain('RPC/Horizon Error');
+      expect(categories).toContain('Other');
+    });
+
+    it('should handle empty results', async () => {
+      mockRepository.find.mockResolvedValue([]);
+      mockDeadLetterService.list.mockResolvedValue([]);
+
+      const result = await service.getFailedTradeStats();
+
+      expect(result.totalFailed).toBe(0);
+      expect(result.totalRetried).toBe(0);
+      expect(result.byErrorType).toHaveLength(0);
+    });
+  });
+
+  // ── discardFailedJob ───────────────────────────────────────────────────────
+
+  describe('discardFailedJob', () => {
+    it('should mark trade as discarded and remove DLQ entry', async () => {
+      const trade = mockTrade();
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+      mockDeadLetterService.list.mockResolvedValue([
+        {
+          id: 'dlq-1',
+          data: { data: { tradeId: 'trade-001' }, queue: 'transactions' },
+        },
+      ]);
+
+      const result = await service.discardFailedJob('trade-001', 'admin-001');
+
+      expect(result.tradeId).toBe('trade-001');
+      expect(result.discardedBy).toBe('admin-001');
+      expect(mockDeadLetterService.discard).toHaveBeenCalledWith('dlq-1');
+      const savedTrade = mockRepository.save.mock.calls[0][0];
+      expect(savedTrade.metadata.discarded).toBeDefined();
+      expect(savedTrade.metadata.discarded.discardedBy).toBe('admin-001');
+    });
+
+    it('should throw NotFoundException when trade does not exist', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.discardFailedJob('nonexistent', 'admin-001'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when trade is not FAILED', async () => {
+      const trade = mockTrade({ status: TradeStatus.COMPLETED });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      await expect(
+        service.discardFailedJob('trade-001', 'admin-001'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should succeed even when no matching DLQ entry exists', async () => {
+      const trade = mockTrade();
+      mockRepository.findOne.mockResolvedValue(trade);
+      mockRepository.save.mockResolvedValue(trade);
+      mockDeadLetterService.list.mockResolvedValue([]);
+
+      const result = await service.discardFailedJob('trade-001', 'admin-001');
+
+      expect(result.tradeId).toBe('trade-001');
+      expect(mockDeadLetterService.discard).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── getRetryHistory ────────────────────────────────────────────────────────
+
+  describe('getRetryHistory', () => {
+    it('should return retry history entries from trade metadata', async () => {
+      const trade = mockTrade({
+        metadata: {
+          retryHistory: [
+            { retriedAt: '2024-01-01T01:00:00Z', previousError: 'timeout', newJobId: 'j1' },
+            { retriedAt: '2024-01-01T02:00:00Z', previousError: 'network', newJobId: 'j2' },
+          ],
+        },
+      });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.getRetryHistory('trade-001', 'user-001');
+
+      expect(result.tradeId).toBe('trade-001');
+      expect(result.totalRetries).toBe(2);
+      expect(result.entries).toHaveLength(2);
+      expect(result.entries[0].previousError).toBe('timeout');
+      expect(result.entries[1].newJobId).toBe('j2');
+    });
+
+    it('should return empty history when no retries exist', async () => {
+      const trade = mockTrade({ metadata: {} });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.getRetryHistory('trade-001', 'user-001');
+
+      expect(result.totalRetries).toBe(0);
+      expect(result.entries).toHaveLength(0);
+    });
+
+    it('should throw NotFoundException when trade not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getRetryHistory('nonexistent', 'user-001'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when user does not own trade', async () => {
+      const trade = mockTrade({ userId: 'other-user' });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      await expect(
+        service.getRetryHistory('trade-001', 'user-001'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ── canRetry ───────────────────────────────────────────────────────────────
+
+  describe('canRetry', () => {
+    it('should return canRetry=true for a retryable FAILED trade', async () => {
+      const trade = mockTrade({ metadata: {} });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.canRetry('trade-001', 'user-001');
+
+      expect(result.canRetry).toBe(true);
+    });
+
+    it('should return canRetry=false when trade not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.canRetry('nonexistent', 'user-001');
+
+      expect(result.canRetry).toBe(false);
+      expect(result.reason).toContain('not found');
+    });
+
+    it('should return canRetry=false when user does not own trade', async () => {
+      const trade = mockTrade({ userId: 'other-user' });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.canRetry('trade-001', 'user-001');
+
+      expect(result.canRetry).toBe(false);
+      expect(result.reason).toContain('do not own');
+    });
+
+    it('should return canRetry=false when trade is not FAILED', async () => {
+      const trade = mockTrade({ status: TradeStatus.PENDING });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.canRetry('trade-001', 'user-001');
+
+      expect(result.canRetry).toBe(false);
+      expect(result.reason).toContain('not FAILED');
+    });
+
+    it('should return canRetry=false when max retries exceeded', async () => {
+      const retryHistory = Array.from({ length: 5 }, (_, i) => ({
+        retriedAt: new Date(Date.now() - (5 - i) * 120000).toISOString(),
+        newJobId: `job-${i}`,
+      }));
+      const trade = mockTrade({ metadata: { retryHistory } });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.canRetry('trade-001', 'user-001');
+
+      expect(result.canRetry).toBe(false);
+      expect(result.reason).toContain('Maximum retry attempts');
+    });
+
+    it('should return canRetry=false during cooldown period', async () => {
+      const trade = mockTrade({
+        metadata: {
+          retryHistory: [
+            { retriedAt: new Date().toISOString(), newJobId: 'j1' },
+          ],
+        },
+      });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.canRetry('trade-001', 'user-001');
+
+      expect(result.canRetry).toBe(false);
+      expect(result.reason).toContain('wait');
+    });
+
+    it('should return canRetry=false when trade is discarded', async () => {
+      const trade = mockTrade({
+        metadata: { discarded: { discardedBy: 'admin', discardedAt: new Date().toISOString() } },
+      });
+      mockRepository.findOne.mockResolvedValue(trade);
+
+      const result = await service.canRetry('trade-001', 'user-001');
+
+      expect(result.canRetry).toBe(false);
+      expect(result.reason).toContain('discarded');
+    });
+  });
+});

--- a/src/trades/services/trade-dlq.service.ts
+++ b/src/trades/services/trade-dlq.service.ts
@@ -1,0 +1,684 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue, Job } from 'bull';
+import { ConfigService } from '@nestjs/config';
+import { Trade, TradeStatus } from '../entities/trade.entity';
+import { DeadLetterService } from '../../jobs/dead-letter.service';
+import { NotificationService } from '../../notifications/notification.service';
+import { NotificationChannel } from '../../notifications/entities/notification.entity';
+import {
+  TradeRetryResponseDto,
+  FailedJobDto,
+  FailedJobsSummaryDto,
+  BulkRetryItemResultDto,
+  BulkRetryResponseDto,
+  FailedTradeStatsDto,
+  ErrorTypeCountDto,
+  TimePeriodCountDto,
+  RetryHistoryDto,
+  RetryHistoryEntryDto,
+  UserFailedTradeDto,
+  UserFailedTradesDto,
+  CanRetryResponseDto,
+  DiscardResponseDto,
+} from '../dto/trade-retry-response.dto';
+
+const MAX_RETRY_ATTEMPTS = 5;
+const RETRY_COOLDOWN_MS = 60_000; // 1 minute between retries for same trade
+
+/**
+ * #999 -- Dead-letter queue handler service for permanently failed trade jobs.
+ *
+ * Responsibilities:
+ * - Updating trade records to FAILED when a job exhausts all retries
+ * - Storing failure details (reason + attempt count) on the trade entity
+ * - Sending user notifications with the failure reason and a retry CTA
+ * - Re-enqueueing failed trade jobs on user request (with ownership validation)
+ * - Providing admin views over failed trade jobs in the DLQ
+ * - Bulk retry support for multiple failed trades
+ * - Retry history tracking and business rule validation
+ */
+@Injectable()
+export class TradeDlqService {
+  private readonly logger = new Logger(TradeDlqService.name);
+  private readonly maxRetryAttempts: number;
+  private readonly retryCooldownMs: number;
+
+  constructor(
+    @InjectRepository(Trade)
+    private readonly tradeRepository: Repository<Trade>,
+    @InjectQueue('transactions')
+    private readonly transactionsQueue: Queue,
+    private readonly deadLetterService: DeadLetterService,
+    private readonly notificationService: NotificationService,
+    private readonly configService: ConfigService,
+  ) {
+    this.maxRetryAttempts = this.configService.get<number>(
+      'dlq.maxRetryAttempts',
+      MAX_RETRY_ATTEMPTS,
+    );
+    this.retryCooldownMs = this.configService.get<number>(
+      'dlq.retryCooldownMs',
+      RETRY_COOLDOWN_MS,
+    );
+  }
+
+  /**
+   * Handle a permanently failed trade job.
+   *
+   * Called by the TradeDlqProcessor when a job on the transactions queue
+   * has exhausted all retry attempts.
+   */
+  async handleFailedJob(job: Job, error: Error): Promise<void> {
+    const tradeId: string | undefined = job.data?.tradeId;
+
+    if (!tradeId) {
+      this.logger.warn(
+        `Failed job ${job.id} has no tradeId in data — skipping trade update`,
+      );
+      await this.deadLetterService.capture(job, error);
+      return;
+    }
+
+    this.logger.warn(
+      `Trade job ${job.id} for trade ${tradeId} permanently failed after ${job.attemptsMade} attempt(s): ${error.message}`,
+    );
+
+    const trade = await this.tradeRepository.findOne({ where: { id: tradeId } });
+
+    if (!trade) {
+      this.logger.error(
+        `Trade ${tradeId} not found in database — cannot mark as FAILED`,
+      );
+      await this.deadLetterService.capture(job, error);
+      return;
+    }
+
+    trade.status = TradeStatus.FAILED;
+    trade.errorMessage = error.message;
+    trade.metadata = {
+      ...trade.metadata,
+      dlq: {
+        jobId: job.id,
+        attemptsMade: job.attemptsMade,
+        failedAt: new Date().toISOString(),
+        failedReason: error.message,
+      },
+    };
+
+    await this.tradeRepository.save(trade);
+
+    this.logger.log(
+      `Trade ${tradeId} updated to FAILED status with error: ${error.message}`,
+    );
+
+    await this.deadLetterService.capture(job, error);
+
+    await this.sendFailureNotification(trade, error.message, job.attemptsMade);
+  }
+
+  /**
+   * Retry a failed trade by re-enqueueing its original job data.
+   */
+  async retryTrade(
+    tradeId: string,
+    userId: string,
+  ): Promise<TradeRetryResponseDto> {
+    const trade = await this.tradeRepository.findOne({
+      where: { id: tradeId },
+    });
+
+    if (!trade) {
+      throw new NotFoundException(`Trade ${tradeId} not found`);
+    }
+
+    if (trade.userId !== userId) {
+      throw new ForbiddenException(
+        'You are not authorized to retry this trade',
+      );
+    }
+
+    if (trade.status !== TradeStatus.FAILED) {
+      throw new BadRequestException(
+        `Trade ${tradeId} is not in FAILED status (current: ${trade.status}). Only failed trades can be retried.`,
+      );
+    }
+
+    const canRetryResult = await this.canRetry(tradeId, userId);
+    if (!canRetryResult.canRetry) {
+      throw new BadRequestException(
+        canRetryResult.reason || 'Trade cannot be retried at this time',
+      );
+    }
+
+    const originalJobData = this.buildRetryJobData(trade);
+
+    const newJob = await this.transactionsQueue.add('execute-trade', originalJobData, {
+      priority: 100,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2000 },
+    });
+
+    trade.status = TradeStatus.PENDING;
+    trade.errorMessage = undefined;
+    trade.metadata = {
+      ...trade.metadata,
+      retryHistory: [
+        ...((trade.metadata?.retryHistory as any[]) || []),
+        {
+          retriedAt: new Date().toISOString(),
+          previousError: trade.metadata?.dlq
+            ? (trade.metadata.dlq as Record<string, unknown>).failedReason
+            : undefined,
+          newJobId: newJob.id,
+        },
+      ],
+      dlq: undefined,
+    };
+
+    await this.tradeRepository.save(trade);
+
+    this.logger.log(
+      `Trade ${tradeId} retried by user ${userId} — new job ${newJob.id}`,
+    );
+
+    return {
+      tradeId: trade.id,
+      newJobId: String(newJob.id),
+      status: TradeStatus.PENDING,
+      message: `Trade ${tradeId} has been re-enqueued for processing`,
+    };
+  }
+
+  /**
+   * Retry multiple failed trades at once.
+   */
+  async bulkRetry(
+    tradeIds: string[],
+    userId: string,
+  ): Promise<BulkRetryResponseDto> {
+    const results: BulkRetryItemResultDto[] = [];
+    let successCount = 0;
+    let failureCount = 0;
+
+    for (const tradeId of tradeIds) {
+      try {
+        const retryResult = await this.retryTrade(tradeId, userId);
+        results.push({
+          tradeId,
+          success: true,
+          newJobId: retryResult.newJobId,
+        });
+        successCount++;
+      } catch (error: any) {
+        results.push({
+          tradeId,
+          success: false,
+          error: error.message,
+        });
+        failureCount++;
+        this.logger.warn(
+          `Bulk retry failed for trade ${tradeId}: ${error.message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Bulk retry completed: ${successCount} succeeded, ${failureCount} failed out of ${tradeIds.length}`,
+    );
+
+    return {
+      totalRequested: tradeIds.length,
+      successCount,
+      failureCount,
+      results,
+    };
+  }
+
+  /**
+   * Return the most recent failed trade jobs from the DLQ.
+   */
+  async getFailedJobs(limit: number = 10): Promise<FailedJobsSummaryDto> {
+    const allDlqJobs = await this.deadLetterService.list();
+
+    const tradeJobs = allDlqJobs.filter(
+      (job) => job.data?.queue === 'transactions',
+    );
+
+    const totalFailed = tradeJobs.length;
+
+    const sorted = tradeJobs
+      .sort((a, b) => {
+        const dateA = a.data?.failedAt || '';
+        const dateB = b.data?.failedAt || '';
+        return dateB.localeCompare(dateA);
+      })
+      .slice(0, limit);
+
+    const recentJobs: FailedJobDto[] = sorted.map((job) => ({
+      jobId: job.data?.jobId ?? job.id,
+      tradeId: (job.data?.data as Record<string, unknown>)?.tradeId as string || 'unknown',
+      userId: (job.data?.data as Record<string, unknown>)?.userId as string || 'unknown',
+      failedReason: job.data?.failedReason || 'Unknown error',
+      attemptsMade: job.data?.attemptsMade || 0,
+      failedAt: job.data?.failedAt || new Date().toISOString(),
+      tradeData: job.data?.data as Record<string, unknown> | undefined,
+    }));
+
+    return {
+      totalFailed,
+      recentJobs,
+    };
+  }
+
+  /**
+   * Return the total count of failed trade jobs currently in the DLQ.
+   */
+  async getFailedJobsCount(): Promise<number> {
+    const allDlqJobs = await this.deadLetterService.list();
+
+    return allDlqJobs.filter(
+      (job) => job.data?.queue === 'transactions',
+    ).length;
+  }
+
+  /**
+   * Get failed trades for a specific user with pagination.
+   */
+  async getFailedTradesByUser(
+    userId: string,
+    page: number = 1,
+    limit: number = 20,
+    sortBy: string = 'updatedAt',
+    sortOrder: 'ASC' | 'DESC' = 'DESC',
+    baseAsset?: string,
+    errorFilter?: string,
+  ): Promise<UserFailedTradesDto> {
+    const queryBuilder = this.tradeRepository
+      .createQueryBuilder('trade')
+      .where('trade.userId = :userId', { userId })
+      .andWhere('trade.status = :status', { status: TradeStatus.FAILED });
+
+    if (baseAsset) {
+      queryBuilder.andWhere('trade.baseAsset = :baseAsset', { baseAsset });
+    }
+
+    if (errorFilter) {
+      queryBuilder.andWhere('trade.errorMessage ILIKE :errorFilter', {
+        errorFilter: `%${errorFilter}%`,
+      });
+    }
+
+    const validSortFields: Record<string, string> = {
+      updatedAt: 'trade.updatedAt',
+      createdAt: 'trade.createdAt',
+      amount: 'trade.amount',
+      baseAsset: 'trade.baseAsset',
+    };
+    const sortField = validSortFields[sortBy] || 'trade.updatedAt';
+
+    queryBuilder
+      .orderBy(sortField, sortOrder)
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [trades, totalFailed] = await queryBuilder.getManyAndCount();
+
+    const tradeItems: UserFailedTradeDto[] = trades.map((trade) => {
+      const retryHistory = (trade.metadata?.retryHistory as any[]) || [];
+      return {
+        tradeId: trade.id,
+        baseAsset: trade.baseAsset,
+        counterAsset: trade.counterAsset,
+        side: trade.side,
+        amount: trade.amount,
+        entryPrice: trade.entryPrice,
+        errorMessage: trade.errorMessage,
+        failedAt: trade.metadata?.dlq
+          ? String((trade.metadata.dlq as Record<string, unknown>).failedAt)
+          : trade.updatedAt.toISOString(),
+        retryCount: retryHistory.length,
+        canRetry: retryHistory.length < this.maxRetryAttempts,
+      };
+    });
+
+    return {
+      userId,
+      totalFailed,
+      trades: tradeItems,
+    };
+  }
+
+  /**
+   * Get aggregate statistics for failed trade jobs.
+   */
+  async getFailedTradeStats(): Promise<FailedTradeStatsDto> {
+    const failedTrades = await this.tradeRepository.find({
+      where: { status: TradeStatus.FAILED },
+      select: ['id', 'errorMessage', 'metadata', 'updatedAt', 'createdAt'],
+    });
+
+    const totalFailed = failedTrades.length;
+
+    // Count retried trades (those with retryHistory in metadata)
+    let totalRetried = 0;
+    let totalDiscarded = 0;
+    const errorTypeCounts: Record<string, number> = {};
+
+    for (const trade of failedTrades) {
+      const retryHistory = (trade.metadata?.retryHistory as any[]) || [];
+      totalRetried += retryHistory.length;
+
+      if (trade.metadata?.discarded) {
+        totalDiscarded++;
+      }
+
+      const errorKey = this.categorizeError(trade.errorMessage || 'Unknown');
+      errorTypeCounts[errorKey] = (errorTypeCounts[errorKey] || 0) + 1;
+    }
+
+    const byErrorType: ErrorTypeCountDto[] = Object.entries(errorTypeCounts)
+      .map(([errorType, count]) => ({ errorType, count }))
+      .sort((a, b) => b.count - a.count);
+
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const byTimePeriod: TimePeriodCountDto[] = [
+      {
+        period: 'last_1h',
+        count: failedTrades.filter((t) => t.updatedAt >= oneHourAgo).length,
+      },
+      {
+        period: 'last_24h',
+        count: failedTrades.filter((t) => t.updatedAt >= oneDayAgo).length,
+      },
+      {
+        period: 'last_7d',
+        count: failedTrades.filter((t) => t.updatedAt >= oneWeekAgo).length,
+      },
+      {
+        period: 'last_30d',
+        count: failedTrades.filter((t) => t.updatedAt >= oneMonthAgo).length,
+      },
+    ];
+
+    const currentDlqDepth = await this.getFailedJobsCount();
+
+    return {
+      totalFailed,
+      totalRetried,
+      totalDiscarded,
+      byErrorType,
+      byTimePeriod,
+      currentDlqDepth,
+    };
+  }
+
+  /**
+   * Discard a failed trade job from the DLQ (admin action).
+   */
+  async discardFailedJob(
+    tradeId: string,
+    adminUserId: string,
+  ): Promise<DiscardResponseDto> {
+    const trade = await this.tradeRepository.findOne({
+      where: { id: tradeId },
+    });
+
+    if (!trade) {
+      throw new NotFoundException(`Trade ${tradeId} not found`);
+    }
+
+    if (trade.status !== TradeStatus.FAILED) {
+      throw new BadRequestException(
+        `Trade ${tradeId} is not in FAILED status (current: ${trade.status})`,
+      );
+    }
+
+    // Find and remove the corresponding DLQ entry
+    const dlqJobs = await this.deadLetterService.list();
+    const matchingJob = dlqJobs.find((job) => {
+      const jobData = job.data?.data as Record<string, unknown> | undefined;
+      return jobData?.tradeId === tradeId;
+    });
+
+    if (matchingJob) {
+      await this.deadLetterService.discard(String(matchingJob.id));
+    }
+
+    // Mark the trade as discarded in metadata
+    trade.metadata = {
+      ...trade.metadata,
+      discarded: {
+        discardedBy: adminUserId,
+        discardedAt: new Date().toISOString(),
+      },
+    };
+
+    await this.tradeRepository.save(trade);
+
+    this.logger.log(
+      `Trade ${tradeId} DLQ entry discarded by admin ${adminUserId}`,
+    );
+
+    return {
+      tradeId,
+      discardedBy: adminUserId,
+      discardedAt: new Date().toISOString(),
+      message: `DLQ entry for trade ${tradeId} has been discarded`,
+    };
+  }
+
+  /**
+   * Get retry history for a specific trade.
+   */
+  async getRetryHistory(
+    tradeId: string,
+    userId: string,
+  ): Promise<RetryHistoryDto> {
+    const trade = await this.tradeRepository.findOne({
+      where: { id: tradeId },
+    });
+
+    if (!trade) {
+      throw new NotFoundException(`Trade ${tradeId} not found`);
+    }
+
+    if (trade.userId !== userId) {
+      throw new ForbiddenException(
+        'You are not authorized to view this trade\'s retry history',
+      );
+    }
+
+    const retryHistory = (trade.metadata?.retryHistory as any[]) || [];
+
+    const entries: RetryHistoryEntryDto[] = retryHistory.map((entry: any) => ({
+      retriedAt: entry.retriedAt,
+      previousError: entry.previousError,
+      newJobId: String(entry.newJobId),
+    }));
+
+    return {
+      tradeId,
+      totalRetries: entries.length,
+      entries,
+    };
+  }
+
+  /**
+   * Check if a trade can be retried (business rule validation).
+   */
+  async canRetry(
+    tradeId: string,
+    userId: string,
+  ): Promise<CanRetryResponseDto> {
+    const trade = await this.tradeRepository.findOne({
+      where: { id: tradeId },
+    });
+
+    if (!trade) {
+      return {
+        tradeId,
+        canRetry: false,
+        reason: 'Trade not found',
+      };
+    }
+
+    if (trade.userId !== userId) {
+      return {
+        tradeId,
+        canRetry: false,
+        reason: 'You do not own this trade',
+      };
+    }
+
+    if (trade.status !== TradeStatus.FAILED) {
+      return {
+        tradeId,
+        canRetry: false,
+        reason: `Trade is in ${trade.status} status, not FAILED`,
+      };
+    }
+
+    // Check retry count limit
+    const retryHistory = (trade.metadata?.retryHistory as any[]) || [];
+    if (retryHistory.length >= this.maxRetryAttempts) {
+      return {
+        tradeId,
+        canRetry: false,
+        reason: `Maximum retry attempts (${this.maxRetryAttempts}) exceeded`,
+      };
+    }
+
+    // Check retry cooldown
+    if (retryHistory.length > 0) {
+      const lastRetry = retryHistory[retryHistory.length - 1];
+      const lastRetryTime = new Date(lastRetry.retriedAt).getTime();
+      const now = Date.now();
+      if (now - lastRetryTime < this.retryCooldownMs) {
+        const waitSeconds = Math.ceil(
+          (this.retryCooldownMs - (now - lastRetryTime)) / 1000,
+        );
+        return {
+          tradeId,
+          canRetry: false,
+          reason: `Please wait ${waitSeconds} second(s) before retrying again`,
+        };
+      }
+    }
+
+    // Check if trade was discarded
+    if (trade.metadata?.discarded) {
+      return {
+        tradeId,
+        canRetry: false,
+        reason: 'Trade has been discarded by an administrator',
+      };
+    }
+
+    return {
+      tradeId,
+      canRetry: true,
+    };
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private buildRetryJobData(trade: Trade): Record<string, unknown> {
+    return {
+      tradeId: trade.id,
+      userId: trade.userId,
+      signalId: trade.signalId,
+      side: trade.side,
+      baseAsset: trade.baseAsset,
+      counterAsset: trade.counterAsset,
+      entryPrice: trade.entryPrice,
+      amount: trade.amount,
+      totalValue: trade.totalValue,
+      stopLossPrice: trade.stopLossPrice,
+      takeProfitPrice: trade.takeProfitPrice,
+      isRetry: true,
+    };
+  }
+
+  private async sendFailureNotification(
+    trade: Trade,
+    failedReason: string,
+    attemptsMade: number,
+  ): Promise<void> {
+    try {
+      const pair = `${trade.baseAsset}/${trade.counterAsset}`;
+      const sideLabel = trade.side.toUpperCase();
+
+      await this.notificationService.send({
+        userId: trade.userId,
+        type: 'TRADE_EXECUTED',
+        title: 'Trade Failed',
+        message:
+          `Your ${sideLabel} trade for ${trade.amount} ${pair} has permanently failed ` +
+          `after ${attemptsMade} attempt(s). Reason: ${failedReason}. ` +
+          `You can retry this trade from your trade history.`,
+        channel: NotificationChannel.IN_APP,
+        metadata: {
+          tradeId: trade.id,
+          action: 'TRADE_FAILED',
+          failedReason,
+          attemptsMade,
+          retryUrl: `/trades/${trade.id}/retry`,
+          side: trade.side,
+          baseAsset: trade.baseAsset,
+          counterAsset: trade.counterAsset,
+          amount: trade.amount,
+        },
+      });
+
+      this.logger.log(
+        `Failure notification sent to user ${trade.userId} for trade ${trade.id}`,
+      );
+    } catch (notifError: any) {
+      this.logger.error(
+        `Failed to send notification for trade ${trade.id}: ${notifError.message}`,
+        notifError.stack,
+      );
+    }
+  }
+
+  private categorizeError(errorMessage: string): string {
+    const lowerMessage = errorMessage.toLowerCase();
+
+    if (lowerMessage.includes('timeout') || lowerMessage.includes('timed out')) {
+      return 'Timeout';
+    }
+    if (lowerMessage.includes('insufficient') || lowerMessage.includes('balance')) {
+      return 'Insufficient Balance';
+    }
+    if (lowerMessage.includes('network') || lowerMessage.includes('connection')) {
+      return 'Network Error';
+    }
+    if (lowerMessage.includes('soroban') || lowerMessage.includes('contract')) {
+      return 'Smart Contract Error';
+    }
+    if (lowerMessage.includes('rpc') || lowerMessage.includes('horizon')) {
+      return 'RPC/Horizon Error';
+    }
+    if (lowerMessage.includes('slippage')) {
+      return 'Slippage Exceeded';
+    }
+    if (lowerMessage.includes('duplicate') || lowerMessage.includes('already')) {
+      return 'Duplicate Transaction';
+    }
+    return 'Other';
+  }
+}

--- a/src/trades/trade-dlq.controller.spec.ts
+++ b/src/trades/trade-dlq.controller.spec.ts
@@ -1,0 +1,270 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TradeDlqController } from './trade-dlq.controller';
+import { TradeDlqService } from './services/trade-dlq.service';
+import { TradeDlqMetricsService } from './services/trade-dlq-metrics.service';
+import { TradeDlqCleanupService } from './services/trade-dlq-cleanup.service';
+import { TradeStatus } from './entities/trade.entity';
+
+describe('TradeDlqController', () => {
+  let controller: TradeDlqController;
+  let mockDlqService: any;
+  let mockMetricsService: any;
+  let mockCleanupService: any;
+
+  const mockReq = { user: { id: 'user-001' } };
+
+  beforeEach(async () => {
+    mockDlqService = {
+      getFailedTradesByUser: jest.fn().mockResolvedValue({
+        userId: 'user-001',
+        totalFailed: 2,
+        trades: [
+          { tradeId: 't1', canRetry: true },
+          { tradeId: 't2', canRetry: false },
+        ],
+      }),
+      retryTrade: jest.fn().mockResolvedValue({
+        tradeId: 'trade-001',
+        newJobId: 'job-001',
+        status: TradeStatus.PENDING,
+        message: 'Trade re-enqueued',
+      }),
+      bulkRetry: jest.fn().mockResolvedValue({
+        totalRequested: 2,
+        successCount: 2,
+        failureCount: 0,
+        results: [],
+      }),
+      getRetryHistory: jest.fn().mockResolvedValue({
+        tradeId: 'trade-001',
+        totalRetries: 1,
+        entries: [{ retriedAt: '2024-01-01T00:00:00Z', newJobId: 'j1' }],
+      }),
+      canRetry: jest.fn().mockResolvedValue({
+        tradeId: 'trade-001',
+        canRetry: true,
+      }),
+      getFailedJobs: jest.fn().mockResolvedValue({
+        totalFailed: 5,
+        recentJobs: [],
+      }),
+      getFailedTradeStats: jest.fn().mockResolvedValue({
+        totalFailed: 10,
+        totalRetried: 3,
+        totalDiscarded: 1,
+        byErrorType: [],
+        byTimePeriod: [],
+        currentDlqDepth: 6,
+      }),
+      discardFailedJob: jest.fn().mockResolvedValue({
+        tradeId: 'trade-001',
+        discardedBy: 'admin-001',
+        discardedAt: '2024-01-01T00:00:00Z',
+        message: 'Discarded',
+      }),
+    };
+
+    mockMetricsService = {
+      getMetrics: jest.fn().mockReturnValue({
+        totalFailures: 100,
+        totalRetries: 20,
+        totalDiscards: 5,
+        retrySuccessRate: 75,
+        failureReasonDistribution: {},
+        currentDlqDepth: 15,
+        lastUpdated: '2024-01-01T00:00:00Z',
+        uptimeMs: 3600000,
+      }),
+    };
+
+    mockCleanupService = {
+      getLastCleanupResult: jest.fn().mockReturnValue({
+        result: {
+          archivedCount: 10,
+          dlqEntriesRemoved: 5,
+          errors: [],
+          durationMs: 1500,
+        },
+        runAt: '2024-01-01T03:00:00Z',
+      }),
+      getRetentionConfig: jest.fn().mockReturnValue({
+        retentionDays: 90,
+        cronExpression: '0 3 * * *',
+      }),
+      cleanupOldEntries: jest.fn().mockResolvedValue({
+        archivedCount: 3,
+        dlqEntriesRemoved: 2,
+        errors: [],
+        durationMs: 800,
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TradeDlqController],
+      providers: [
+        { provide: TradeDlqService, useValue: mockDlqService },
+        { provide: TradeDlqMetricsService, useValue: mockMetricsService },
+        { provide: TradeDlqCleanupService, useValue: mockCleanupService },
+      ],
+    }).compile();
+
+    controller = module.get(TradeDlqController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── User endpoints ─────────────────────────────────────────────────────────
+
+  describe('getUserFailedTrades', () => {
+    it('should return user failed trades with default pagination', async () => {
+      const result = await controller.getUserFailedTrades(mockReq, {});
+
+      expect(mockDlqService.getFailedTradesByUser).toHaveBeenCalledWith(
+        'user-001', 1, 20, 'updatedAt', 'DESC', undefined, undefined,
+      );
+      expect(result.userId).toBe('user-001');
+      expect(result.totalFailed).toBe(2);
+    });
+
+    it('should pass query parameters through to service', async () => {
+      await controller.getUserFailedTrades(mockReq, {
+        page: 2,
+        limit: 10,
+        sortBy: 'amount',
+        sortOrder: 'ASC',
+        baseAsset: 'XLM',
+        errorFilter: 'timeout',
+      });
+
+      expect(mockDlqService.getFailedTradesByUser).toHaveBeenCalledWith(
+        'user-001', 2, 10, 'amount', 'ASC', 'XLM', 'timeout',
+      );
+    });
+
+    it('should cap limit at 100', async () => {
+      await controller.getUserFailedTrades(mockReq, { limit: 500 });
+
+      expect(mockDlqService.getFailedTradesByUser).toHaveBeenCalledWith(
+        'user-001', 1, 100, 'updatedAt', 'DESC', undefined, undefined,
+      );
+    });
+  });
+
+  describe('retryFailedTrade', () => {
+    it('should delegate retry to service and return result', async () => {
+      const result = await controller.retryFailedTrade('trade-001', mockReq);
+
+      expect(mockDlqService.retryTrade).toHaveBeenCalledWith(
+        'trade-001',
+        'user-001',
+      );
+      expect(result.tradeId).toBe('trade-001');
+      expect(result.status).toBe(TradeStatus.PENDING);
+    });
+  });
+
+  describe('bulkRetryTrades', () => {
+    it('should delegate bulk retry to service', async () => {
+      const dto = { tradeIds: ['t1', 't2'] };
+
+      const result = await controller.bulkRetryTrades(dto, mockReq);
+
+      expect(mockDlqService.bulkRetry).toHaveBeenCalledWith(
+        ['t1', 't2'],
+        'user-001',
+      );
+      expect(result.totalRequested).toBe(2);
+    });
+  });
+
+  describe('getRetryHistory', () => {
+    it('should return retry history for a trade', async () => {
+      const result = await controller.getRetryHistory('trade-001', mockReq);
+
+      expect(mockDlqService.getRetryHistory).toHaveBeenCalledWith(
+        'trade-001',
+        'user-001',
+      );
+      expect(result.totalRetries).toBe(1);
+    });
+  });
+
+  describe('checkCanRetry', () => {
+    it('should return can-retry result', async () => {
+      const result = await controller.checkCanRetry('trade-001', mockReq);
+
+      expect(mockDlqService.canRetry).toHaveBeenCalledWith(
+        'trade-001',
+        'user-001',
+      );
+      expect(result.canRetry).toBe(true);
+    });
+  });
+
+  // ── Admin endpoints ────────────────────────────────────────────────────────
+
+  describe('getFailedJobs', () => {
+    it('should return failed jobs summary with default limit', async () => {
+      const result = await controller.getFailedJobs({});
+
+      expect(mockDlqService.getFailedJobs).toHaveBeenCalledWith(10);
+      expect(result.totalFailed).toBe(5);
+    });
+
+    it('should pass custom limit to service', async () => {
+      await controller.getFailedJobs({ limit: 25 });
+
+      expect(mockDlqService.getFailedJobs).toHaveBeenCalledWith(25);
+    });
+  });
+
+  describe('getFailedJobStats', () => {
+    it('should return aggregate failure statistics', async () => {
+      const result = await controller.getFailedJobStats();
+
+      expect(mockDlqService.getFailedTradeStats).toHaveBeenCalled();
+      expect(result.totalFailed).toBe(10);
+      expect(result.currentDlqDepth).toBe(6);
+    });
+  });
+
+  describe('discardFailedJob', () => {
+    it('should delegate discard to service', async () => {
+      const result = await controller.discardFailedJob('trade-001', mockReq);
+
+      expect(mockDlqService.discardFailedJob).toHaveBeenCalledWith(
+        'trade-001',
+        'user-001',
+      );
+      expect(result.tradeId).toBe('trade-001');
+    });
+  });
+
+  describe('getDlqMetrics', () => {
+    it('should return metrics snapshot', async () => {
+      const result = await controller.getDlqMetrics();
+
+      expect(mockMetricsService.getMetrics).toHaveBeenCalled();
+      expect(result.totalFailures).toBe(100);
+      expect(result.retrySuccessRate).toBe(75);
+    });
+  });
+
+  describe('getCleanupStatus', () => {
+    it('should return last cleanup result with config', async () => {
+      const result = await controller.getCleanupStatus();
+
+      expect(result.result).toBeDefined();
+      expect(result.config.retentionDays).toBe(90);
+    });
+  });
+
+  describe('triggerCleanup', () => {
+    it('should trigger manual cleanup with given retention', async () => {
+      const result = await controller.triggerCleanup(60);
+
+      expect(mockCleanupService.cleanupOldEntries).toHaveBeenCalledWith(60);
+      expect(result.archivedCount).toBe(3);
+    });
+  });
+});

--- a/src/trades/trade-dlq.controller.ts
+++ b/src/trades/trade-dlq.controller.ts
@@ -1,0 +1,339 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  Query,
+  Request,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  ParseUUIDPipe,
+  DefaultValuePipe,
+  ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TradeDlqService } from './services/trade-dlq.service';
+import { TradeDlqMetricsService, DlqMetricsSnapshot } from './services/trade-dlq-metrics.service';
+import { TradeDlqCleanupService } from './services/trade-dlq-cleanup.service';
+import {
+  TradeRetryResponseDto,
+  FailedJobsSummaryDto,
+  BulkRetryRequestDto,
+  BulkRetryResponseDto,
+  FailedTradeStatsDto,
+  RetryHistoryDto,
+  UserFailedTradesDto,
+  CanRetryResponseDto,
+  DiscardResponseDto,
+} from './dto/trade-retry-response.dto';
+import { FailedTradesQueryDto, AdminFailedJobsQueryDto } from './dto/dlq-query.dto';
+
+/**
+ * #999 -- Dead-letter queue endpoints for failed trade jobs.
+ *
+ * User endpoints:
+ *   GET    /trades/failed                 -- List user's failed trades
+ *   POST   /trades/:id/dlq-retry          -- Re-enqueue a failed trade (owner only)
+ *   POST   /trades/bulk-retry             -- Bulk re-enqueue failed trades
+ *   GET    /trades/:id/retry-history      -- View retry history for a trade
+ *   GET    /trades/:id/can-retry          -- Check if a trade can be retried
+ *
+ * Admin endpoints:
+ *   GET    /admin/trades/failed-jobs       -- View failed queue depth and recent failures
+ *   GET    /admin/trades/failed-jobs/stats -- Aggregate failure statistics
+ *   POST   /admin/trades/failed-jobs/:id/discard -- Discard a DLQ entry
+ *   GET    /admin/trades/dlq-metrics       -- In-memory metrics snapshot
+ *   GET    /admin/trades/dlq-cleanup       -- Last cleanup result
+ *   POST   /admin/trades/dlq-cleanup/run   -- Trigger cleanup manually
+ */
+@Controller()
+export class TradeDlqController {
+  private readonly logger = new Logger(TradeDlqController.name);
+
+  constructor(
+    private readonly tradeDlqService: TradeDlqService,
+    private readonly metricsService: TradeDlqMetricsService,
+    private readonly cleanupService: TradeDlqCleanupService,
+  ) {}
+
+  // ── User endpoints ────────────────────────────────────────────────────────
+
+  @Get('trades/failed')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Trades')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'List failed trades for the authenticated user',
+    description:
+      'Returns a paginated list of failed trades owned by the current user. ' +
+      'Supports filtering by base asset and error message.',
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'sortBy', required: false, type: String })
+  @ApiQuery({ name: 'sortOrder', required: false, enum: ['ASC', 'DESC'] })
+  @ApiQuery({ name: 'baseAsset', required: false, type: String })
+  @ApiQuery({ name: 'errorFilter', required: false, type: String })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of failed trades',
+    type: UserFailedTradesDto,
+  })
+  async getUserFailedTrades(
+    @Request() req: any,
+    @Query() query: FailedTradesQueryDto,
+  ): Promise<UserFailedTradesDto> {
+    const userId = req.user?.id;
+    return this.tradeDlqService.getFailedTradesByUser(
+      userId,
+      query.page ?? 1,
+      Math.min(query.limit ?? 20, 100),
+      query.sortBy ?? 'updatedAt',
+      query.sortOrder ?? 'DESC',
+      query.baseAsset,
+      query.errorFilter,
+    );
+  }
+
+  @Post('trades/:id/dlq-retry')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Trades')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Retry a permanently failed trade',
+    description:
+      'Re-enqueues a trade job that has been moved to the dead-letter queue. ' +
+      'Only the trade owner can retry their own trades. The trade must be in FAILED status.',
+  })
+  @ApiParam({ name: 'id', description: 'Trade ID (UUID)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Trade successfully re-enqueued',
+    type: TradeRetryResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Trade is not in FAILED status or cannot be retried' })
+  @ApiResponse({ status: 403, description: 'User does not own this trade' })
+  @ApiResponse({ status: 404, description: 'Trade not found' })
+  async retryFailedTrade(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: any,
+  ): Promise<TradeRetryResponseDto> {
+    const userId = req.user?.id;
+    this.logger.log(`User ${userId} requesting retry for trade ${id}`);
+    return this.tradeDlqService.retryTrade(id, userId);
+  }
+
+  @Post('trades/bulk-retry')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Trades')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Bulk retry multiple failed trades',
+    description:
+      'Re-enqueues multiple failed trade jobs at once. Each trade is retried independently; ' +
+      'partial failures do not affect other trades in the batch.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Bulk retry results',
+    type: BulkRetryResponseDto,
+  })
+  async bulkRetryTrades(
+    @Body() dto: BulkRetryRequestDto,
+    @Request() req: any,
+  ): Promise<BulkRetryResponseDto> {
+    const userId = req.user?.id;
+    this.logger.log(
+      `User ${userId} requesting bulk retry for ${dto.tradeIds.length} trade(s)`,
+    );
+    return this.tradeDlqService.bulkRetry(dto.tradeIds, userId);
+  }
+
+  @Get('trades/:id/retry-history')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Trades')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get retry history for a trade',
+    description:
+      'Returns the list of all retry attempts for a specific trade, ' +
+      'including timestamps and previous error messages.',
+  })
+  @ApiParam({ name: 'id', description: 'Trade ID (UUID)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Retry history',
+    type: RetryHistoryDto,
+  })
+  @ApiResponse({ status: 403, description: 'User does not own this trade' })
+  @ApiResponse({ status: 404, description: 'Trade not found' })
+  async getRetryHistory(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: any,
+  ): Promise<RetryHistoryDto> {
+    const userId = req.user?.id;
+    return this.tradeDlqService.getRetryHistory(id, userId);
+  }
+
+  @Get('trades/:id/can-retry')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Trades')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Check if a trade can be retried',
+    description:
+      'Validates all business rules (ownership, status, retry limit, cooldown) ' +
+      'and returns whether the trade is eligible for retry.',
+  })
+  @ApiParam({ name: 'id', description: 'Trade ID (UUID)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Can-retry check result',
+    type: CanRetryResponseDto,
+  })
+  async checkCanRetry(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: any,
+  ): Promise<CanRetryResponseDto> {
+    const userId = req.user?.id;
+    return this.tradeDlqService.canRetry(id, userId);
+  }
+
+  // ── Admin endpoints ───────────────────────────────────────────────────────
+
+  @Get('admin/trades/failed-jobs')
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Admin Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'View failed trade job queue depth and recent failures',
+    description:
+      'Returns the total number of permanently failed trade jobs in the dead-letter queue ' +
+      'along with details of the most recent failures.',
+  })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'Failed jobs summary',
+    type: FailedJobsSummaryDto,
+  })
+  async getFailedJobs(
+    @Query() query: AdminFailedJobsQueryDto,
+  ): Promise<FailedJobsSummaryDto> {
+    this.logger.log('Admin requesting failed trade jobs summary');
+    return this.tradeDlqService.getFailedJobs(query.limit ?? 10);
+  }
+
+  @Get('admin/trades/failed-jobs/stats')
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Admin Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get aggregate statistics for failed trade jobs',
+    description:
+      'Returns aggregated failure statistics including breakdowns by error type, ' +
+      'time period, and current DLQ depth.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Failed trade statistics',
+    type: FailedTradeStatsDto,
+  })
+  async getFailedJobStats(): Promise<FailedTradeStatsDto> {
+    this.logger.log('Admin requesting failed trade job statistics');
+    return this.tradeDlqService.getFailedTradeStats();
+  }
+
+  @Post('admin/trades/failed-jobs/:id/discard')
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Admin Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Discard a failed trade from the DLQ',
+    description:
+      'Permanently removes a failed trade job from the dead-letter queue. ' +
+      'The trade remains in FAILED status but is marked as discarded.',
+  })
+  @ApiParam({ name: 'id', description: 'Trade ID (UUID)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Trade discarded successfully',
+    type: DiscardResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Trade is not in FAILED status' })
+  @ApiResponse({ status: 404, description: 'Trade not found' })
+  async discardFailedJob(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: any,
+  ): Promise<DiscardResponseDto> {
+    const adminUserId = req.user?.id ?? 'system';
+    this.logger.log(`Admin ${adminUserId} discarding DLQ entry for trade ${id}`);
+    return this.tradeDlqService.discardFailedJob(id, adminUserId);
+  }
+
+  @Get('admin/trades/dlq-metrics')
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Admin Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get in-memory DLQ metrics',
+    description:
+      'Returns a snapshot of in-memory DLQ metrics including failure counts, ' +
+      'retry rates, and failure reason distribution.',
+  })
+  @ApiResponse({ status: 200, description: 'DLQ metrics snapshot' })
+  async getDlqMetrics(): Promise<DlqMetricsSnapshot> {
+    return this.metricsService.getMetrics();
+  }
+
+  @Get('admin/trades/dlq-cleanup')
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Admin Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get last DLQ cleanup result',
+    description: 'Returns the result of the most recent DLQ cleanup run.',
+  })
+  @ApiResponse({ status: 200, description: 'Last cleanup result' })
+  async getCleanupStatus() {
+    return {
+      ...this.cleanupService.getLastCleanupResult(),
+      config: this.cleanupService.getRetentionConfig(),
+    };
+  }
+
+  @Post('admin/trades/dlq-cleanup/run')
+  @HttpCode(HttpStatus.OK)
+  @ApiTags('Admin Management')
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Trigger DLQ cleanup manually',
+    description: 'Manually triggers the DLQ cleanup process. This is normally run daily at 3 AM.',
+  })
+  @ApiQuery({ name: 'retentionDays', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Cleanup result' })
+  async triggerCleanup(
+    @Query('retentionDays', new DefaultValuePipe(90), ParseIntPipe)
+    retentionDays: number,
+  ) {
+    this.logger.log(`Admin manually triggering DLQ cleanup (retention: ${retentionDays} days)`);
+    const result = await this.cleanupService.cleanupOldEntries(retentionDays);
+    return result;
+  }
+}

--- a/src/trades/trades.module.ts
+++ b/src/trades/trades.module.ts
@@ -50,6 +50,13 @@ import {
 } from './services/notification-preferences-client.service';
 import { CanaryRoutingModule } from './canary/canary-routing.module';
 import { SlippageGuardService } from './services/slippage-guard.service';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TradeDlqProcessor } from './jobs/trade-dlq.processor';
+import { TradeDlqService } from './services/trade-dlq.service';
+import { TradeDlqController } from './trade-dlq.controller';
+import { TradeDlqMetricsService } from './services/trade-dlq-metrics.service';
+import { TradeDlqCleanupService } from './services/trade-dlq-cleanup.service';
+import { DeadLetterService, DEAD_LETTER_QUEUE } from '../jobs/dead-letter.service';
 
 @Module({
   imports: [
@@ -60,6 +67,8 @@ import { SlippageGuardService } from './services/slippage-guard.service';
     SdexModule,
     SorobanModule,
     BullModule.registerQueue({ name: 'transactions' }),
+    BullModule.registerQueue({ name: DEAD_LETTER_QUEUE }),
+    ScheduleModule.forRoot(),
     WebsocketModule,
     AuditModule,
     NotificationsModule,
@@ -78,7 +87,7 @@ import { SlippageGuardService } from './services/slippage-guard.service';
       },
     ]),
   ],
-  controllers: [TradesController, AdvancedOrdersController, LimitOrderController, SwipeController, MarketOrderController, TradeRetryController],
+  controllers: [TradesController, AdvancedOrdersController, LimitOrderController, SwipeController, MarketOrderController, TradeRetryController, TradeDlqController],
   providers: [
     TradesService,
     MarketOrderService,
@@ -102,6 +111,11 @@ import { SlippageGuardService } from './services/slippage-guard.service';
     TradeSagaService,
     NotificationPreferencesClientService,
     SlippageGuardService,
+    TradeDlqProcessor,
+    TradeDlqService,
+    TradeDlqMetricsService,
+    TradeDlqCleanupService,
+    DeadLetterService,
     ...TRADE_CQRS_HANDLERS,
   ],
   exports: [


### PR DESCRIPTION
## Summary

Closes #999

- process exhausted transaction jobs and persist failed trade state
- capture failed jobs in the dead-letter store and notify the owner
- support owner-validated single and bulk retry with cooldown/max-attempt rules
- expose user retry/history endpoints and admin failed-job, metrics, discard, and cleanup endpoints
- add scheduled DLQ cleanup and operational metrics
- add comprehensive unit coverage across processor, services, controller, and cleanup paths

## Validation

- 3,699 lines added in the implementation and tests.
- Repository-wide build currently has pre-existing TypeScript failures across unrelated modules; GitHub CI is required to report the authoritative checks.